### PR TITLE
Renaming Waypoint actions commands

### DIFF
--- a/.changelog/61.txt
+++ b/.changelog/61.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+waypoint: Rename HCP Waypoint add-on definition, add-on, and action config command groups.
+```

--- a/.changelog/61.txt
+++ b/.changelog/61.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-waypoint: Rename HCP Waypoint add-on definition, add-on, and action config command groups.
+waypoint: Rename HCP Waypoint action config command group.
 ```

--- a/internal/commands/waypoint/actions/action.go
+++ b/internal/commands/waypoint/actions/action.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package actionconfig
+package actions
 
 import (
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
@@ -10,14 +10,14 @@ import (
 
 func NewCmdActionConfig(ctx *cmd.Context) *cmd.Command {
 	cmd := &cmd.Command{
-		Name:      "action-config",
+		Name:      "actions",
 		ShortHelp: "Manage action configuration options for HCP Waypoint.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp waypoint action-config" }} command
-		group manages all action configuration options for HCP Waypoint. An action
-		configuration is a set of options that define how an action is executed. This
-		includes the action request type, and the action name. The action
-		configuration is used to launch action runs depending on the Request type.
+		The {{ template "mdCodeOrBold" "hcp waypoint actions" }} command group
+		manages all action options for HCP Waypoint. An action is a set of 
+		options that define how an action is executed. This includes the action
+		request type, and the action name. The action is used to launch action 
+		runs depending on the Request type.
 		`),
 	}
 

--- a/internal/commands/waypoint/actions/delete.go
+++ b/internal/commands/waypoint/actions/delete.go
@@ -28,7 +28,7 @@ func NewCmdDelete(ctx *cmd.Context) *cmd.Command {
 		Name:      "delete",
 		ShortHelp: "Delete an existing action.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp waypoint action-config delete" }}
+		The {{ template "mdCodeOrBold" "hcp waypoint actions delete" }}
 		command deletes an existing action. This will remove the action 
 		completely from HCP Waypoint.
 		`),

--- a/internal/commands/waypoint/actions/list.go
+++ b/internal/commands/waypoint/actions/list.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package actionconfig
+package actions
 
 import (
 	"fmt"
@@ -24,13 +24,13 @@ func NewCmdList(ctx *cmd.Context) *cmd.Command {
 
 	cmd := &cmd.Command{
 		Name:      "list",
-		ShortHelp: "List all known action configurations.",
+		ShortHelp: "List all known actions.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp waypoint action-config list" }}
-		command lists all known action configurations from HCP Waypoint.
+		The {{ template "mdCodeOrBold" "hcp waypoint actions list" }} command 
+		lists all known actions from HCP Waypoint.
 		`),
 		RunF: func(c *cmd.Command, args []string) error {
-			return listActionConfig(c, args, opts)
+			return listActions(c, args, opts)
 		},
 		PersistentPreRun: func(c *cmd.Command, args []string) error {
 			return cmd.RequireOrgAndProject(ctx)
@@ -40,7 +40,7 @@ func NewCmdList(ctx *cmd.Context) *cmd.Command {
 	return cmd
 }
 
-func listActionConfig(c *cmd.Command, args []string, opts *ListOpts) error {
+func listActions(c *cmd.Command, args []string, opts *ListOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
 		return err
@@ -51,7 +51,7 @@ func listActionConfig(c *cmd.Command, args []string, opts *ListOpts) error {
 		Context:     opts.Ctx,
 	}, nil)
 	if err != nil {
-		return fmt.Errorf("error listing action configurations: %w", err)
+		return fmt.Errorf("error listing actions: %w", err)
 	}
 
 	respPayload := resp.GetPayload()

--- a/internal/commands/waypoint/actions/read.go
+++ b/internal/commands/waypoint/actions/read.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package actionconfig
+package actions
 
 import (
 	"fmt"
@@ -10,30 +10,30 @@ import (
 	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 )
 
-type DeleteOpts struct {
+type ReadOpts struct {
 	opts.WaypointOpts
 
 	Name string
 }
 
-func NewCmdDelete(ctx *cmd.Context) *cmd.Command {
-	opts := &DeleteOpts{
+func NewCmdRead(ctx *cmd.Context) *cmd.Command {
+	opts := &ReadOpts{
 		WaypointOpts: opts.New(ctx),
 	}
 
 	cmd := &cmd.Command{
-		Name:      "delete",
-		ShortHelp: "Delete an existing action configuration.",
+		Name:      "read",
+		ShortHelp: "Read more details about an action.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp waypoint action-config delete" }}
-		command deletes an existing action configuration. This will remove the
-		config completely from HCP Waypoint.
+		The {{ template "mdCodeOrBold" "hcp waypoint actions read" }}
+		command returns more details about an action configurations.
 		`),
 		RunF: func(c *cmd.Command, args []string) error {
-			return deleteActionConfig(c, args, opts)
+			return readAction(c, args, opts)
 		},
 		PersistentPreRun: func(c *cmd.Command, args []string) error {
 			return cmd.RequireOrgAndProject(ctx)
@@ -43,7 +43,7 @@ func NewCmdDelete(ctx *cmd.Context) *cmd.Command {
 				{
 					Name:        "name",
 					Shorthand:   "n",
-					Description: "The name of the action configuration to delete.",
+					Description: "The name of the action.",
 					Value:       flagvalue.Simple("", &opts.Name),
 					Required:    true,
 				},
@@ -54,7 +54,7 @@ func NewCmdDelete(ctx *cmd.Context) *cmd.Command {
 	return cmd
 }
 
-func deleteActionConfig(c *cmd.Command, args []string, opts *DeleteOpts) error {
+func readAction(c *cmd.Command, args []string, opts *ReadOpts) error {
 	ns, err := opts.Namespace()
 	if err != nil {
 		return err
@@ -62,15 +62,16 @@ func deleteActionConfig(c *cmd.Command, args []string, opts *DeleteOpts) error {
 
 	// Make action name a string pointer
 	actionName := &opts.Name
-	_, err = opts.WS.WaypointServiceDeleteActionConfig(&waypoint_service.WaypointServiceDeleteActionConfigParams{
+	resp, err := opts.WS.WaypointServiceGetActionConfig(&waypoint_service.WaypointServiceGetActionConfigParams{
 		NamespaceID: ns.ID,
 		Context:     opts.Ctx,
 		ActionName:  actionName,
 	}, nil)
 	if err != nil {
-		return fmt.Errorf("failed to delete action config %q: %w", opts.Name, err)
+		return fmt.Errorf("error getting action for %q: %w",
+			opts.Name, err)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Action config %q deleted.", opts.Name)
-	return nil
+	respPayload := resp.GetPayload()
+	return opts.Output.Show(respPayload.ActionConfig, format.Pretty)
 }

--- a/internal/commands/waypoint/waypoint.go
+++ b/internal/commands/waypoint/waypoint.go
@@ -4,7 +4,7 @@
 package waypoint
 
 import (
-	"github.com/hashicorp/hcp/internal/commands/waypoint/actionconfig"
+	"github.com/hashicorp/hcp/internal/commands/waypoint/actions"
 	addon "github.com/hashicorp/hcp/internal/commands/waypoint/add-ons"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/agent"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/applications"
@@ -26,7 +26,7 @@ func NewCmdWaypoint(ctx *cmd.Context) *cmd.Command {
 	}
 
 	cmd.AddChild(tfcconfig.NewCmdTFCConfig(ctx))
-	cmd.AddChild(actionconfig.NewCmdActionConfig(ctx))
+	cmd.AddChild(actions.NewCmdActionConfig(ctx))
 	cmd.AddChild(agent.NewCmdAgent(ctx))
 	cmd.AddChild(templates.NewCmdTemplate(ctx))
 	cmd.AddChild(addon.NewCmdAddOn(ctx))


### PR DESCRIPTION
### Changes proposed in this PR:

Closes WAYP-2557.

`hcp waypoint action-config` command group is renamed to `hcp waypoint actions`

### How I've tested this PR:

Manually run these new commands, run unit tests.

### How I expect reviewers to test this PR:

Try out the commands in your own HCP project.
