### PR TITLE
PR template uses right make command for changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 
 ### How I expect reviewers to test this PR:
 
+
 <!-- If you are adding a new command or editing an existing one, please provide
      an example of the command being invoked.
 ### Output of affected commands:
@@ -12,6 +13,7 @@
 ### Checklist:
 - [ ] Tests added if applicable
 - [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
-  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
-  > commit the resulting file, which should have a name matching your PR number.
-  > Entries should use imperative present tense (e.g. Add support for...)
+  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
+  > in authoring a changelog entry, and commit the resulting file, which should
+  > have a name matching your PR number. Entries should use imperative present
+  > tense (e.g. Add support for...)


### PR DESCRIPTION
### Changes proposed in this PR:

PR template shows correct make command for generating changelog entry.

### How I've tested this PR:
N/A

### How I expect reviewers to test this PR:
Does the updated text clarify what needs to be run?

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
