### PR TITLE
Fix copy'n'paste error in read service principal command

### DIFF
--- a/internal/commands/iam/serviceprincipals/read.go
+++ b/internal/commands/iam/serviceprincipals/read.go
@@ -39,7 +39,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 				`),
 			},
 			{
-				Preamble: `Read the group using the service principal's resource name:`,
+				Preamble: `Read the service principal using the service principal's resource name:`,
 				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
 				$ hcp iam service-principals read \
 				  iam/project/example-project/service-principal/example-sp


### PR DESCRIPTION
### Changes proposed in this PR:

Fix copy'n'paste error in read service principal command. The example referred to a group instead of a service principal.

### How I've tested this PR:

n/a

### How I expect reviewers to test this PR:

n/a

### Checklist:
- [ ] ~~Tests added if applicable~~
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
