### PR TITLE
VAULT-26821 - Add hcp vault-secrets secrets delete comand 

### DIFF
--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -28,10 +28,10 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 	}
 
 	cmd := &cmd.Command{
-		Name:      "create",
+		Name:      "delete",
 		ShortHelp: "Delete a static secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets create" }} command deletes a static secret under an Vault Secrets App.`),
+		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets delete" }} command deletes a static secret under an Vault Secrets App.`),
 		Examples: []cmd.Example{
 			{
 				Preamble: `Delete a secret from Vault Secrets application on active profile:`,
@@ -87,9 +87,11 @@ func deleteRun(opts *DeleteOpts) error {
 	req.AppName = opts.AppName
 	req.SecretName = opts.SecretName
 
-	resp, err := opts.Client.DeleteAppSecret(req, nil)
+	_, err := opts.Client.DeleteAppSecret(req, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create secret with name: %q - %w", opts.SecretName, err)
+		return fmt.Errorf("failed to delete secret with name: %q - %w", opts.SecretName, err)
 	}
-	return opts.Output.Display(newDisplayer(true, resp.Payload))
+
+	fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted secret with name: %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
+	return nil
 }

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -1,0 +1,95 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
+	opts := &DeleteOpts{
+		Ctx:           ctx.ShutdownCtx,
+		Profile:       ctx.Profile,
+		IO:            ctx.IO,
+		Output:        ctx.Output,
+		PreviewClient: preview_secret_service.New(ctx.HCP, nil),
+		Client:        secret_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "create",
+		ShortHelp: "Delete a static secret.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets create" }} command deletes a static secret under an Vault Secrets App.`),
+		Examples: []cmd.Example{
+			{
+				Preamble: `Delete a secret from Vault Secrets application on active profile:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp vault-secrets secrets delete secret_1
+				`),
+			},
+			{
+				Preamble: `Delete secret from different Vault Secrets application, not active profile:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithNoWrap()).Must(`
+				$ hcp vault-secrets secrets create secret_2 --app-name test-app
+				`),
+			},
+		},
+		Args: cmd.PositionalArguments{
+			Args: []cmd.PositionalArgument{
+				{
+					Name:          "SECRET_NAME",
+					Documentation: "The name of the secret to create.",
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			opts.AppName = appName
+			opts.SecretName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return deleteRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+type DeleteOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	IO      iostreams.IOStreams
+	Output  *format.Outputter
+
+	AppName       string
+	SecretName    string
+	PreviewClient preview_secret_service.ClientService
+	Client        secret_service.ClientService
+}
+
+func deleteRun(opts *DeleteOpts) error {
+	req := secret_service.NewDeleteAppSecretParamsWithContext(opts.Ctx)
+	req.LocationOrganizationID = opts.Profile.OrganizationID
+	req.LocationProjectID = opts.Profile.ProjectID
+	req.AppName = opts.AppName
+	req.SecretName = opts.SecretName
+
+	resp, err := opts.Client.DeleteAppSecret(req, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create secret with name: %q - %w", opts.SecretName, err)
+	}
+	return opts.Output.Display(newDisplayer(true, resp.Payload))
+}

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -92,6 +92,6 @@ func deleteRun(opts *DeleteOpts) error {
 		return fmt.Errorf("failed to delete secret with name: %q - %w", opts.SecretName, err)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted secret with name: %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
+	fmt.Fprintf(opts.IO.Out(), "%s Successfully deleted secret with name: %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
 	return nil
 }

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -92,6 +92,6 @@ func deleteRun(opts *DeleteOpts) error {
 		return fmt.Errorf("failed to delete secret with name: %q - %w", opts.SecretName, err)
 	}
 
-	fmt.Fprintf(opts.IO.Out(), "%s Successfully deleted secret with name: %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
+	fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted secret with name: %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
 	return nil
 }

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -40,9 +40,9 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 				`),
 			},
 			{
-				Preamble: `Delete secret from different Vault Secrets application, not active profile:`,
+				Preamble: `Delete a secret from specified Vault Secrets application:`,
 				Command: heredoc.New(ctx.IO, heredoc.WithNoWrap()).Must(`
-				$ hcp vault-secrets secrets create secret_2 --app-name test-app
+				$ hcp vault-secrets secrets delete secret_2 --app-name test-app
 				`),
 			},
 		},

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -31,7 +31,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 		Name:      "delete",
 		ShortHelp: "Delete a static secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets delete" }} command deletes a static secret under an Vault Secrets App.`),
+		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets delete" }} command deletes a static secret under an Vault Secrets application.`),
 		Examples: []cmd.Example{
 			{
 				Preamble: `Delete a secret from Vault Secrets application on active profile:`,

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -89,9 +89,9 @@ func deleteRun(opts *DeleteOpts) error {
 
 	_, err := opts.Client.DeleteAppSecret(req, nil)
 	if err != nil {
-		return fmt.Errorf("failed to delete secret with name: %q - %w", opts.SecretName, err)
+		return fmt.Errorf("failed to delete secret with name %q: - %w", opts.SecretName, err)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted secret with name: %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
+	fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted secret with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
 	return nil
 }

--- a/internal/commands/vaultsecrets/secrets/delete_test.go
+++ b/internal/commands/vaultsecrets/secrets/delete_test.go
@@ -161,7 +161,7 @@ func TestDeleteRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name: %q\n", opts.SecretName))
+			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name: %q", opts.SecretName))
 		})
 	}
 }

--- a/internal/commands/vaultsecrets/secrets/delete_test.go
+++ b/internal/commands/vaultsecrets/secrets/delete_test.go
@@ -129,7 +129,7 @@ func TestDeleteRun(t *testing.T) {
 			r := require.New(t)
 
 			io := iostreams.Test()
-			io.OutputTTY = true
+			io.ErrorTTY = true
 			vs := mock_secret_service.NewMockClientService(t)
 			opts := &DeleteOpts{
 				Ctx:        context.Background(),
@@ -161,7 +161,7 @@ func TestDeleteRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Equal(io.Output.String(), fmt.Sprintf("✓ Successfully deleted secret with name: %q\n", opts.SecretName))
+			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name: %q\n", opts.SecretName))
 		})
 	}
 }

--- a/internal/commands/vaultsecrets/secrets/delete_test.go
+++ b/internal/commands/vaultsecrets/secrets/delete_test.go
@@ -117,7 +117,7 @@ func TestDeleteRun(t *testing.T) {
 			ErrMsg:  "[DELETE /secrets/2023-06-13/organizations/{location.organization_id}/projects/{location.project_id}/apps/{app_name}/secrets/{secret_name}][404]DeleteAppSecret default  &{Code:5 Details:[] Message:secret not found}",
 		},
 		{
-			Name:    "Success: Created secret",
+			Name:    "Success: Delete secret",
 			RespErr: false,
 		},
 	}
@@ -161,7 +161,7 @@ func TestDeleteRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name: %q", opts.SecretName))
+			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name: %q\n", opts.SecretName))
 		})
 	}
 }

--- a/internal/commands/vaultsecrets/secrets/delete_test.go
+++ b/internal/commands/vaultsecrets/secrets/delete_test.go
@@ -129,7 +129,7 @@ func TestDeleteRun(t *testing.T) {
 			r := require.New(t)
 
 			io := iostreams.Test()
-			io.ErrorTTY = true
+			io.OutputTTY = true
 			vs := mock_secret_service.NewMockClientService(t)
 			opts := &DeleteOpts{
 				Ctx:        context.Background(),
@@ -161,7 +161,7 @@ func TestDeleteRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name: %q\n", opts.SecretName))
+			r.Equal(io.Output.String(), fmt.Sprintf("✓ Successfully deleted secret with name: %q\n", opts.SecretName))
 		})
 	}
 }

--- a/internal/commands/vaultsecrets/secrets/delete_test.go
+++ b/internal/commands/vaultsecrets/secrets/delete_test.go
@@ -1,0 +1,4 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package secrets

--- a/internal/commands/vaultsecrets/secrets/delete_test.go
+++ b/internal/commands/vaultsecrets/secrets/delete_test.go
@@ -112,9 +112,9 @@ func TestDeleteRun(t *testing.T) {
 		ErrMsg  string
 	}{
 		{
-			Name:    "Failed: Secret not there",
+			Name:    "Failed: Secret not found",
 			RespErr: true,
-			ErrMsg:  "failed to delete secret with name: \"test_secret\"",
+			ErrMsg:  "[DELETE /secrets/2023-06-13/organizations/{location.organization_id}/projects/{location.project_id}/apps/{app_name}/secrets/{secret_name}][404]DeleteAppSecret default  &{Code:5 Details:[] Message:secret not found}",
 		},
 		{
 			Name:    "Success: Created secret",

--- a/internal/commands/vaultsecrets/secrets/delete_test.go
+++ b/internal/commands/vaultsecrets/secrets/delete_test.go
@@ -2,3 +2,166 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdDelete(t *testing.T) {
+	t.Parallel()
+
+	testProfile := func(t *testing.T) *profile.Profile {
+		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+		tp.VaultSecrets = &profile.VaultSecretsConf{
+			AppName: "test-app-name",
+		}
+		return tp
+	}
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *DeleteOpts
+	}{
+		{
+			Name:    "Failed: No secret name arg specified",
+			Profile: testProfile,
+			Args:    []string{},
+			Error:   "ERROR: accepts 1 arg(s), received 0",
+		},
+		{
+			Name:    "Good: Secret name arg specified",
+			Profile: testProfile,
+			Args:    []string{"test"},
+			Expect: &DeleteOpts{
+				AppName:    testProfile(t).VaultSecrets.AppName,
+				SecretName: "test",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts *DeleteOpts
+			createCmd := NewCmdDelete(ctx, func(o *DeleteOpts) error {
+				gotOpts = o
+				gotOpts.AppName = c.Profile(t).VaultSecrets.AppName
+				return nil
+			})
+			createCmd.SetIO(io)
+
+			code := createCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+			r.Equal(c.Expect.AppName, gotOpts.AppName)
+			r.Equal(c.Expect.SecretName, gotOpts.SecretName)
+		})
+	}
+}
+
+func TestDeleteRun(t *testing.T) {
+	t.Parallel()
+
+	testProfile := func(t *testing.T) *profile.Profile {
+		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+		tp.VaultSecrets = &profile.VaultSecretsConf{
+			AppName: "test-app-name",
+		}
+		return tp
+	}
+
+	cases := []struct {
+		Name    string
+		RespErr bool
+		ErrMsg  string
+	}{
+		{
+			Name:    "Failed: Secret not there",
+			RespErr: true,
+			ErrMsg:  "failed to delete secret with name: \"test_secret\"",
+		},
+		{
+			Name:    "Success: Created secret",
+			RespErr: false,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			io.ErrorTTY = true
+			vs := mock_secret_service.NewMockClientService(t)
+			opts := &DeleteOpts{
+				Ctx:        context.Background(),
+				IO:         io,
+				Profile:    testProfile(t),
+				Output:     format.New(io),
+				Client:     vs,
+				AppName:    testProfile(t).VaultSecrets.AppName,
+				SecretName: "test_secret",
+			}
+
+			if c.RespErr {
+				vs.EXPECT().DeleteAppSecret(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
+			} else {
+				vs.EXPECT().DeleteAppSecret(&secret_service.DeleteAppSecretParams{
+					LocationOrganizationID: testProfile(t).OrganizationID,
+					LocationProjectID:      testProfile(t).ProjectID,
+					AppName:                testProfile(t).VaultSecrets.AppName,
+					SecretName:             opts.SecretName,
+					Context:                opts.Ctx,
+				}, mock.Anything).Return(&secret_service.DeleteAppSecretOK{}, nil).Once()
+			}
+
+			// Run the command
+			err := deleteRun(opts)
+			if c.ErrMsg != "" {
+				r.Contains(err.Error(), c.ErrMsg)
+				return
+			}
+
+			r.NoError(err)
+			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name: %q\n", opts.SecretName))
+		})
+	}
+}

--- a/internal/commands/vaultsecrets/secrets/delete_test.go
+++ b/internal/commands/vaultsecrets/secrets/delete_test.go
@@ -161,7 +161,7 @@ func TestDeleteRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name: %q\n", opts.SecretName))
+			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name %q\n", opts.SecretName))
 		})
 	}
 }

--- a/internal/commands/vaultsecrets/secrets/secrets.go
+++ b/internal/commands/vaultsecrets/secrets/secrets.go
@@ -44,5 +44,6 @@ func NewCmdSecrets(ctx *cmd.Context) *cmd.Command {
 	}
 
 	cmd.AddChild(NewCmdCreate(ctx, nil))
+	cmd.AddChild(NewCmdDelete(ctx, nil))
 	return cmd
 }


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds the `hcp vault-secrets secrets delete` command to the `hcp` CLI.

### How I've tested this PR:
- [x] locally ran the binary to create a HVS secrets
```
> make go/build && ./bin/hcp vs secrets delete -h          
USAGE
  hcp vault-secrets secrets delete SECRET_NAME [Optional Flags]

DESCRIPTION
  The hcp vault-secrets secrets delete command deletes a static secret under an
  Vault Secrets application.

EXAMPLES
  Delete a secret from Vault Secrets application on active profile:
  
  $ hcp vault-secrets secrets delete secret_1
  
  Delete a secret from specified Vault Secrets application:
  
  $ hcp vault-secrets secrets delete secret_2 --app-name test-app

POSITIONAL ARGUMENTS
  SECRET_NAME
    The name of the secret to create.

INHERITED FLAGS
  -a, --app-name=NAME
    The name of the Vault Secrets application. If not specified, the value from the
    active profile will be used.

GLOBAL FLAGS
  --debug, --format=FORMAT, --profile=NAME, --project=ID, --quiet
  
  For more global flag details, run $ hcp --help
```
```
> > make go/build && ./bin/hcp vs secrets delete sec_001     
✓ Successfully deleted secret with name "sec_001"

>  make go/build && ./bin/hcp vs secrets delete test                      
ERROR: failed to delete secret with name "test": - [DELETE
/secrets/2023-06-13/organizations/{location.organization_id}/projects/{location.project_id}/apps/{app_name}/secrets/{secret_name}][404]
DeleteAppSecret default  &{Code:5 Details:[] Message:secret not found}

 > > make go/build && ./bin/hcp vs secrets delete test --quiet
ERROR: failed to delete secret with name "test": - [DELETE
/secrets/2023-06-13/organizations/{location.organization_id}/projects/{location.project_id}/apps/{app_name}/secrets/{secret_name}][404]
DeleteAppSecret default  &{Code:5 Details:[] Message:secret not found}
```
### How I expect reviewers to test this PR:
```
$ make go/build 
$ ./bin/hcp auth login 
$ ./bin/hcp profile init --vault-secrets
$ ./bin/hcp vault-secrets secrets delete test
```
<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
