### PR TITLE
Show handles nested structs

### DIFF
--- a/internal/pkg/format/example_test.go
+++ b/internal/pkg/format/example_test.go
@@ -14,11 +14,17 @@ func ExampleOutputter() {
 	outputter := format.New(io)
 
 	// Resource is an example resource that we want to display
+	type Metadata struct {
+		Owner     string
+		CreatedAt string
+	}
+
 	type Resource struct {
 		Name        string
 		ID          string
 		Description string
 		Bytes       int
+		Metadata    Metadata
 	}
 
 	// Build our mock resources. Typically this is the response payload from an API
@@ -29,17 +35,29 @@ func ExampleOutputter() {
 			ID:          "123",
 			Description: "world",
 			Bytes:       100,
+			Metadata: Metadata{
+				Owner:     "Bob Builder",
+				CreatedAt: "2021-01-01",
+			},
 		},
 		{
 			Name:        "another",
 			ID:          "456",
 			Description: "example",
 			Bytes:       1024 * 1024,
+			Metadata: Metadata{
+				Owner:     "Jeff Bezos",
+				CreatedAt: "2023-02-04",
+			},
 		},
 	}
 
 	// For displaying a table of the exact values, Show can be used:
 	_ = outputter.Show(payload, format.Table)
+
+	// For displaying a table with a subset of the fields, list the fields as
+	// such:
+	// _ = outputter.Show(payload, format.Table, "Name", "ID", "Metadata.Owner")
 
 	// Since the IO is a test io, manually print it.
 	// We trim the lines to make examples testing pass correctly.
@@ -50,9 +68,9 @@ func ExampleOutputter() {
 	fmt.Println(strings.Join(lines, "\n"))
 
 	// Output:
-	// Name     ID   Description  Bytes
-	// hello    123  world        100
-	// another  456  example      1048576
+	// Name     ID   Description  Bytes    Metadata Owner  Metadata Created At
+	// hello    123  world        100      Bob Builder     2021-01-01
+	// another  456  example      1048576  Jeff Bezos      2023-02-04
 	//
 
 }

--- a/internal/pkg/format/infer_fields_test.go
+++ b/internal/pkg/format/infer_fields_test.go
@@ -79,4 +79,35 @@ func TestInferFields(t *testing.T) {
 		{Name: "Created At", ValueFormat: "{{ .CreatedAt }}"},
 	}, inferFields(s6, nil))
 
+	type nested struct {
+		Test string
+		max  int
+	}
+
+	s7 := struct {
+		Metadata nested
+	}{
+		Metadata: nested{
+			Test: "s7",
+			max:  10,
+		},
+	}
+
+	r.Equal([]Field{
+		{Name: "Metadata Test", ValueFormat: "{{ .Metadata.Test }}"},
+	}, inferFields(s7, nil))
+
+	s8 := struct {
+		Metadata *nested
+	}{
+		Metadata: &nested{
+			Test: "s8",
+			max:  10,
+		},
+	}
+
+	r.Equal([]Field{
+		{Name: "Metadata Test", ValueFormat: "{{ .Metadata.Test }}"},
+	}, inferFields(s8, nil))
+
 }


### PR DESCRIPTION
### Changes proposed in this PR:
Update the `inferFields` function to handle Showing nested structs. Prior to this change, if there was a nested struct it would display it value directly.

### How I've tested this PR:
Wrote tests and I updated `hcp projects list` to use the Show command and prior to this change get:

```
Created At                Description  ID   Name    Parent               State
2023-05-16T20:15:53.203Z               xxx  cli     {aaa 0x140003ac310}  ACTIVE
2023-10-09T22:48:49.981Z               yyy  portal  {bbb 0x140003ac360}  ACTIVE
```

and after:

```
Created At                Description  ID   Name    Parent ID   Parent Type   State
2023-05-16T20:15:53.203Z               xxx  cli     aaa         ORGANIZATION  ACTIVE
2023-10-09T22:48:49.981Z               yyy  portal  bbb         ORGANIZATION  ACTIVE
```

### How I expect reviewers to test this PR:

I wasn't able to run all the Waypoint commands as I don't have a TFC no-code setup. It would be great if you could checkout and the branch and test against the waypoint commands and test them since they use Show. 

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
