### PR TITLE
VAULT-26819 - implement hvs apps read

### DIFF
--- a/internal/commands/vaultsecrets/apps/apps.go
+++ b/internal/commands/vaultsecrets/apps/apps.go
@@ -23,5 +23,6 @@ func NewCmdApps(ctx *cmd.Context) *cmd.Command {
 
 	cmd.AddChild(NewCmdCreate(ctx, nil))
 	cmd.AddChild(NewCmdDelete(ctx, nil))
+	cmd.AddChild(NewCmdRead(ctx, nil))
 	return cmd
 }

--- a/internal/commands/vaultsecrets/apps/create.go
+++ b/internal/commands/vaultsecrets/apps/create.go
@@ -57,7 +57,7 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 		Args: cmd.PositionalArguments{
 			Args: []cmd.PositionalArgument{
 				{
-					Name:          "APP_NAME",
+					Name:          "NAME",
 					Documentation: "The name of the app to create.",
 				},
 			},

--- a/internal/commands/vaultsecrets/apps/delete.go
+++ b/internal/commands/vaultsecrets/apps/delete.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package apps
 
 import (

--- a/internal/commands/vaultsecrets/apps/delete.go
+++ b/internal/commands/vaultsecrets/apps/delete.go
@@ -54,7 +54,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 		Args: cmd.PositionalArguments{
 			Args: []cmd.PositionalArgument{
 				{
-					Name:          "APP_NAME",
+					Name:          "NAME",
 					Documentation: "The name of the app to delete.",
 				},
 			},

--- a/internal/commands/vaultsecrets/apps/displayer.go
+++ b/internal/commands/vaultsecrets/apps/displayer.go
@@ -18,7 +18,7 @@ func newDisplayer(single bool, apps ...*models.Secrets20230613App) *displayer {
 }
 
 func (d *displayer) DefaultFormat() format.Format {
-	return format.Pretty
+	return format.Table
 }
 
 func (d *displayer) Payload() any {

--- a/internal/commands/vaultsecrets/apps/read.go
+++ b/internal/commands/vaultsecrets/apps/read.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package apps
 
 import (

--- a/internal/commands/vaultsecrets/apps/read.go
+++ b/internal/commands/vaultsecrets/apps/read.go
@@ -1,0 +1,86 @@
+package apps
+
+import (
+	"context"
+	"fmt"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+type ReadOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	Output  *format.Outputter
+	IO      iostreams.IOStreams
+
+	AppName       string
+	Description   string
+	Client        secret_service.ClientService
+	PreviewClient preview_secret_service.ClientService
+}
+
+func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
+	opts := &ReadOpts{
+		Ctx:           ctx.ShutdownCtx,
+		Profile:       ctx.Profile,
+		Output:        ctx.Output,
+		IO:            ctx.IO,
+		Client:        secret_service.New(ctx.HCP, nil),
+		PreviewClient: preview_secret_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "read",
+		ShortHelp: "Read a Vault Secrets application.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets apps read" }} command gets a Vault Secrets application.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: `Read an application:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp vault-secrets apps read company-card
+				`),
+			},
+		},
+		Args: cmd.PositionalArguments{
+			Args: []cmd.PositionalArgument{
+				{
+					Name:          "APP_NAME",
+					Documentation: "The name of the app to read.",
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			opts.AppName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return readRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+func readRun(opts *ReadOpts) error {
+	resp, err := opts.Client.GetApp(&secret_service.GetAppParams{
+		Context:                opts.Ctx,
+		LocationProjectID:      opts.Profile.ProjectID,
+		LocationOrganizationID: opts.Profile.OrganizationID,
+		Name:                   opts.AppName,
+	}, nil)
+
+	if err != nil {
+		return fmt.Errorf("failed to read application: %w", err)
+	}
+
+	return opts.Output.Display(newDisplayer(true, resp.Payload.App))
+}

--- a/internal/commands/vaultsecrets/apps/read.go
+++ b/internal/commands/vaultsecrets/apps/read.go
@@ -23,7 +23,6 @@ type ReadOpts struct {
 	IO      iostreams.IOStreams
 
 	AppName       string
-	Description   string
 	Client        secret_service.ClientService
 	PreviewClient preview_secret_service.ClientService
 }
@@ -55,7 +54,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 		Args: cmd.PositionalArguments{
 			Args: []cmd.PositionalArgument{
 				{
-					Name:          "APP_NAME",
+					Name:          "NAME",
 					Documentation: "The name of the app to read.",
 				},
 			},

--- a/internal/commands/vaultsecrets/apps/read_test.go
+++ b/internal/commands/vaultsecrets/apps/read_test.go
@@ -89,7 +89,6 @@ func TestNewCmdRead(t *testing.T) {
 			r.Zero(code, io.Error.String())
 			r.NotNil(readOpts)
 			r.Equal(c.Expect.AppName, readOpts.AppName)
-			r.Equal(c.Expect.Description, readOpts.Description)
 		})
 	}
 }
@@ -141,8 +140,7 @@ func TestReadRun(t *testing.T) {
 				}, nil).Return(&secret_service.GetAppOK{
 					Payload: &models.Secrets20230613GetAppResponse{
 						App: &models.Secrets20230613App{
-							Name:        opts.AppName,
-							Description: opts.Description,
+							Name: opts.AppName,
 						},
 					},
 				}, nil).Once()
@@ -156,7 +154,7 @@ func TestReadRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Contains(io.Output.String(), fmt.Sprintf("App Name:    %s", opts.AppName))
+			r.Contains(io.Output.String(), fmt.Sprintf("App Name      Description  \n%s", opts.AppName))
 		})
 	}
 }

--- a/internal/commands/vaultsecrets/apps/read_test.go
+++ b/internal/commands/vaultsecrets/apps/read_test.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-openapi/runtime/client"
@@ -155,7 +156,7 @@ func TestReadRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Contains(io.Output.String(), "App Name:    company-card")
+			r.Contains(io.Output.String(), fmt.Sprintf("App Name:    %s", opts.AppName))
 		})
 	}
 }

--- a/internal/commands/vaultsecrets/apps/read_test.go
+++ b/internal/commands/vaultsecrets/apps/read_test.go
@@ -1,0 +1,161 @@
+package apps
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/models"
+	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func TestNewCmdRead(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *ReadOpts
+	}{
+		{
+			Name: "Good",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args: []string{"company-card"},
+			Expect: &ReadOpts{
+				AppName: "company-card",
+			},
+		},
+		{
+			Name: "No args",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args:  []string{},
+			Error: "accepts 1 arg(s), received 0",
+		},
+		{
+			Name: "Too many args",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args:  []string{"company-card", "additional-arg"},
+			Error: "ERROR: accepts 1 arg(s), received 2",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+
+			r := require.New(t)
+			io := iostreams.Test()
+
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				ShutdownCtx: context.Background(),
+				HCP:         &client.Runtime{},
+				Output:      format.New(io),
+			}
+
+			var readOpts *ReadOpts
+			readCmd := NewCmdRead(ctx, func(o *ReadOpts) error {
+				readOpts = o
+				return nil
+			})
+			readCmd.SetIO(io)
+
+			code := readCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(readOpts)
+			r.Equal(c.Expect.AppName, readOpts.AppName)
+			r.Equal(c.Expect.Description, readOpts.Description)
+		})
+	}
+}
+
+func TestReadRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		ErrMsg  string
+		AppName string
+	}{
+		{
+			Name:   "Failed: App not found",
+			ErrMsg: "[GET /secrets/2023-06-13/organizations/{location.organization_id}/projects/{location.project_id}/apps/{name}][403] GetApp",
+		},
+		{
+			Name:    "Success: Read app",
+			AppName: "company-card",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			vs := mock_secret_service.NewMockClientService(t)
+
+			opts := &ReadOpts{
+				Ctx:     context.Background(),
+				Profile: profile.TestProfile(t).SetOrgID("123").SetProjectID("abc"),
+				IO:      io,
+				Client:  vs,
+				Output:  format.New(io),
+				AppName: c.AppName,
+			}
+
+			if c.ErrMsg != "" {
+				vs.EXPECT().GetApp(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
+			} else {
+				vs.EXPECT().GetApp(&secret_service.GetAppParams{
+					LocationOrganizationID: "123",
+					LocationProjectID:      "abc",
+					Name:                   opts.AppName,
+					Context:                opts.Ctx,
+				}, nil).Return(&secret_service.GetAppOK{
+					Payload: &models.Secrets20230613GetAppResponse{
+						App: &models.Secrets20230613App{
+							Name:        opts.AppName,
+							Description: opts.Description,
+						},
+					},
+				}, nil).Once()
+			}
+
+			// Run the command
+			err := readRun(opts)
+			if c.ErrMsg != "" {
+				r.Contains(err.Error(), c.ErrMsg)
+				return
+			}
+
+			r.NoError(err)
+			r.Contains(io.Output.String(), "App Name:    company-card")
+		})
+	}
+}


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds the `read` command for hvs apps for ticket https://hashicorp.atlassian.net/browse/VAULT-26819

### How I've tested this PR:
Ran `make go/build` to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run make go/build
3. Create an app `./bin/hcp vault-secrets apps read {YOUR_APP_NAME}`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
<img width="863" alt="Screenshot 2024-05-16 at 9 27 47 AM" src="https://github.com/hashicorp/hcp/assets/19840012/56c3ec75-df26-409b-93d6-2867f4244052">

### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
