### PR TITLE
Add read and list commands for organizations

### DIFF
--- a/internal/commands/organizations/displayer.go
+++ b/internal/commands/organizations/displayer.go
@@ -1,0 +1,69 @@
+package organizations
+
+import (
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+)
+
+type displayer struct {
+	orgs          []*models.HashicorpCloudResourcemanagerOrganization
+	defaultFormat format.Format
+	single        bool
+}
+
+func newDisplayer(defaultFormat format.Format, single bool, orgs ...*models.HashicorpCloudResourcemanagerOrganization) *displayer {
+	return &displayer{
+		orgs:          orgs,
+		defaultFormat: defaultFormat,
+		single:        single,
+	}
+}
+
+func (d *displayer) DefaultFormat() format.Format {
+	return d.defaultFormat
+}
+
+func (d *displayer) Payload() any {
+	if d.single {
+		if len(d.orgs) != 1 {
+			return nil
+		}
+
+		return d.orgs[0]
+	}
+
+	return d.orgs
+}
+
+func (d *displayer) FieldTemplates() []format.Field {
+	fields := []format.Field{
+		{
+			Name:        "Name",
+			ValueFormat: "{{ .Name }}",
+		},
+		{
+			Name:        "ID",
+			ValueFormat: "{{ .ID }}",
+		},
+	}
+
+	if d.single {
+		fields = append(fields,
+			format.Field{
+				Name:        "Owner Principal ID",
+				ValueFormat: "{{ .Owner.User }}",
+			},
+			format.Field{
+				Name:        "State",
+				ValueFormat: "{{ .State }}",
+			},
+		)
+	}
+
+	fields = append(fields, format.Field{
+		Name:        "Created At",
+		ValueFormat: "{{ .CreatedAt }}",
+	})
+
+	return fields
+}

--- a/internal/commands/organizations/list.go
+++ b/internal/commands/organizations/list.go
@@ -1,0 +1,69 @@
+package organizations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/organization_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func NewCmdList(ctx *cmd.Context, runF func(*ListOpts) error) *cmd.Command {
+	opts := &ListOpts{
+		Ctx:     ctx.ShutdownCtx,
+		Profile: ctx.Profile,
+		IO:      ctx.IO,
+		Output:  ctx.Output,
+		Client:  organization_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "list",
+		ShortHelp: "List organizations.",
+		LongHelp:  "List the organizations the authenticated principal is a member of.",
+		RunF: func(c *cmd.Command, args []string) error {
+			if runF != nil {
+				return runF(opts)
+			}
+			return listRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+type ListOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	IO      iostreams.IOStreams
+	Output  *format.Outputter
+
+	Client organization_service.ClientService
+}
+
+func listRun(opts *ListOpts) error {
+	req := organization_service.NewOrganizationServiceListParamsWithContext(opts.Ctx)
+
+	var orgs []*models.HashicorpCloudResourcemanagerOrganization
+	for {
+		resp, err := opts.Client.OrganizationServiceList(req, nil)
+		if err != nil {
+			return fmt.Errorf("failed to list organizations: %w", err)
+		}
+
+		orgs = append(orgs, resp.Payload.Organizations...)
+		if resp.Payload.Pagination == nil || resp.Payload.Pagination.NextPageToken == "" {
+			break
+		}
+
+		next := resp.Payload.Pagination.NextPageToken
+		req.PaginationNextPageToken = &next
+	}
+
+	d := newDisplayer(format.Table, false, orgs...)
+	return opts.Output.Display(d)
+}

--- a/internal/commands/organizations/list_test.go
+++ b/internal/commands/organizations/list_test.go
@@ -1,0 +1,198 @@
+package organizations
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/organization_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
+	cloud "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
+	mock_organization_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/organization_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdList(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+	}{
+		{
+			Name:    "Too many args",
+			Profile: profile.TestProfile,
+			Args:    []string{"foo", "bar"},
+			Error:   "no arguments allowed, but received 2",
+		},
+		{
+			Name:    "Good",
+			Profile: profile.TestProfile,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			listCmd := NewCmdList(ctx, func(o *ListOpts) error {
+				return nil
+			})
+			listCmd.SetIO(io)
+
+			code := listCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+		})
+	}
+}
+
+func TestListRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Resp    [][]*models.HashicorpCloudResourcemanagerOrganization
+		RespErr bool
+		Error   string
+	}{
+		{
+			Name:    "Server error",
+			RespErr: true,
+			Error:   "failed to list organizations: [GET /resource-manager/2019-12-10/organizations][403]",
+		},
+		{
+			Name: "Good no pagination",
+			Resp: [][]*models.HashicorpCloudResourcemanagerOrganization{
+				{
+					{
+						CreatedAt: strfmt.DateTime(time.Now()),
+						ID:        "456",
+						Name:      "Good",
+					},
+				},
+			},
+		},
+		{
+			Name: "Good pagination",
+			Resp: [][]*models.HashicorpCloudResourcemanagerOrganization{
+				{
+					{
+						CreatedAt: strfmt.DateTime(time.Now()),
+						ID:        "456",
+						Name:      "Good",
+					},
+					{
+						CreatedAt: strfmt.DateTime(time.Now()),
+						ID:        "789",
+						Name:      "Good 2",
+					},
+				},
+				{
+					{
+						CreatedAt: strfmt.DateTime(time.Now()),
+						ID:        "012",
+						Name:      "Page 2",
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			org := mock_organization_service.NewMockClientService(t)
+			opts := &ListOpts{
+				Ctx:     context.Background(),
+				Profile: profile.TestProfile(t).SetOrgID("123"),
+				IO:      io,
+				Output:  format.New(io),
+				Client:  org,
+			}
+
+			e := org.EXPECT()
+			for i := 0; i < len(c.Resp) || c.RespErr; i++ {
+				i := i
+				call := e.OrganizationServiceList(mock.MatchedBy(func(req *organization_service.OrganizationServiceListParams) bool {
+					// No initial pagination
+					if i == 0 && req.PaginationNextPageToken != nil {
+						return false
+					} else if i >= 1 && *req.PaginationNextPageToken != fmt.Sprintf("next-page-%d", i) {
+						// Expect a page token
+						return false
+					}
+
+					return true
+				}), nil)
+
+				if c.RespErr {
+					call.Return(nil, organization_service.NewOrganizationServiceListDefault(http.StatusForbidden))
+					break
+				} else {
+					ok := organization_service.NewOrganizationServiceListOK()
+					ok.Payload = &models.HashicorpCloudResourcemanagerOrganizationListResponse{
+						Organizations: c.Resp[i],
+					}
+
+					if i < len(c.Resp)-1 {
+						ok.Payload.Pagination = &cloud.HashicorpCloudCommonPaginationResponse{
+							NextPageToken: fmt.Sprintf("next-page-%d", i+1),
+						}
+					}
+
+					call.Return(ok, nil)
+				}
+			}
+
+			// Run the command
+			err := listRun(opts)
+			if c.Error != "" {
+				r.ErrorContains(err, c.Error)
+				return
+			}
+
+			r.NoError(err)
+
+			// Check we outputted the project
+			for _, page := range c.Resp {
+				for _, p := range page {
+					r.Contains(io.Output.String(), p.ID)
+					r.Contains(io.Output.String(), p.Name)
+				}
+			}
+		})
+	}
+}

--- a/internal/commands/organizations/orgs.go
+++ b/internal/commands/organizations/orgs.go
@@ -16,6 +16,8 @@ func NewCmdOrganizations(ctx *cmd.Context) *cmd.Command {
 		`),
 	}
 
+	cmd.AddChild(NewCmdRead(ctx, nil))
+	cmd.AddChild(NewCmdList(ctx, nil))
 	cmd.AddChild(iam.NewCmdIAM(ctx))
 	return cmd
 }

--- a/internal/commands/organizations/read.go
+++ b/internal/commands/organizations/read.go
@@ -1,0 +1,68 @@
+package organizations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/organization_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
+	opts := &ReadOpts{
+		Ctx:     ctx.ShutdownCtx,
+		Profile: ctx.Profile,
+		IO:      ctx.IO,
+		Output:  ctx.Output,
+		Client:  organization_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "read",
+		ShortHelp: "Show metadata for the organization.",
+		LongHelp:  "Show metadata for the organization.",
+		Args: cmd.PositionalArguments{
+			Args: []cmd.PositionalArgument{
+				{
+					Name:          "ID",
+					Documentation: "ID of the organization to read.",
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			opts.ID = args[0]
+			if runF != nil {
+				return runF(opts)
+			}
+			return readRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+type ReadOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	IO      iostreams.IOStreams
+	Output  *format.Outputter
+
+	ID     string
+	Client organization_service.ClientService
+}
+
+func readRun(opts *ReadOpts) error {
+	req := organization_service.NewOrganizationServiceGetParamsWithContext(opts.Ctx)
+	req.ID = opts.ID
+
+	resp, err := opts.Client.OrganizationServiceGet(req, nil)
+	if err != nil {
+		return fmt.Errorf("failed to read organization: %w", err)
+	}
+
+	d := newDisplayer(format.Pretty, true, resp.Payload.Organization)
+	return opts.Output.Display(d)
+}

--- a/internal/commands/organizations/read_test.go
+++ b/internal/commands/organizations/read_test.go
@@ -1,0 +1,156 @@
+package organizations
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/organization_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
+	mock_organization_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/organization_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdRead(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name     string
+		Args     []string
+		Profile  func(t *testing.T) *profile.Profile
+		ExpectID string
+		Error    string
+	}{
+		{
+			Name:    "Too many args",
+			Profile: profile.TestProfile,
+			Args:    []string{"foo", "bar"},
+			Error:   "accepts 1 arg(s), received 2",
+		},
+		{
+			Name:     "Good",
+			Args:     []string{"123"},
+			ExpectID: "123",
+			Profile:  profile.TestProfile,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts *ReadOpts
+			readCmd := NewCmdRead(ctx, func(o *ReadOpts) error {
+				gotOpts = o
+				return nil
+			})
+			readCmd.SetIO(io)
+
+			code := readCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+			r.Equal(c.ExpectID, gotOpts.ID)
+		})
+	}
+}
+
+func TestReadRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		RespErr bool
+		Error   string
+	}{
+		{
+			Name:    "Server error",
+			RespErr: true,
+			Error:   "failed to read organization: [GET /resource-manager/2019-12-10/organizations/{id}][403]",
+		},
+		{
+			Name: "Good",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			org := mock_organization_service.NewMockClientService(t)
+			opts := &ReadOpts{
+				Ctx:     context.Background(),
+				Profile: profile.TestProfile(t),
+				IO:      io,
+				Output:  format.New(io),
+				Client:  org,
+				ID:      "123",
+			}
+
+			// Expect a request to create the project.
+			call := org.EXPECT().OrganizationServiceGet(mock.MatchedBy(func(req *organization_service.OrganizationServiceGetParams) bool {
+				return req.ID == "123"
+			}), nil).Once()
+
+			if c.RespErr {
+				call.Return(nil, organization_service.NewOrganizationServiceGetDefault(http.StatusForbidden))
+			} else {
+				ok := organization_service.NewOrganizationServiceGetOK()
+				ok.Payload = &models.HashicorpCloudResourcemanagerOrganizationGetResponse{
+					Organization: &models.HashicorpCloudResourcemanagerOrganization{
+						CreatedAt: strfmt.DateTime(time.Now()),
+						ID:        "123",
+						Name:      "Hello",
+						Owner: &models.HashicorpCloudResourcemanagerOrganizationOwner{
+							User: "user-123",
+						},
+						State: models.HashicorpCloudResourcemanagerOrganizationOrganizationStateACTIVE.Pointer(),
+					},
+				}
+
+				call.Return(ok, nil)
+			}
+
+			// Run the command
+			err := readRun(opts)
+			if c.Error != "" {
+				r.ErrorContains(err, c.Error)
+				return
+			}
+
+			r.NoError(err)
+			r.Contains(io.Output.String(), "Hello")
+			r.Contains(io.Output.String(), "123")
+			r.Contains(io.Output.String(), "user-123")
+			r.Contains(io.Output.String(), "ACTIVE")
+		})
+	}
+}


### PR DESCRIPTION
Adds basic list and read commands for organizations.  Example output (IDs are fake):

```
$ hcp orgs list
Name                 ID                                    Created At
alex-org             15869931-a384-4c02-ab98-b3aa030c100c  2020-05-05T22:52:23.462Z
example              4b809533-65d5-4afc-81a8-6e5538ca664e  2020-10-01T13:16:42.519Z

$ hcp orgs read 15869931-a384-4c02-ab98-b3aa030c100c
Name:               alex-org
ID:                 15869931-a384-4c02-ab98-b3aa030c100c
Owner Principal ID: c1ceb44c-bdc1-4c60-86c8-b20357253915
State:              ACTIVE
Created At:         2020-05-05T22:52:23.462Z
```