### PR TITLE
[IAM] Sort IAM Roles by ID

### DIFF
--- a/.changelog/67.txt
+++ b/.changelog/67.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Adds opinionated sorting to the listing of iam roles
+```

--- a/internal/commands/iam/roles/list_test.go
+++ b/internal/commands/iam/roles/list_test.go
@@ -271,6 +271,7 @@ func Test_sortRoles(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := sortRolesByID(tt.inputRoles); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Sorting failed.\nExpected:\n")
 				for _, role := range tt.want {

--- a/internal/commands/iam/roles/list_test.go
+++ b/internal/commands/iam/roles/list_test.go
@@ -223,6 +223,8 @@ func TestListRun(t *testing.T) {
 }
 
 func Test_sortRoles(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		inputRoles []*models.HashicorpCloudResourcemanagerRole


### PR DESCRIPTION
### Changes proposed in this PR:
Today roles are displayed in the order they are returned. This PR sorts the roles alphabetically grouped by role prefix. Platform roles (e.g. `roles/admin`) appear before service roles (e.g. `roles/iam.admin`).

### How I've tested this PR:
Unit test added.
Listing roles in all formats (`table`, `pretty`, & `json`) work as expected.

Sample output:
<img width="579" alt="preview" src="https://github.com/hashicorp/hcp/assets/94396874/53338aca-0da6-4671-922a-0ec7a59d98f1">

Previous output:
<img width="540" alt="previous" src="https://github.com/hashicorp/hcp/assets/94396874/e72a3cd5-4757-42b1-a35b-8a6459a519e5">

### How I expect reviewers to test this PR:
Give it a whirl.

`hcp iam roles list`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
