### PR TITLE
Fixup: Rename -application-name to just -app for consistency

### DIFF
--- a/.changelog/77.txt
+++ b/.changelog/77.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+Renames the -application-name flag for creating waypoint add-ons to just -app
+```

--- a/internal/commands/waypoint/add-ons/create.go
+++ b/internal/commands/waypoint/add-ons/create.go
@@ -59,7 +59,7 @@ $ hcp waypoint add-ons create -n=my-addon -a=my-application -d=my-addon-definiti
 				},
 				{
 					Name:         "app",
-					DisplayValue: "APP-NAME",
+					DisplayValue: "NAME",
 					Description:  "The name of the application to which the add-on will be added.",
 					Value:        flagvalue.Simple("", &opts.ApplicationName),
 					Required:     true,

--- a/internal/commands/waypoint/add-ons/create.go
+++ b/internal/commands/waypoint/add-ons/create.go
@@ -58,8 +58,8 @@ $ hcp waypoint add-ons create -n=my-addon -a=my-application -d=my-addon-definiti
 					Required:     true,
 				},
 				{
-					Name:         "application-name",
-					DisplayValue: "NAME",
+					Name:         "app",
+					DisplayValue: "APP-NAME",
 					Description:  "The name of the application to which the add-on will be added.",
 					Value:        flagvalue.Simple("", &opts.ApplicationName),
 					Required:     true,

--- a/internal/commands/waypoint/add-ons/create_test.go
+++ b/internal/commands/waypoint/add-ons/create_test.go
@@ -46,7 +46,7 @@ func TestNewCmdCreate(t *testing.T) {
 			},
 			Args: []string{
 				"-n=cli-test",
-				"--application-name=testApp",
+				"--app=testApp",
 				"--add-on-definition-name=testAddOnDefinition",
 			},
 			Expect: &AddOnOpts{


### PR DESCRIPTION
### Changes proposed in this PR:

Other HCP commands use -app for the app name, and it's much less typing than -application-name. This simplifies this flag value.

### How I've tested this PR:

Built and validated the flag name changed, updated the tests and saw they passed.

### How I expect reviewers to test this PR:

Same ☝🏻 

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
