### PR TITLE
Rename app_name flag/property to app for HVS

### DIFF
--- a/internal/commands/profile/property_docs.go
+++ b/internal/commands/profile/property_docs.go
@@ -52,7 +52,7 @@ func addCoreProperties(b *availablePropertiesBuilder) {
 }
 
 func addVaultSecretsProperties(b *availablePropertiesBuilder) {
-	b.AddProperty("vault-secrets", "app_name", `App name under HCP Vault Secrets to operate on by default.`)
+	b.AddProperty("vault-secrets", "app", `HCP Vault Secrets application name to operate on by default.`)
 }
 
 type availablePropertiesBuilder struct {

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -56,7 +56,7 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 			{
 				Preamble: `Create a new secret in the specified Vault Secrets application:`,
 				Command: heredoc.New(ctx.IO, heredoc.WithNoWrap()).Must(`
-				$ hcp vault-secrets secrets create secret_3 --app-name test-app --secret_file=/tmp/secrets2.txt
+				$ hcp vault-secrets secrets create secret_3 --app test-app --secret_file=/tmp/secrets2.txt
 				`),
 			},
 		},

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -29,7 +29,7 @@ func TestNewCmdCreate(t *testing.T) {
 	testProfile := func(t *testing.T) *profile.Profile {
 		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
 		tp.VaultSecrets = &profile.VaultSecretsConf{
-			AppName: "test-app-name",
+			AppName: "test-app",
 		}
 		return tp
 	}
@@ -77,7 +77,7 @@ func TestNewCmdCreate(t *testing.T) {
 			var gotOpts *CreateOpts
 			createCmd := NewCmdCreate(ctx, func(o *CreateOpts) error {
 				gotOpts = o
-				gotOpts.AppName = "test-app-name"
+				gotOpts.AppName = "test-app"
 				return nil
 			})
 			createCmd.SetIO(io)
@@ -103,7 +103,7 @@ func TestCreateRun(t *testing.T) {
 	testProfile := func(t *testing.T) *profile.Profile {
 		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
 		tp.VaultSecrets = &profile.VaultSecretsConf{
-			AppName: "test-app-name",
+			AppName: "test-app",
 		}
 		return tp
 	}

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -42,7 +42,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 			{
 				Preamble: `Delete a secret from specified Vault Secrets application:`,
 				Command: heredoc.New(ctx.IO, heredoc.WithNoWrap()).Must(`
-				$ hcp vault-secrets secrets delete secret_2 --app-name test-app
+				$ hcp vault-secrets secrets delete secret_2 --app test-app
 				`),
 			},
 		},

--- a/internal/commands/vaultsecrets/secrets/delete_test.go
+++ b/internal/commands/vaultsecrets/secrets/delete_test.go
@@ -27,7 +27,7 @@ func TestNewCmdDelete(t *testing.T) {
 	testProfile := func(t *testing.T) *profile.Profile {
 		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
 		tp.VaultSecrets = &profile.VaultSecretsConf{
-			AppName: "test-app-name",
+			AppName: "test-app",
 		}
 		return tp
 	}
@@ -101,7 +101,7 @@ func TestDeleteRun(t *testing.T) {
 	testProfile := func(t *testing.T) *profile.Profile {
 		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
 		tp.VaultSecrets = &profile.VaultSecretsConf{
-			AppName: "test-app-name",
+			AppName: "test-app",
 		}
 		return tp
 	}

--- a/internal/commands/vaultsecrets/secrets/secrets.go
+++ b/internal/commands/vaultsecrets/secrets/secrets.go
@@ -27,7 +27,7 @@ func NewCmdSecrets(ctx *cmd.Context) *cmd.Command {
 		Flags: cmd.Flags{
 			Persistent: []*cmd.Flag{
 				{
-					Name:         "app-name",
+					Name:         "app",
 					DisplayValue: "NAME",
 					Description:  "The name of the Vault Secrets application. If not specified, the value from the active profile will be used.",
 					Shorthand:    "a",

--- a/internal/pkg/profile/profile_test.go
+++ b/internal/pkg/profile/profile_test.go
@@ -21,7 +21,7 @@ func TestPropertyNames(t *testing.T) {
 	r.Contains(properties, "project_id")
 	r.Contains(properties, "core/no_color")
 	r.Contains(properties, "core/verbosity")
-	r.Contains(properties, "vault-secrets/app_name")
+	r.Contains(properties, "vault-secrets/app")
 }
 
 func TestProfile_Validate(t *testing.T) {
@@ -125,7 +125,7 @@ func TestProfile_Predict(t *testing.T) {
 			Args: complete.Args{
 				All: []string{"vault-secrets/"},
 			},
-			Expected: []string{"vault-secrets/app_name"},
+			Expected: []string{"vault-secrets/app"},
 		},
 	}
 

--- a/internal/pkg/profile/vault_secrets.go
+++ b/internal/pkg/profile/vault_secrets.go
@@ -15,13 +15,13 @@ import (
 // vault secrets related configuration values such as app name.
 type VaultSecretsConf struct {
 	// AppName stores the app name against which the requests will be made.
-	AppName string `hcl:"app_name"`
+	AppName string `hcl:"app"`
 }
 
 // Predict predicts the HCL key names and basic settable values
 func (vsc *VaultSecretsConf) Predict(args complete.Args) []string {
 	properties := map[string][]string{
-		"vault-secrets/app_name": {""},
+		"vault-secrets/app": {""},
 	}
 	// If the property has been specified, return possible values.
 	if len(args.All) >= 1 {
@@ -47,7 +47,7 @@ func (vsc *VaultSecretsConf) Validate() error {
 		return nil
 	}
 	if vsc.AppName == "" {
-		return errors.New("app_name must be set")
+		return errors.New("app must be set")
 	}
 	return nil
 }

--- a/internal/pkg/profile/vault_secrets_test.go
+++ b/internal/pkg/profile/vault_secrets_test.go
@@ -25,7 +25,7 @@ func TestVaultSecretsConf_Validate(t *testing.T) {
 		{
 			Name:    "empty",
 			Profile: &VaultSecretsConf{},
-			Error:   "name must be set",
+			Error:   "app must be set",
 		},
 	}
 

--- a/internal/pkg/vaultsecrets/validation.go
+++ b/internal/pkg/vaultsecrets/validation.go
@@ -25,13 +25,22 @@ func RequireVaultSecretsAppName(ctx *cmd.Context, appName string) error {
 	cs := ctx.IO.ColorScheme()
 	help := heredoc.Docf(`%v
 
-	Please run %s to interactively set the Vault Secrets application name, or run:
+	To set the Vault Secrets application name interactively, run:
+
+	%v
+
+	Alternatively, you can set the Vault Secrets applicaton name on the active pofile using the command:
+
+	%v
+
+	If you prefer specifying the Vault Secrets application name directly via the command line, use:
 
 	%v
 	`,
 		cs.String("Vault Secrets application name must be configured before running the command.").Color(cs.Orange()),
 		cs.String("$ hcp profile set vault-secrets/app <app_name>").Bold(),
 		cs.String("$ hcp profile init --vault-secrets").Bold(),
+		cs.String("$ hcp vault-secrets secrets --app <app_name> <sub-cmd>").Bold(),
 	)
 
 	return errors.New(help)

--- a/internal/pkg/vaultsecrets/validation.go
+++ b/internal/pkg/vaultsecrets/validation.go
@@ -30,7 +30,7 @@ func RequireVaultSecretsAppName(ctx *cmd.Context, appName string) error {
 	%v
 	`,
 		cs.String("Vault Secrets application name must be configured before running the command.").Color(cs.Orange()),
-		cs.String("$ hcp profile set vault-secrets/app_name <app_name>").Bold(),
+		cs.String("$ hcp profile set vault-secrets/app <app_name>").Bold(),
 		cs.String("$ hcp profile init --vault-secrets").Bold(),
 	)
 

--- a/internal/pkg/vaultsecrets/validation.go
+++ b/internal/pkg/vaultsecrets/validation.go
@@ -29,7 +29,7 @@ func RequireVaultSecretsAppName(ctx *cmd.Context, appName string) error {
 
 	%v
 
-	Alternatively, you can set the Vault Secrets applicaton name on the active pofile using the command:
+	Alternatively, you can set the Vault Secrets application name on the active pofile using the command:
 
 	%v
 


### PR DESCRIPTION
### Changes proposed in this PR:

Centralizing on `app` over `app_name` across vault secrets use cases in `hcp` CLI.

Slack chatter: [link](https://hashicorp.slack.com/archives/C0630MA5H8B/p1715721973724659)

### How I've tested this PR:

- [x] Local CLI run
- [x] Existing unit tests
 
### How I expect reviewers to test this PR:

```
$ make go/build && ./bin/hcp vs secrets create -h
```
Should show `app` instead of `app_name`
<img width="502" alt="Screenshot 2024-05-15 at 3 59 01 PM" src="https://github.com/hashicorp/hcp/assets/5619092/38af304f-15e4-4fb2-8bd4-fc90531216b6">


```
$ ./bin/hcp profile init --vault-secrets
$ ./bin/hcp profile display 
```
Should show `app` instead of  `app_name`
<img width="502" alt="image" src="https://github.com/hashicorp/hcp/assets/5619092/a1e48287-4dcb-4946-b1e4-f532c25f9e4e">

```
$ ./bin/hcp --autocomplete-install
Error executing hcp: 1 error occurred:
        * already installed in  ....
# tab auto complete should show app instead of app_name
$ ./bin/hcp profile set vault-secrets/app
```

```
$ ./bin/hcp profile set vault-secrets/app fancy-app
✓ Property "vault-secrets/app" updated
```

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
