### PR TITLE
[WAYP-2336] `waypoint templates read` command

### DIFF
--- a/internal/commands/waypoint/actionconfig/read.go
+++ b/internal/commands/waypoint/actionconfig/read.go
@@ -23,8 +23,8 @@ func NewCmdRead(ctx *cmd.Context) *cmd.Command {
 
 	cmd := &cmd.Command{
 		Name:      "read",
-		ShortHelp: "Read more details about an action configurations.",
-		LongHelp:  "Read more details about an action configurations.",
+		ShortHelp: "Read more details about an action configuration.",
+		LongHelp:  "Read more details about an action configuration.",
 		RunF: func(c *cmd.Command, args []string) error {
 			return readActionConfig(c, args, opts)
 		},

--- a/internal/commands/waypoint/template/read.go
+++ b/internal/commands/waypoint/template/read.go
@@ -1,0 +1,63 @@
+package template
+
+import (
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/pkg/errors"
+)
+
+func NewCmdRead(ctx *cmd.Context, opts *TemplateOpts) *cmd.Command {
+	cmd := &cmd.Command{
+		Name:      "read",
+		ShortHelp: "Read more details about an HCP Waypoint template.",
+		LongHelp: "Read more details about an HCP Waypoint template. This will display " +
+			"the details of the template.",
+		RunF: func(c *cmd.Command, args []string) error {
+			if opts.testFunc != nil {
+				return opts.testFunc(c, args)
+			}
+			return templateRead(opts)
+		},
+		PersistentPreRun: func(c *cmd.Command, args []string) error {
+			return cmd.RequireOrgAndProject(ctx)
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "name",
+					Shorthand:    "n",
+					DisplayValue: "NAME",
+					Description:  "The name of the template.",
+					Value:        flagvalue.Simple("", &opts.Name),
+					Required:     true,
+				},
+			},
+		},
+	}
+
+	return cmd
+}
+
+func templateRead(opts *TemplateOpts) error {
+	ns, err := opts.Namespace()
+	if err != nil {
+		return errors.Wrapf(err, "Unable to access HCP project")
+	}
+
+	resp, err := opts.WS.WaypointServiceGetApplicationTemplate2(
+		&waypoint_service.WaypointServiceGetApplicationTemplate2Params{
+			NamespaceID:             ns.ID,
+			Context:                 opts.Ctx,
+			ApplicationTemplateName: opts.Name,
+		}, nil,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to get template")
+	}
+
+	respPayload := resp.GetPayload()
+
+	return opts.Output.Show(respPayload.ApplicationTemplate, format.Pretty)
+}

--- a/internal/commands/waypoint/template/template.go
+++ b/internal/commands/waypoint/template/template.go
@@ -43,6 +43,7 @@ func NewCmdTemplate(ctx *cmd.Context) *cmd.Command {
 
 	cmd.AddChild(NewCmdCreate(ctx, opts))
 	cmd.AddChild(NewCmdDelete(ctx, opts))
+	cmd.AddChild(NewCmdRead(ctx, opts))
 
 	return cmd
 }

--- a/internal/commands/waypoint/template/template_read_test.go
+++ b/internal/commands/waypoint/template/template_read_test.go
@@ -1,0 +1,84 @@
+package template
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmdTemplateRead(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *TemplateOpts
+	}{
+		{
+			Name:    "No Org",
+			Profile: profile.TestProfile,
+			Args:    []string{},
+			Error:   "Organization ID must be configured",
+		},
+		{
+			Name: "no args",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args:  []string{},
+			Error: "accepts 1 arg(s), received 0",
+		},
+		{
+			Name: "happy",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args: []string{
+				"-n=cli-test",
+			},
+			Expect: &TemplateOpts{
+				Name: "cli-test",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+
+			r := require.New(t)
+
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var tplOpts TemplateOpts
+			tplOpts.testFunc = func(c *cmd.Command, args []string) error {
+				return nil
+			}
+			cmd := NewCmdRead(ctx, &tplOpts)
+			cmd.SetIO(io)
+
+			cmd.Run(c.Args)
+
+			if c.Expect != nil {
+				r.Equal(c.Expect.Name, tplOpts.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The command this PR adds lets you read the details a template that you've created.

```shell
$ waypoint templates read -n test                         
Action Cfg Refs:                   []
Description:                       
ID:                                12345678-1234-1234-1234-123456789012
Labels:                            [test]
Name:                              test
Readme Markdown Template:          
Summary:                           test
Tags:                              []
Terraform Cloud Workspace Details: {test prj-1234567890}
Terraform Nocode Module:           {private/waypoint/waypoint-test/null 0.0.1}
Variable Options:                  []
```