### PR TITLE
VAULT-26816 -  implement vault-secrets apps delete

### DIFF
--- a/internal/commands/vaultsecrets/apps/apps.go
+++ b/internal/commands/vaultsecrets/apps/apps.go
@@ -19,5 +19,6 @@ func NewCmdApps(ctx *cmd.Context) *cmd.Command {
 	}
 
 	cmd.AddChild(NewCmdCreate(ctx, nil))
+	cmd.AddChild(NewCmdDelete(ctx, nil))
 	return cmd
 }

--- a/internal/commands/vaultsecrets/apps/apps.go
+++ b/internal/commands/vaultsecrets/apps/apps.go
@@ -16,6 +16,9 @@ func NewCmdApps(ctx *cmd.Context) *cmd.Command {
 		The {{ template "mdCodeOrBold" "hcp vault-secrets apps" }} command group lets you
 		manage Vault Secrets applications.
 		`),
+		PersistentPreRun: func(c *cmd.Command, args []string) error {
+			return cmd.RequireOrgAndProject(ctx)
+		},
 	}
 
 	cmd.AddChild(NewCmdCreate(ctx, nil))

--- a/internal/commands/vaultsecrets/apps/create.go
+++ b/internal/commands/vaultsecrets/apps/create.go
@@ -84,9 +84,6 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 			}
 			return createRun(opts)
 		},
-		PersistentPreRun: func(c *cmd.Command, args []string) error {
-			return cmd.RequireOrgAndProject(ctx)
-		},
 	}
 
 	return cmd

--- a/internal/commands/vaultsecrets/apps/create_test.go
+++ b/internal/commands/vaultsecrets/apps/create_test.go
@@ -51,12 +51,6 @@ func TestNewCmdCreate(t *testing.T) {
 			},
 		},
 		{
-			Name:    "No Org or Project ID",
-			Profile: profile.TestProfile,
-			Args:    []string{},
-			Error:   "Organization ID and Project ID must be configured before running the command.",
-		},
-		{
 			Name: "No args",
 			Profile: func(t *testing.T) *profile.Profile {
 				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
@@ -98,6 +92,7 @@ func TestNewCmdCreate(t *testing.T) {
 
 			code := createCmd.Run(c.Args)
 			if c.Error != "" {
+				fmt.Println("io.Error.String()", io.Error.String())
 				r.NotZero(code)
 				r.Contains(io.Error.String(), c.Error)
 				return

--- a/internal/commands/vaultsecrets/apps/create_test.go
+++ b/internal/commands/vaultsecrets/apps/create_test.go
@@ -92,7 +92,6 @@ func TestNewCmdCreate(t *testing.T) {
 
 			code := createCmd.Run(c.Args)
 			if c.Error != "" {
-				fmt.Println("io.Error.String()", io.Error.String())
 				r.NotZero(code)
 				r.Contains(io.Error.String(), c.Error)
 				return

--- a/internal/commands/vaultsecrets/apps/delete.go
+++ b/internal/commands/vaultsecrets/apps/delete.go
@@ -64,9 +64,6 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 			}
 			return deleteRun(opts)
 		},
-		PersistentPreRun: func(c *cmd.Command, args []string) error {
-			return cmd.RequireOrgAndProject(ctx)
-		},
 	}
 
 	return cmd

--- a/internal/commands/vaultsecrets/apps/delete.go
+++ b/internal/commands/vaultsecrets/apps/delete.go
@@ -1,0 +1,89 @@
+package apps
+
+import (
+	"context"
+	"fmt"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+type DeleteOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	Output  *format.Outputter
+	IO      iostreams.IOStreams
+
+	AppName       string
+	Client        secret_service.ClientService
+	PreviewClient preview_secret_service.ClientService
+}
+
+func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
+	opts := &DeleteOpts{
+		Ctx:           ctx.ShutdownCtx,
+		Profile:       ctx.Profile,
+		Output:        ctx.Output,
+		IO:            ctx.IO,
+		Client:        secret_service.New(ctx.HCP, nil),
+		PreviewClient: preview_secret_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "delete",
+		ShortHelp: "Delete a Vault Secrets application.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets apps delete" }} command deletes a Vault Secrets application.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: `Delete an application:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp vault-secrets apps delete company-card
+				`),
+			},
+		},
+		Args: cmd.PositionalArguments{
+			Args: []cmd.PositionalArgument{
+				{
+					Name:          "APP_NAME",
+					Documentation: "The name of the app to delete.",
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			opts.AppName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return deleteRun(opts)
+		},
+		PersistentPreRun: func(c *cmd.Command, args []string) error {
+			return cmd.RequireOrgAndProject(ctx)
+		},
+	}
+
+	return cmd
+}
+
+func deleteRun(opts *DeleteOpts) error {
+	_, err := opts.Client.DeleteApp(&secret_service.DeleteAppParams{
+		Context:                opts.Ctx,
+		LocationOrganizationID: opts.Profile.OrganizationID,
+		LocationProjectID:      opts.Profile.ProjectID,
+		Name:                   opts.AppName,
+	}, nil)
+
+	if err != nil {
+		return fmt.Errorf("failed to delete application: %w", err)
+	}
+
+	fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted application with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.AppName)
+	return nil
+}

--- a/internal/commands/vaultsecrets/apps/delete_test.go
+++ b/internal/commands/vaultsecrets/apps/delete_test.go
@@ -39,12 +39,6 @@ func TestNewCmdDelete(t *testing.T) {
 			},
 		},
 		{
-			Name:    "No Org or Project ID",
-			Profile: profile.TestProfile,
-			Args:    []string{},
-			Error:   "Organization ID and Project ID must be configured before running the command.",
-		},
-		{
 			Name: "No args",
 			Profile: func(t *testing.T) *profile.Profile {
 				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")

--- a/internal/commands/vaultsecrets/apps/delete_test.go
+++ b/internal/commands/vaultsecrets/apps/delete_test.go
@@ -1,0 +1,159 @@
+package apps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func TestNewCmdDelete(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *DeleteOpts
+	}{
+		{
+			Name: "Good",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args: []string{"company-card"},
+			Expect: &DeleteOpts{
+				AppName: "company-card",
+			},
+		},
+		{
+			Name:    "No Org or Project ID",
+			Profile: profile.TestProfile,
+			Args:    []string{},
+			Error:   "Organization ID and Project ID must be configured before running the command.",
+		},
+		{
+			Name: "No args",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args:  []string{},
+			Error: "accepts 1 arg(s), received 0",
+		},
+		{
+			Name: "Too many args",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args:  []string{"company-card", "additional-arg"},
+			Error: "ERROR: accepts 1 arg(s), received 2",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+
+			r := require.New(t)
+			io := iostreams.Test()
+
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				ShutdownCtx: context.Background(),
+				HCP:         &client.Runtime{},
+				Output:      format.New(io),
+			}
+
+			var deleteOpts *DeleteOpts
+			deleteCmd := NewCmdDelete(ctx, func(o *DeleteOpts) error {
+				deleteOpts = o
+				return nil
+			})
+			deleteCmd.SetIO(io)
+
+			code := deleteCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(deleteOpts)
+			r.Equal(c.Expect.AppName, deleteOpts.AppName)
+		})
+	}
+}
+
+func TestDeleteRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		ErrMsg  string
+		AppName string
+	}{
+		{
+			Name:   "Failed: App not found",
+			ErrMsg: "[DELETE /secrets/2023-06-13/organizations/{location.organization_id}/projects/{location.project_id}/apps/{name}][403] DeleteApp",
+		},
+		{
+			Name:    "Success: Delete app",
+			AppName: "company-card",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			vs := mock_secret_service.NewMockClientService(t)
+
+			opts := &DeleteOpts{
+				Ctx:     context.Background(),
+				Profile: profile.TestProfile(t).SetOrgID("123").SetProjectID("abc"),
+				IO:      io,
+				Client:  vs,
+				Output:  format.New(io),
+				AppName: c.AppName,
+			}
+
+			if c.ErrMsg != "" {
+				vs.EXPECT().DeleteApp(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
+			} else {
+				vs.EXPECT().DeleteApp(&secret_service.DeleteAppParams{
+					LocationOrganizationID: "123",
+					LocationProjectID:      "abc",
+					Name:                   opts.AppName,
+					Context:                opts.Ctx,
+				}, nil).Return(&secret_service.DeleteAppOK{}, nil).Once()
+			}
+
+			// Run the command
+			err := deleteRun(opts)
+			if c.ErrMsg != "" {
+				r.Contains(err.Error(), c.ErrMsg)
+				return
+			}
+
+			r.NoError(err)
+			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted application with name %q\n", opts.AppName))
+		})
+	}
+}


### PR DESCRIPTION
### Changes proposed in this PR:

This PR adds the delete command for hvs apps for ticket https://hashicorp.atlassian.net/browse/VAULT-26816

### How I've tested this PR:
Ran `make go/build` to test local changes:
<img width="969" alt="Screenshot 2024-05-14 at 3 06 52 PM" src="https://github.com/hashicorp/hcp/assets/19840012/c732a441-61a9-4a32-938e-565d2ed4a9f8">

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run make go/build
3. Delete an app `./bin/hcp vault-secrets apps delete {YOUR_APP_NAME}`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
