### PR TITLE
Improve Waypoint CLI UX

### DIFF
--- a/internal/commands/waypoint/add-ons/definitions/create.go
+++ b/internal/commands/waypoint/add-ons/definitions/create.go
@@ -128,14 +128,16 @@ $ hcp waypoint add-ons definitions create -n my-add-on-definition \
 func addOnDefinitionCreate(opts *AddOnDefinitionOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrapf(err, "Unable to access HCP project")
+		return err
 	}
 
 	var readmeTpl []byte
 	if opts.ReadmeMarkdownTemplateFile != "" {
 		readmeTpl, err = os.ReadFile(opts.ReadmeMarkdownTemplateFile)
 		if err != nil {
-			return errors.Wrapf(err, "failed to read README markdown template file %q", opts.ReadmeMarkdownTemplateFile)
+			return errors.Wrapf(err, "%s failed to read README markdown template file %q",
+				opts.IO.ColorScheme().FailureIcon(),
+				opts.ReadmeMarkdownTemplateFile)
 		}
 	}
 
@@ -160,10 +162,16 @@ func addOnDefinitionCreate(opts *AddOnDefinitionOpts) error {
 			Context: opts.Ctx,
 		}, nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create add-on definition %q", opts.Name)
+		return errors.Wrapf(err, "%s failed to create add-on definition %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Add-on definition %q created.", opts.Name)
+	fmt.Fprintf(opts.IO.Err(), "%s Add-on definition %q created.\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name,
+	)
 
 	return nil
 }

--- a/internal/commands/waypoint/add-ons/definitions/delete.go
+++ b/internal/commands/waypoint/add-ons/definitions/delete.go
@@ -66,10 +66,16 @@ func addOnDefinitionDelete(opts *AddOnDefinitionOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete add-on definition %q", opts.Name)
+		return errors.Wrapf(err, "%s failed to delete add-on definition %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Add-on definition %q deleted.", opts.Name)
+	fmt.Fprintf(opts.IO.Err(), "%s Add-on definition %q deleted.\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name,
+	)
 
 	return nil
 }

--- a/internal/commands/waypoint/add-ons/definitions/list.go
+++ b/internal/commands/waypoint/add-ons/definitions/list.go
@@ -54,7 +54,9 @@ func addOnDefinitionsList(opts *AddOnDefinitionOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return errors.Wrap(err, "failed to list add-on definitions")
+		return errors.Wrapf(err, "%s failed to list add-on definitions",
+			opts.IO.ColorScheme().FailureIcon(),
+		)
 	}
 
 	addOnDefinitions = append(addOnDefinitions, listResp.GetPayload().AddOnDefinitions...)
@@ -67,7 +69,9 @@ func addOnDefinitionsList(opts *AddOnDefinitionOpts) error {
 				PaginationNextPageToken: &listResp.GetPayload().Pagination.NextPageToken,
 			}, nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to list paginated add-on definitions")
+			return errors.Wrapf(err, "%s failed to list paginated add-on definitions",
+				opts.IO.ColorScheme().FailureIcon(),
+			)
 		}
 
 		addOnDefinitions = append(addOnDefinitions, listResp.GetPayload().AddOnDefinitions...)

--- a/internal/commands/waypoint/add-ons/definitions/read.go
+++ b/internal/commands/waypoint/add-ons/definitions/read.go
@@ -53,7 +53,7 @@ $ hcp waypoint add-ons definitions read -n my-addon-definition
 func addOnDefinitionRead(opts *AddOnDefinitionOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrap(err, "unable to access HCP project")
+		return err
 	}
 
 	getResp, err := opts.WS.WaypointServiceGetAddOnDefinition2(
@@ -64,7 +64,10 @@ func addOnDefinitionRead(opts *AddOnDefinitionOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get add-on definition %q", opts.Name)
+		return errors.Wrapf(err, "%s failed to get add-on definition %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
 	getRespPayload := getResp.GetPayload()

--- a/internal/commands/waypoint/add-ons/definitions/update.go
+++ b/internal/commands/waypoint/add-ons/definitions/update.go
@@ -118,14 +118,17 @@ $ hcp waypoint add-ons definitions update -n=my-add-on-definition \
 func addOnDefinitionUpdate(opts *AddOnDefinitionOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrap(err, "unable to access HCP project")
+		return err
 	}
 
 	var readmeTpl []byte
 	if opts.ReadmeMarkdownTemplateFile != "" {
 		readmeTpl, err = os.ReadFile(opts.ReadmeMarkdownTemplateFile)
 		if err != nil {
-			return errors.Wrapf(err, "failed to read README markdown template file %q", opts.ReadmeMarkdownTemplateFile)
+			return errors.Wrapf(err, "%s failed to read README markdown template file %q",
+				opts.IO.ColorScheme().FailureIcon(),
+				opts.ReadmeMarkdownTemplateFile,
+			)
 		}
 	}
 
@@ -151,10 +154,15 @@ func addOnDefinitionUpdate(opts *AddOnDefinitionOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to update add-on definition %q", opts.Name)
+		return errors.Wrapf(err, "%s failed to update add-on definition %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Add-on definition %q updated.", opts.Name)
+	fmt.Fprintf(opts.IO.Err(), "%s Add-on definition %q updated.\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name)
 
 	return nil
 }

--- a/internal/commands/waypoint/applications/create.go
+++ b/internal/commands/waypoint/applications/create.go
@@ -72,7 +72,7 @@ $ hcp waypoint application create -n my-application -t my-templates
 func applicationCreate(opts *ApplicationOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrap(err, "unable to access HCP project")
+		return err
 	}
 
 	actionConfigs := make([]*models.HashicorpCloudWaypointActionCfgRef, len(opts.ActionConfigNames))
@@ -95,10 +95,16 @@ func applicationCreate(opts *ApplicationOpts) error {
 			},
 		}, nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create application %q", opts.Name)
+		return errors.Wrapf(err, "%s failed to create application %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Application %q created.", opts.Name)
+	fmt.Fprintf(opts.IO.Err(), "%s Application %q created.\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name,
+	)
 
 	return nil
 }

--- a/internal/commands/waypoint/applications/destroy.go
+++ b/internal/commands/waypoint/applications/destroy.go
@@ -55,7 +55,7 @@ $ hcp waypoint applications destroy -n my-application
 func applicationDestroy(opts *ApplicationOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrap(err, "failed to get namespace")
+		return err
 	}
 
 	if opts.IO.CanPrompt() {
@@ -63,9 +63,10 @@ func applicationDestroy(opts *ApplicationOpts) error {
 			"The HCP Waypoint application will be deleted.\n\n" +
 				"Do you want to continue")
 		if err != nil {
-			return fmt.Errorf("failed to retrieve confirmation: %w", err)
+			return errors.Wrapf(err, "%s failed to prompt for confirmation",
+				opts.IO.ColorScheme().FailureIcon(),
+			)
 		}
-
 		if !ok {
 			return nil
 		}
@@ -79,10 +80,15 @@ func applicationDestroy(opts *ApplicationOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to destroy application %q", opts.Name)
+		return errors.Wrapf(err, "%s failed to destroy application %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Application %q destroyed.", opts.Name)
+	fmt.Fprintf(opts.IO.Err(), "%s Application %q destroyed.\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name)
 
 	return nil
 }

--- a/internal/commands/waypoint/applications/list.go
+++ b/internal/commands/waypoint/applications/list.go
@@ -11,7 +11,7 @@ import (
 func NewCmdApplicationsList(ctx *cmd.Context, opts *ApplicationOpts) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "list",
-		ShortHelp: "List HCP Waypoint applications.",
+		ShortHelp: "List all HCP Waypoint applications.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 			The {{ template "mdCodeOrBold" "hcp waypoint applications list" }} command lists all
 			HCP Waypoint applications.
@@ -30,7 +30,7 @@ func NewCmdApplicationsList(ctx *cmd.Context, opts *ApplicationOpts) *cmd.Comman
 func applicationsList(opts *ApplicationOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrap(err, "unable to access HCP project")
+		return err
 	}
 
 	resp, err := opts.WS.WaypointServiceListApplications(
@@ -40,7 +40,9 @@ func applicationsList(opts *ApplicationOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return errors.Wrap(err, "failed to list applications")
+		return errors.Wrapf(err, "%s failed to list applications",
+			opts.IO.ColorScheme().FailureIcon(),
+		)
 	}
 
 	return opts.Output.Show(resp.GetPayload().Applications, format.Pretty)

--- a/internal/commands/waypoint/applications/read.go
+++ b/internal/commands/waypoint/applications/read.go
@@ -12,7 +12,7 @@ import (
 func NewCmdApplicationsRead(ctx *cmd.Context, opts *ApplicationOpts) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "read",
-		ShortHelp: "Read an HCP Waypoint application.",
+		ShortHelp: "Read details about an HCP Waypoint application.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 The {{ template "mdCodeOrBold" "hcp waypoint applications read" }} command lets you read
 details about an HCP Waypoint application.
@@ -52,7 +52,7 @@ details about an HCP Waypoint application.
 func applicationRead(opts *ApplicationOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrap(err, "failed to get namespace")
+		return err
 	}
 
 	getResp, err := opts.WS.WaypointServiceGetApplication2(
@@ -63,7 +63,10 @@ func applicationRead(opts *ApplicationOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get application %q", opts.Name)
+		return errors.Wrapf(err, "%s failed to get application %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
 	return opts.Output.Show(getResp.GetPayload().Application, format.Pretty)

--- a/internal/commands/waypoint/applications/update.go
+++ b/internal/commands/waypoint/applications/update.go
@@ -72,7 +72,7 @@ $ hcp waypoint applications update -n my-application --action-config-name my-act
 func applicationUpdate(opts *ApplicationOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrap(err, "failed to get namespace")
+		return err
 	}
 
 	var acrs []*models.HashicorpCloudWaypointActionCfgRef
@@ -86,7 +86,10 @@ func applicationUpdate(opts *ApplicationOpts) error {
 	if opts.ReadmeMarkdownFile != "" {
 		readme, err = os.ReadFile(opts.ReadmeMarkdownFile)
 		if err != nil {
-			return errors.Wrapf(err, "failed to read README markdown file %q", opts.ReadmeMarkdownFile)
+			return errors.Wrapf(err,
+				"%s failed to read README markdown file %q",
+				opts.IO.ColorScheme().FailureIcon(),
+				opts.ReadmeMarkdownFile)
 		}
 	}
 
@@ -102,10 +105,16 @@ func applicationUpdate(opts *ApplicationOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to update application %q", opts.Name)
+		return errors.Wrapf(err, "%s failed to update application %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Application %q updated.", opts.Name)
+	fmt.Fprintf(opts.IO.Err(), "%s Application %q updated.\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name,
+	)
 
 	return nil
 }

--- a/internal/commands/waypoint/opts/opts.go
+++ b/internal/commands/waypoint/opts/opts.go
@@ -38,7 +38,9 @@ func (w *WaypointOpts) Namespace() (*models.HashicorpCloudWaypointNamespace, err
 		Context:                w.Ctx,
 	}, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to access HCP project")
+		return nil, errors.Wrapf(err, "%s Unable to access HCP project",
+			w.IO.ColorScheme().FailureIcon(),
+		)
 	}
 
 	return resp.Payload.Namespace, nil

--- a/internal/commands/waypoint/templates/create.go
+++ b/internal/commands/waypoint/templates/create.go
@@ -139,7 +139,7 @@ $ hcp waypoint templates create -n my-template \
 func templateCreate(opts *TemplateOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrapf(err, "unable to access HCP project")
+		return err
 	}
 
 	var tags []*models.HashicorpCloudWaypointTag
@@ -154,7 +154,10 @@ func templateCreate(opts *TemplateOpts) error {
 	if opts.ReadmeMarkdownTemplateFile != "" {
 		readmeTpl, err = os.ReadFile(opts.ReadmeMarkdownTemplateFile)
 		if err != nil {
-			return errors.Wrapf(err, "failed to read README markdown template file %q", opts.ReadmeMarkdownTemplateFile)
+			return errors.Wrapf(err, "%s failed to read README markdown template file %q",
+				opts.IO.ColorScheme().FailureIcon(),
+				opts.ReadmeMarkdownTemplateFile,
+			)
 		}
 	}
 
@@ -182,10 +185,18 @@ func templateCreate(opts *TemplateOpts) error {
 			Context: opts.Ctx,
 		}, nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create template %q", opts.Name)
+		return errors.Wrapf(
+			err,
+			"%s failed to create template %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Template %q created.", opts.Name)
+	fmt.Fprintf(opts.IO.Err(), "%s Template %q created.\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name,
+	)
 
 	return nil
 }

--- a/internal/commands/waypoint/templates/delete.go
+++ b/internal/commands/waypoint/templates/delete.go
@@ -47,7 +47,7 @@ existing HCP Waypoint templates.
 func templateDelete(opts *TemplateOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrapf(err, "unable to access HCP project")
+		return err
 	}
 
 	_, err = opts.WS.WaypointServiceDeleteApplicationTemplate2(
@@ -61,7 +61,10 @@ func templateDelete(opts *TemplateOpts) error {
 		return errors.Wrapf(err, "failed to delete template %q", opts.Name)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Template %q deleted.", opts.Name)
+	fmt.Fprintf(opts.IO.Err(), "%s Template %q deleted.\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name,
+	)
 
 	return nil
 }

--- a/internal/commands/waypoint/templates/list.go
+++ b/internal/commands/waypoint/templates/list.go
@@ -12,11 +12,19 @@ import (
 func NewCmdList(ctx *cmd.Context, opts *TemplateOpts) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "list",
-		ShortHelp: "List all known HCP Waypoint templates.",
+		ShortHelp: "List all HCP Waypoint templates.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 The {{ template "mdCodeOrBold" "hcp waypoint templates list" }} command lets you list
 existing HCP Waypoint templates.
 		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: "List all HCP Waypoint templates:",
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+$ hcp waypoint templates list
+`),
+			},
+		},
 		RunF: func(c *cmd.Command, args []string) error {
 			return listTemplates(opts)
 		},
@@ -31,7 +39,7 @@ existing HCP Waypoint templates.
 func listTemplates(opts *TemplateOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrapf(err, "unable to access HCP project")
+		return err
 	}
 
 	var templates []*models.HashicorpCloudWaypointApplicationTemplate
@@ -42,7 +50,9 @@ func listTemplates(opts *TemplateOpts) error {
 			Context:     opts.Ctx,
 		}, nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list templates")
+		return errors.Wrapf(err, "%s failed to list templates",
+			opts.IO.ColorScheme().FailureIcon(),
+		)
 	}
 
 	templates = append(templates, resp.GetPayload().ApplicationTemplates...)
@@ -55,7 +65,9 @@ func listTemplates(opts *TemplateOpts) error {
 				PaginationNextPageToken: &resp.GetPayload().Pagination.NextPageToken,
 			}, nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to list paginated templates")
+			return errors.Wrapf(err, "%s failed to list paginated templates",
+				opts.IO.ColorScheme().FailureIcon(),
+			)
 		}
 
 		templates = append(templates, resp.GetPayload().ApplicationTemplates...)

--- a/internal/commands/waypoint/templates/read.go
+++ b/internal/commands/waypoint/templates/read.go
@@ -17,6 +17,14 @@ func NewCmdRead(ctx *cmd.Context, opts *TemplateOpts) *cmd.Command {
 The {{ template "mdCodeOrBold" "hcp waypoint templates read" }} command lets you read
 an existing HCP Waypoint template.
 		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: "Read an HCP Waypoint template:",
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+$ hcp waypoint templates read -n my-template
+`),
+			},
+		},
 		RunF: func(c *cmd.Command, args []string) error {
 			if opts.testFunc != nil {
 				return opts.testFunc(c, args)
@@ -46,7 +54,7 @@ an existing HCP Waypoint template.
 func templateRead(opts *TemplateOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrapf(err, "unable to access HCP project")
+		return err
 	}
 
 	resp, err := opts.WS.WaypointServiceGetApplicationTemplate2(
@@ -57,7 +65,10 @@ func templateRead(opts *TemplateOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get template %q", opts.Name)
+		return errors.Wrapf(err, "%s failed to get template %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
 	respPayload := resp.GetPayload()

--- a/internal/commands/waypoint/templates/update.go
+++ b/internal/commands/waypoint/templates/update.go
@@ -140,7 +140,7 @@ $ hcp waypoint templates update -n my-template \
 func templateUpdate(opts *TemplateOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
-		return errors.Wrapf(err, "unable to access HCP project")
+		return err
 	}
 
 	var tags []*models.HashicorpCloudWaypointTag
@@ -155,7 +155,10 @@ func templateUpdate(opts *TemplateOpts) error {
 	if opts.ReadmeMarkdownTemplateFile != "" {
 		readmeTpl, err = os.ReadFile(opts.ReadmeMarkdownTemplateFile)
 		if err != nil {
-			return errors.Wrapf(err, "failed to read file %q", opts.ReadmeMarkdownTemplateFile)
+			return errors.Wrapf(err, "%s failed to read README template file %q",
+				opts.IO.ColorScheme().FailureIcon(),
+				opts.ReadmeMarkdownTemplateFile,
+			)
 		}
 	}
 
@@ -187,10 +190,16 @@ func templateUpdate(opts *TemplateOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to update template %q", opts.Name)
+		return errors.Wrapf(err, "%s failed to update template %q",
+			opts.IO.ColorScheme().FailureIcon(),
+			opts.Name,
+		)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Template %q updated.", opts.ID)
+	fmt.Fprintf(opts.IO.Err(), "%s Template %q updated.\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.ID,
+	)
 
 	return nil
 }

--- a/internal/commands/waypoint/tfcconfig/tfc_config.go
+++ b/internal/commands/waypoint/tfcconfig/tfc_config.go
@@ -15,8 +15,8 @@ func NewCmdTFCConfig(ctx *cmd.Context) *cmd.Command {
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp waypoint tfc-config" }} command group manages 
 		the set of TFC Configs. New TFC Configs can be created using
-		{{ template "mdCodeOrBold" "hcp waypoint tfc-config set" }} and existing
-		profiles can be viewed using {{ template "mdCodeOrBold" "hcp waypoint tfc-config get" }}.
+		{{ template "mdCodeOrBold" "hcp waypoint tfc-config create" }} and existing
+		profiles can be viewed using {{ template "mdCodeOrBold" "hcp waypoint tfc-config read" }}.
 		`),
 	}
 

--- a/internal/commands/waypoint/tfcconfig/tfc_config_create.go
+++ b/internal/commands/waypoint/tfcconfig/tfc_config_create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
 	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/pkg/errors"
 )
 
 func NewCmdCreate(ctx *cmd.Context, runF func(opts *TFCConfigCreateOpts) error) *cmd.Command {
@@ -110,11 +111,11 @@ func createRun(opts *TFCConfigCreateOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return fmt.Errorf("error creating TFC config: %w", err)
+		return errors.Wrapf(err, "%s error creating TFC config", opts.IO.ColorScheme().FailureIcon())
 
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "%s TFC Config  %q created!\n", opts.IO.ColorScheme().SuccessIcon(), resp.Payload.TfcConfig.OrganizationName)
+	fmt.Fprintf(opts.IO.Err(), "%s TFC Config %q created!\n", opts.IO.ColorScheme().SuccessIcon(), resp.Payload.TfcConfig.OrganizationName)
 
 	return nil
 

--- a/internal/commands/waypoint/tfcconfig/tfc_config_read.go
+++ b/internal/commands/waypoint/tfcconfig/tfc_config_read.go
@@ -2,7 +2,6 @@ package tfcconfig
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
 	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/pkg/errors"
 )
 
 func NewCmdRead(ctx *cmd.Context, runF func(opts *TFCConfigReadOpts) error) *cmd.Command {
@@ -53,7 +53,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(opts *TFCConfigReadOpts) error) *cmd
 func readRun(opts *TFCConfigReadOpts) error {
 	nsID, err := GetNamespace(opts.Ctx, opts.WaypointClient, opts.Profile.OrganizationID, opts.Profile.ProjectID)
 	if err != nil {
-		return fmt.Errorf("error getting namespace: %w", err)
+		return err
 	}
 	resp, err := opts.WaypointClient.WaypointServiceGetTFCConfig(
 		&waypoint_service.WaypointServiceGetTFCConfigParams{
@@ -62,8 +62,7 @@ func readRun(opts *TFCConfigReadOpts) error {
 		}, nil,
 	)
 	if err != nil {
-		return fmt.Errorf("error retrieving TFC config: %w", err)
-
+		return errors.Wrapf(err, "%s failed to get TFC Config", opts.IO.ColorScheme().FailureIcon())
 	}
 	d := newDisplayer(format.Pretty, resp.Payload.TfcConfig)
 	return opts.Output.Display(d)


### PR DESCRIPTION
### Changes proposed in this PR:

Fix doubly wrapped error message when failing to retrieve a namespace.

Include failure and success icons for relevant commands for TFC configs, templates, apps, and add-on definitions.

Fix and improve text in some command help texts.

### How I've tested this PR:

Manually using examples in help text.

### How I expect reviewers to test this PR:

Manually using examples in help text.

### Output of affected commands:

TODO

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
