### PR TITLE
Add vault-secrets component property

### DIFF
--- a/internal/pkg/profile/profile.go
+++ b/internal/pkg/profile/profile.go
@@ -103,7 +103,7 @@ func (p *Profile) Predict(args complete.Args) []string {
 
 	// predicting the property
 	if len(args.All) == 1 {
-		return []string{"organization_id", "project_id", "core/"}
+		return []string{"organization_id", "project_id", "core/", "vault-secrets"}
 	}
 
 	return nil

--- a/internal/pkg/profile/profile.go
+++ b/internal/pkg/profile/profile.go
@@ -91,7 +91,8 @@ type Profile struct {
 // Predict predicts the HCL key names and basic settable values
 func (p *Profile) Predict(args complete.Args) []string {
 	sub := map[string]complete.Predictor{
-		"core": p.Core,
+		"core":          p.Core,
+		"vault-secrets": p.VaultSecrets,
 	}
 
 	if len(args.All) >= 1 {
@@ -103,7 +104,7 @@ func (p *Profile) Predict(args complete.Args) []string {
 
 	// predicting the property
 	if len(args.All) == 1 {
-		return []string{"organization_id", "project_id", "core/", "vault-secrets"}
+		return []string{"organization_id", "project_id", "core/", "vault-secrets/"}
 	}
 
 	return nil

--- a/internal/pkg/profile/profile_test.go
+++ b/internal/pkg/profile/profile_test.go
@@ -97,14 +97,14 @@ func TestProfile_Predict(t *testing.T) {
 			Args: complete.Args{
 				All: []string{""},
 			},
-			Expected: []string{"organization_id", "project_id", "core/"},
+			Expected: []string{"organization_id", "project_id", "core/", "vault-secrets"},
 		},
 		{
 			Name: "specific field",
 			Args: complete.Args{
 				All: []string{"org"},
 			},
-			Expected: []string{"organization_id", "project_id", "core/"},
+			Expected: []string{"organization_id", "project_id", "core/", "vault-secrets"},
 		},
 		{
 			Name: "core",

--- a/internal/pkg/profile/profile_test.go
+++ b/internal/pkg/profile/profile_test.go
@@ -97,14 +97,14 @@ func TestProfile_Predict(t *testing.T) {
 			Args: complete.Args{
 				All: []string{""},
 			},
-			Expected: []string{"organization_id", "project_id", "core/", "vault-secrets"},
+			Expected: []string{"organization_id", "project_id", "core/", "vault-secrets/"},
 		},
 		{
 			Name: "specific field",
 			Args: complete.Args{
 				All: []string{"org"},
 			},
-			Expected: []string{"organization_id", "project_id", "core/", "vault-secrets"},
+			Expected: []string{"organization_id", "project_id", "core/", "vault-secrets/"},
 		},
 		{
 			Name: "core",
@@ -112,6 +112,20 @@ func TestProfile_Predict(t *testing.T) {
 				All: []string{"core/"},
 			},
 			Expected: []string{"core/no_color", "core/output_format", "core/verbosity"},
+		},
+		{
+			Name: "core",
+			Args: complete.Args{
+				All: []string{"core/"},
+			},
+			Expected: []string{"core/no_color", "core/output_format", "core/verbosity"},
+		},
+		{
+			Name: "vault-secrets",
+			Args: complete.Args{
+				All: []string{"vault-secrets/"},
+			},
+			Expected: []string{"vault-secrets/app_name"},
 		},
 	}
 

--- a/internal/pkg/profile/vault_secrets.go
+++ b/internal/pkg/profile/vault_secrets.go
@@ -5,8 +5,10 @@ package profile
 
 import (
 	"errors"
+	"slices"
 
 	"github.com/posener/complete"
+	"golang.org/x/exp/maps"
 )
 
 // VaultSecrets is a named set of configuration for the HCP CLI. It captures
@@ -18,6 +20,23 @@ type VaultSecretsConf struct {
 
 // Predict predicts the HCL key names and basic settable values
 func (vsc *VaultSecretsConf) Predict(args complete.Args) []string {
+	properties := map[string][]string{
+		"vault-secrets/app_name": {""},
+	}
+	// If the property has been specified, return possible values.
+	if len(args.All) >= 1 {
+		prediction, ok := properties[args.All[0]]
+		if ok {
+			return prediction
+		}
+	}
+
+	// Predicting the property
+	if len(args.All) == 1 {
+		keys := maps.Keys(properties)
+		slices.Sort(keys)
+		return keys
+	}
 	return nil
 }
 


### PR DESCRIPTION
### Changes proposed in this PR:

This change adds the missing `vault-secrets` profile component. 

### How I've tested this PR:
- [x] tested locally 
 
### How I expect reviewers to test this PR:
Auto complete should show vault-secrets and/or vault-secrets/app_name when tab is hit.
```
$ ./bin/hcp profile set 
```

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
