### PR TITLE
Honor the org and project picked up my HCPConfig (usually from env)

### DIFF
--- a/internal/pkg/profile/loader.go
+++ b/internal/pkg/profile/loader.go
@@ -177,11 +177,11 @@ func (l *Loader) LoadProfile(name string) (*Profile, error) {
 
 	// Honor environment variables around org and project over whatever
 	// we load from the profile file.
-	if orgID, ok := os.LookupEnv(envVarHCPOrganizationID); ok {
+	if orgID, ok := os.LookupEnv(envVarHCPOrganizationID); ok && orgID != "" {
 		c.OrganizationID = orgID
 	}
 
-	if projID, ok := os.LookupEnv(envVarHCPProjectID); ok {
+	if projID, ok := os.LookupEnv(envVarHCPProjectID); ok && projID != "" {
 		c.ProjectID = projID
 	}
 


### PR DESCRIPTION
The new profile system doesn't support the same env vars that hcpconfig supports, so I've merged hcpconfig's information after the new profile has been loaded.