### PR TITLE
Fix table output for waypoint agent group list

### DIFF
--- a/.changelog/59.txt
+++ b/.changelog/59.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+waypoint: Fix table output for agent group list command
+```

--- a/internal/commands/waypoint/agent/group_list.go
+++ b/internal/commands/waypoint/agent/group_list.go
@@ -61,5 +61,5 @@ func agentGroupList(log hclog.Logger, opts *GroupOpts) error {
 		return fmt.Errorf("error listing groups: %w", err)
 	}
 
-	return opts.Output.Show(list.Payload.Groups, format.Table, "name", "description")
+	return opts.Output.Show(list.Payload.Groups, format.Table, "Name", "Description")
 }


### PR DESCRIPTION
### Changes proposed in this PR:

Fix the table output in the `waypoint agent group list` command.

### How I've tested this PR:

Manually. See screenshots below.

### How I expect reviewers to test this PR:

1. Create some agent groups
2. Run `hcp waypoint agent group list`
3. Verify you see the expected agent groups

### Output of affected commands:

| Before | After |
| --- | --- |
| ![CleanShot 2024-04-17 at 12 51 12@2x](https://github.com/hashicorp/hcp/assets/34030/ea1c6498-e034-46f8-93d4-fb31aabcab55) | ![CleanShot 2024-04-17 at 12 51 33@2x](https://github.com/hashicorp/hcp/assets/34030/cd598620-3a58-4ffc-bd55-490660c0d1af) |

### Checklist:
- [ ] Tests added if applicable
- [x] CHANGELOG entry added