### PR TITLE
Add make build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# bin/ directory
+bin/*

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ MOCKERY_OUTPUT_FILES=internal/pkg/api/iampolicy/mock_setter.go \
 
 default: help
 
+.PHONY: build
+build: ## Build the HCP CLI binary
+	@go build -o bin/ ./...
+
 .PHONY: go/lint
 go/lint: ## Run the Go Linter
 	@golangci-lint run


### PR DESCRIPTION
Add a `make build` target that builds and outputs the `hcp` binary to `bin/hcp`

Fixes #7 