### PR TITLE
[WAYP-2571] TFC Config error

### DIFF
--- a/.changelog/63.txt
+++ b/.changelog/63.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+A better error message is now returned if a user attempts to read a Waypoint TFC Config when one has not been set
+```

--- a/internal/commands/waypoint/tfcconfig/tfc_config_read.go
+++ b/internal/commands/waypoint/tfcconfig/tfc_config_read.go
@@ -5,6 +5,7 @@ package tfcconfig
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
@@ -68,7 +69,9 @@ func readRun(opts *TFCConfigReadOpts) error {
 		return errors.Wrapf(err, "%s failed to get TFC Config", opts.IO.ColorScheme().FailureIcon())
 	}
 	if resp.Payload.TfcConfig == nil {
-		return errors.New("No TFC Config found for this project")
+		fmt.Fprintf(opts.IO.Out(), "%s No TFC Config found for this project\n",
+			opts.IO.ColorScheme().FailureIcon())
+		return nil
 	}
 	d := newDisplayer(format.Pretty, resp.Payload.TfcConfig)
 	return opts.Output.Display(d)

--- a/internal/commands/waypoint/tfcconfig/tfc_config_read.go
+++ b/internal/commands/waypoint/tfcconfig/tfc_config_read.go
@@ -5,6 +5,7 @@ package tfcconfig
 
 import (
 	"context"
+
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"

--- a/internal/commands/waypoint/tfcconfig/tfc_config_read.go
+++ b/internal/commands/waypoint/tfcconfig/tfc_config_read.go
@@ -5,7 +5,6 @@ package tfcconfig
 
 import (
 	"context"
-
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
@@ -66,6 +65,9 @@ func readRun(opts *TFCConfigReadOpts) error {
 	)
 	if err != nil {
 		return errors.Wrapf(err, "%s failed to get TFC Config", opts.IO.ColorScheme().FailureIcon())
+	}
+	if resp.Payload.TfcConfig == nil {
+		return errors.New("No TFC Config found for this project")
 	}
 	d := newDisplayer(format.Pretty, resp.Payload.TfcConfig)
 	return opts.Output.Display(d)


### PR DESCRIPTION
### Changes proposed in this PR:

This is a small bugfix to return a better error message when a user attempts to read a Waypoint TFC Config and one has not been set.

### How I've tested this PR:

This has been manually tested and the acceptance tests have been run.

### How I expect reviewers to test this PR:

Run `make go/test` to run the acceptance tests

To manually test, build the binary and connect to your HCP org. If that org already has a TFC Config set for waypoint, first run:

```
hcp waypoint tfc-config delete
```

To test the change, run:

```
hcp waypoint tfc-config read
```

### Output of affected commands:
--> 
```
% hcp waypoint tfc-config read  
X No TFC Config found for this project

```