### PR TITLE
Adds help text after vault-secret app and secret creates

### DIFF
--- a/internal/commands/vaultsecrets/apps/create.go
+++ b/internal/commands/vaultsecrets/apps/create.go
@@ -104,7 +104,7 @@ func createRun(opts *CreateOpts) error {
 	if opts.Output.GetFormat() == format.Unset {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully created application with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.AppName)
 
-		command := fmt.Sprintf(`$ hcp vault-secrets secrets create <secret name> --app %s --data-file <path to secret>`, opts.AppName)
+		command := "$ hcp vault-secrets secrets create <secret name> --data-file <path to secret>"
 
 		fmt.Fprintln(opts.IO.Err())
 		fmt.Fprintf(opts.IO.Err(), `To create a secret in the app, run:

--- a/internal/commands/vaultsecrets/apps/create.go
+++ b/internal/commands/vaultsecrets/apps/create.go
@@ -104,7 +104,7 @@ func createRun(opts *CreateOpts) error {
 	if opts.Output.GetFormat() == format.Unset {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully created application with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.AppName)
 
-		command := "$ hcp vault-secrets secrets create <secret name> --data-file <path to secret>"
+		command := fmt.Sprintf(`$ hcp vault-secrets secrets create <secret name> --app %s --data-file <path to secret>`, opts.AppName)
 
 		fmt.Fprintln(opts.IO.Err())
 		fmt.Fprintf(opts.IO.Err(), `To create a secret in the app, run:

--- a/internal/commands/vaultsecrets/apps/create.go
+++ b/internal/commands/vaultsecrets/apps/create.go
@@ -44,9 +44,6 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 		ShortHelp: "Create a new Vault Secrets application.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets apps create" }} command creates a new Vault Secrets application.
-
-		Once an application is created, secrets lifecycle can be managed using the
-		{{ template "mdCodeOrBold" "hcp vault-secrets secrets" }} command group.
 		`),
 		Examples: []cmd.Example{
 			{
@@ -106,6 +103,13 @@ func createRun(opts *CreateOpts) error {
 
 	if opts.Output.GetFormat() == format.Unset {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully created application with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.AppName)
+
+		command := fmt.Sprintf(`$ hcp vault-secrets secrets create <secret name> --app %s --data-file <path to secret>`, opts.AppName)
+
+		fmt.Fprintln(opts.IO.Err())
+		fmt.Fprintf(opts.IO.Err(), `To create a secret in the app, run:
+  %s`, opts.IO.ColorScheme().String(command).Bold())
+		fmt.Fprintln(opts.IO.Err())
 		return nil
 	}
 

--- a/internal/commands/vaultsecrets/apps/create_test.go
+++ b/internal/commands/vaultsecrets/apps/create_test.go
@@ -173,7 +173,7 @@ func TestCreateRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully created application with name %q\n", opts.AppName))
+			r.Contains(io.Error.String(), fmt.Sprintf("✓ Successfully created application with name %q\n", opts.AppName))
 		})
 	}
 }

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -126,7 +126,7 @@ func createRun(opts *CreateOpts) error {
 	if opts.Output.GetFormat() == format.Unset {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully created secret with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
 
-		command := fmt.Sprintf(`$ hcp vault-secrets secrets read %s --app %s`, opts.SecretName, req.AppName)
+		command := fmt.Sprintf(`$ hcp vault-secrets secrets read %s`, opts.SecretName)
 
 		fmt.Fprintln(opts.IO.Err())
 		fmt.Fprintf(opts.IO.Err(), `To read your secret, run:

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -126,7 +126,7 @@ func createRun(opts *CreateOpts) error {
 	if opts.Output.GetFormat() == format.Unset {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully created secret with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
 
-		command := fmt.Sprintf(`$ hcp vault-secrets secrets read %s`, opts.SecretName)
+		command := fmt.Sprintf(`$ hcp vault-secrets secrets read %s --app %s`, opts.SecretName, req.AppName)
 
 		fmt.Fprintln(opts.IO.Err())
 		fmt.Fprintf(opts.IO.Err(), `To read your secret, run:

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -36,9 +36,6 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 		ShortHelp: "Create a new static secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets create" }} command creates a new static secret under an Vault Secrets application.
-
-		Once the secret is created, it can be read using
-		{{ template "mdCodeOrBold" "hcp vault-secrets secrets read" }} subcommand.
 		`),
 		Examples: []cmd.Example{
 			{
@@ -128,6 +125,13 @@ func createRun(opts *CreateOpts) error {
 
 	if opts.Output.GetFormat() == format.Unset {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully created secret with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
+
+		command := fmt.Sprintf(`$ hcp vault-secrets secrets read %s --app %s`, opts.SecretName, req.AppName)
+
+		fmt.Fprintln(opts.IO.Err())
+		fmt.Fprintf(opts.IO.Err(), `To read your secret, run:
+  %s`, opts.IO.ColorScheme().String(command).Bold())
+		fmt.Fprintln(opts.IO.Err())
 		return nil
 	}
 

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -221,7 +221,7 @@ func TestCreateRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully created secret with name %q\n", opts.SecretName))
+			r.Contains(io.Error.String(), fmt.Sprintf("✓ Successfully created secret with name %q\n", opts.SecretName))
 		})
 	}
 }


### PR DESCRIPTION
### Changes proposed in this PR:

### How I've tested this PR:
Ran `make go/build` to test local changes

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run make go/build
3. Create an app and view the help text
4. Create a secret and view the help text

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
<img width="1226" alt="Screenshot 2024-05-15 at 10 24 57 AM" src="https://github.com/hashicorp/hcp/assets/19840012/f47a3a3b-a9e6-49f8-957c-618bb5401eed">


Not going with the below route - see comments below and [this Slack thread]

(https://hashicorp.slack.com/archives/C0630MA5H8B/p1715803590808439?thread_ts=1715721973.724659&cid=C0630MA5H8B) for more details
~~Without app name in help text (Current). We're opting to omit the app name flag from the help command since (1) users will likely have it in their profile, and (2) it may mislead users to believe it is required in the command.~~
<img width="877" alt="Screenshot 2024-05-15 at 11 00 31 AM" src="https://github.com/hashicorp/hcp/assets/19840012/a8536d4b-18e7-4c56-9245-7a83488d4c1c">

### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
