### PR TITLE
Waypoint: update the list display to use a table

### DIFF
--- a/.changelog/60.txt
+++ b/.changelog/60.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+waypoint: change template list format to use a table
+```

--- a/internal/commands/waypoint/templates/list.go
+++ b/internal/commands/waypoint/templates/list.go
@@ -76,5 +76,11 @@ func listTemplates(opts *TemplateOpts) error {
 		templates = append(templates, resp.GetPayload().ApplicationTemplates...)
 	}
 
-	return opts.Output.Show(templates, format.Pretty)
+	templateFields := []format.Field{
+		format.NewField("Name", "{{ .Name }}"),
+		format.NewField("ID", "{{ .ID }}"),
+		format.NewField("Summary", "{{ .Summary }}"),
+	}
+
+	return opts.Output.Display(format.NewDisplayer(templates, format.Table, templateFields))
 }


### PR DESCRIPTION
Simple change to how we list templates from just dumping them out to tabling them.

Ex:

![templates_table](https://github.com/hashicorp/hcp/assets/61721/f43e9af4-bf75-4b52-94f9-3b46067f30d7)
