### PR TITLE
Update the validation error message on secrets subcommands

### DIFF
--- a/internal/pkg/vaultsecrets/validation.go
+++ b/internal/pkg/vaultsecrets/validation.go
@@ -28,8 +28,7 @@ func RequireVaultSecretsAppName(ctx *cmd.Context, appName string) error {
 	Set the app name using the --app flag or set the app name on your active profile one of the following commands:
 
 	%v
-	%v
-	`,
+	%v`,
 		cs.String("Vault Secrets application name must set.").Color(cs.Orange()),
 		cs.String("$ hcp profile set vault-secrets/app <app_name>").Bold(),
 		cs.String("$ hcp profile init --vault-secrets").Bold(),

--- a/internal/pkg/vaultsecrets/validation.go
+++ b/internal/pkg/vaultsecrets/validation.go
@@ -25,22 +25,14 @@ func RequireVaultSecretsAppName(ctx *cmd.Context, appName string) error {
 	cs := ctx.IO.ColorScheme()
 	help := heredoc.Docf(`%v
 
-	To set the Vault Secrets application name interactively, run:
+	Set the app name using the --app flag or set the app name on your active profile one of the following commands:
 
 	%v
-
-	Alternatively, you can set the Vault Secrets application name on the active pofile using the command:
-
-	%v
-
-	If you prefer specifying the Vault Secrets application name directly via the command line, use:
-
 	%v
 	`,
-		cs.String("Vault Secrets application name must be configured before running the command.").Color(cs.Orange()),
+		cs.String("Vault Secrets application name must set.").Color(cs.Orange()),
 		cs.String("$ hcp profile set vault-secrets/app <app_name>").Bold(),
 		cs.String("$ hcp profile init --vault-secrets").Bold(),
-		cs.String("$ hcp vault-secrets secrets --app <app_name> <sub-cmd>").Bold(),
 	)
 
 	return errors.New(help)


### PR DESCRIPTION
### Changes proposed in this PR:

Capturing feedback post merge - https://github.com/hashicorp/hcp/pull/74#discussion_r1602225723

### How I've tested this PR:

```
> make go/build && ./bin/hcp vs secrets create                              
Vault Secrets application name must set.

Set the app name using the --app flag or set the app name on your active profile one of the following commands:

$ hcp profile set vault-secrets/app <app_name>
$ hcp profile init --vault-secrets
```
### How I expect reviewers to test this PR:

^^^

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
