### PR TITLE
Examples are not italicized

### DIFF
--- a/internal/pkg/cmd/command_internal.go
+++ b/internal/pkg/cmd/command_internal.go
@@ -340,7 +340,7 @@ func (e *Example) text(cs *iostreams.ColorScheme) string {
 	if e.Command != "" {
 		// Use a higher limit for command wrapping since they may include
 		// potentially long identifiers.
-		fmt.Fprintln(&buf, cs.String(wordWrap(e.Command, 120)).Italic().Color(cs.Green()))
+		fmt.Fprintln(&buf, cs.String(wordWrap(e.Command, 120)).Color(cs.Green()))
 	}
 
 	return buf.String()


### PR DESCRIPTION
Makes longer examples a bit more legible by not italicizing them.

**Before**
<img width="981" alt="Screenshot 2024-03-13 at 5 25 05 PM" src="https://github.com/hashicorp/hcp/assets/1047914/d34af752-30c3-42f0-a224-9cff46337034">

**After**
<img width="853" alt="Screenshot 2024-03-13 at 5 24 52 PM" src="https://github.com/hashicorp/hcp/assets/1047914/9a109dda-82b7-4ba6-ac0d-ba0d5235dfe5">


