### PR TITLE
VAULT-26824 - Show help output after the displayer output

### DIFF
--- a/internal/commands/vaultsecrets/apps/create.go
+++ b/internal/commands/vaultsecrets/apps/create.go
@@ -101,17 +101,17 @@ func createRun(opts *CreateOpts) error {
 		return fmt.Errorf("failed to create application: %w", err)
 	}
 
-	if opts.Output.GetFormat() == format.Unset {
-		fmt.Fprintf(opts.IO.Err(), "%s Successfully created application with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.AppName)
-
-		command := fmt.Sprintf(`$ hcp vault-secrets secrets create <secret name> --app %s --data-file <path to secret>`, opts.AppName)
-
-		fmt.Fprintln(opts.IO.Err())
-		fmt.Fprintf(opts.IO.Err(), `To create a secret in the app, run:
-  %s`, opts.IO.ColorScheme().String(command).Bold())
-		fmt.Fprintln(opts.IO.Err())
-		return nil
+	if err := opts.Output.Display(newDisplayer(true, resp.Payload.App)); err != nil {
+		return err
 	}
 
-	return opts.Output.Display(newDisplayer(true, resp.Payload.App))
+	command := fmt.Sprintf(`$ hcp vault-secrets secrets create <secret name> --app %s --data-file <path to secret>`, opts.AppName)
+
+	fmt.Fprintln(opts.IO.Err())
+	fmt.Fprintf(opts.IO.Err(), "%s Successfully created application with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.AppName)
+	fmt.Fprintln(opts.IO.Err())
+	fmt.Fprintf(opts.IO.Err(), `To create a secret in the app, run:
+  %s`, opts.IO.ColorScheme().String(command).Bold())
+	fmt.Fprintln(opts.IO.Err())
+	return nil
 }

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -123,19 +123,18 @@ func createRun(opts *CreateOpts) error {
 		return fmt.Errorf("failed to create secret with name %q: %w", opts.SecretName, err)
 	}
 
-	if opts.Output.GetFormat() == format.Unset {
-		fmt.Fprintf(opts.IO.Err(), "%s Successfully created secret with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
-
-		command := fmt.Sprintf(`$ hcp vault-secrets secrets read %s --app %s`, opts.SecretName, req.AppName)
-
-		fmt.Fprintln(opts.IO.Err())
-		fmt.Fprintf(opts.IO.Err(), `To read your secret, run:
-  %s`, opts.IO.ColorScheme().String(command).Bold())
-		fmt.Fprintln(opts.IO.Err())
-		return nil
+	if err := opts.Output.Display(newDisplayer(true).Secrets(resp.Payload.Secret)); err != nil {
+		return err
 	}
 
-	return opts.Output.Display(newDisplayer(true).Secrets(resp.Payload.Secret))
+	command := fmt.Sprintf(`$ hcp vault-secrets secrets read %s --app %s`, opts.SecretName, req.AppName)
+	fmt.Fprintln(opts.IO.Err())
+	fmt.Fprintf(opts.IO.Err(), "%s Successfully created secret with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
+	fmt.Fprintln(opts.IO.Err())
+	fmt.Fprintf(opts.IO.Err(), `To read your secret, run:
+  %s`, opts.IO.ColorScheme().String(command).Bold())
+	fmt.Fprintln(opts.IO.Err())
+	return nil
 }
 
 func readPlainTextSecret(opts *CreateOpts) error {


### PR DESCRIPTION
### Changes proposed in this PR:

As per discussion on this [thread](https://github.com/hashicorp/hcp/pull/79#discussion_r1604118673), we will be showing help output always after the displayer output. The users can suppress the help output using the `--quiet` flag (if required).

### How I've tested this PR:
- [x] built locally and ran the commands

```
> make go/build && echo "temp" | ./bin/hcp vs secrets create temp --data-file=- --app test-gs 
Secret Name  Latest Version  Created At                
temp         12              2024-05-17T14:47:24.104Z  

✓ Successfully created secret with name "temp"

To read your secret, run:
  $ hcp vault-secrets secrets read temp --app test-gs


> echo "temp" | ./bin/hcp vs secrets create temp --data-file=- --app test-gs --quiet
Secret Name  Latest Version  Created At                
temp         13              2024-05-17T14:47:24.104Z  
```

```
> ./bin/hcp vault-secrets apps create test 
App Name  Description  
test                   

✓ Successfully created application with name "test"

To create a secret in the app, run:
  $ hcp vault-secrets secrets create <secret name> --app test --data-file <path to secret>


> ./bin/hcp vault-secrets apps create test --quiet
App Name  Description  
test                   
```

### How I expect reviewers to test this PR:
```
$ make go/build 
$ ./bin/hcp auth login 
$ ./bin/hcp profile init --vault-secrets
$ ./bin/hcp vault-secrets secrets read
```
<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
