### PR TITLE
VAULT-26814 - Adds top-level vault-secrets command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,6 @@ internal/pkg/api/mocks
 # Waypoint Owned
 internal/commands/waypoint @hashicorp/cloud-waypoint
 internal/pkg/waypoint @hashicorp/cloud-waypoint
+
+# Vault Secrets Owned
+internal/commands/vaultsecrets @hashicorp/cloud-vault-secrets

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@ internal/commands/waypoint @hashicorp/cloud-waypoint
 internal/pkg/waypoint @hashicorp/cloud-waypoint
 
 # Vault Secrets Owned
-internal/commands/vaultsecrets @hashicorp/cloud-vault-secrets
+*vaultsecrets* @hashicorp/cloud-vault-secrets

--- a/internal/commands/hcp/hcp.go
+++ b/internal/commands/hcp/hcp.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/hcp/internal/commands/organizations"
 	"github.com/hashicorp/hcp/internal/commands/profile"
 	"github.com/hashicorp/hcp/internal/commands/projects"
+	vaultsecrets "github.com/hashicorp/hcp/internal/commands/vault-secrets"
 	"github.com/hashicorp/hcp/internal/commands/version"
 	"github.com/hashicorp/hcp/internal/commands/waypoint"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
@@ -38,6 +39,7 @@ func NewCmdHcp(ctx *cmd.Context) *cmd.Command {
 	c.AddChild(organizations.NewCmdOrganizations(ctx))
 	c.AddChild(iam.NewCmdIam(ctx))
 	c.AddChild(waypoint.NewCmdWaypoint(ctx))
+	c.AddChild(vaultsecrets.NewCmdVaultSecrets(ctx))
 
 	// Configure the command as the root command.
 	cmd.ConfigureRootCommand(ctx, c)

--- a/internal/commands/hcp/hcp.go
+++ b/internal/commands/hcp/hcp.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/hcp/internal/commands/organizations"
 	"github.com/hashicorp/hcp/internal/commands/profile"
 	"github.com/hashicorp/hcp/internal/commands/projects"
-	vaultsecrets "github.com/hashicorp/hcp/internal/commands/vault-secrets"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets"
 	"github.com/hashicorp/hcp/internal/commands/version"
 	"github.com/hashicorp/hcp/internal/commands/waypoint"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"

--- a/internal/commands/vaultsecrets/apps/apps.go
+++ b/internal/commands/vaultsecrets/apps/apps.go
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package apps
+
+import (
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+)
+
+func NewCmdApps(ctx *cmd.Context) *cmd.Command {
+	cmd := &cmd.Command{
+		Name:      "apps",
+		ShortHelp: "Manage HCP Vault Secrets apps.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets apps" }} command group lets you
+		manage HCP Vault Secrets applications.
+		`),
+		// Validation rules requires either RunF or Children are set
+		// RunF can be removed when CRUD children are added
+		RunF: func(c *cmd.Command, args []string) error {
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/commands/vaultsecrets/vault_secrets.go
+++ b/internal/commands/vaultsecrets/vault_secrets.go
@@ -11,13 +11,18 @@ import (
 func NewCmdVaultSecrets(ctx *cmd.Context) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "vault-secrets",
-		ShortHelp: "Manage Vault Secrets (Beta).",
+		ShortHelp: "Manage Vault Secrets in Beta.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets" }} command group lets you manage HCP Vault Secrets
 		resources through the CLI (in Beta). 
 		`),
 		Aliases: []string{
 			"vault-secrets-beta",
+		},
+		// Validation rules requires either RunF or Children are set
+		// RunF can be removed when apps and secrets children are added
+		RunF: func(c *cmd.Command, args []string) error {
+			return nil
 		},
 	}
 

--- a/internal/commands/vaultsecrets/vault_secrets.go
+++ b/internal/commands/vaultsecrets/vault_secrets.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vaultsecrets
+
+import (
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+)
+
+func NewCmdVaultSecrets(ctx *cmd.Context) *cmd.Command {
+	cmd := &cmd.Command{
+		Name:      "vault-secrets",
+		ShortHelp: "Manage Vault Secrets (Beta).",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets" }} command group lets you manage HCP Vault Secrets
+		resources through the CLI (in Beta). 
+		`),
+		Aliases: []string{
+			"vault-secrets-beta",
+		},
+	}
+
+	return cmd
+}

--- a/internal/commands/vaultsecrets/vault_secrets.go
+++ b/internal/commands/vaultsecrets/vault_secrets.go
@@ -4,6 +4,7 @@
 package vaultsecrets
 
 import (
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/apps"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 )
@@ -19,12 +20,8 @@ func NewCmdVaultSecrets(ctx *cmd.Context) *cmd.Command {
 		Aliases: []string{
 			"vault-secrets-beta",
 		},
-		// Validation rules requires either RunF or Children are set
-		// RunF can be removed when apps and secrets children are added
-		RunF: func(c *cmd.Command, args []string) error {
-			return nil
-		},
 	}
 
+	cmd.AddChild(apps.NewCmdApps(ctx))
 	return cmd
 }

--- a/internal/commands/vaultsecrets/vault_secrets.go
+++ b/internal/commands/vaultsecrets/vault_secrets.go
@@ -18,7 +18,7 @@ func NewCmdVaultSecrets(ctx *cmd.Context) *cmd.Command {
 		resources through the CLI (in Beta). 
 		`),
 		Aliases: []string{
-			"vault-secrets-beta",
+			"secrets",
 		},
 	}
 

--- a/internal/commands/vaultsecrets/vault_secrets.go
+++ b/internal/commands/vaultsecrets/vault_secrets.go
@@ -12,7 +12,7 @@ import (
 func NewCmdVaultSecrets(ctx *cmd.Context) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "vault-secrets",
-		ShortHelp: "Manage Vault Secrets in Beta.",
+		ShortHelp: "Manage Vault Secrets.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets" }} command group lets you manage HCP Vault Secrets
 		resources through the CLI (in Beta). 


### PR DESCRIPTION
### Changes proposed in this PR:
This PR just adds the groundwork for the top-level vault-secrets command to the `hcp` command groups. `apps` was also stubbed out to pass validation that required either children or `RunF` be added to the command

### How I've tested this PR:
Build the local changes and ran the binary
<img width="784" alt="Screenshot 2024-05-07 at 1 12 14 PM" src="https://github.com/hashicorp/hcp/assets/19840012/db533f01-708c-43de-9a5e-e7d8b9e6e263">
<img width="713" alt="Screenshot 2024-05-07 at 1 12 43 PM" src="https://github.com/hashicorp/hcp/assets/19840012/647e531e-3f07-4803-b5cb-d9dde72d8cb6">

### How I expect reviewers to test this PR:
N/A

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
