### PR TITLE
HCPCP-1620: ReadSecret: Respect Ctrl-C Interrupt

### DIFF
--- a/internal/pkg/iostreams/io.go
+++ b/internal/pkg/iostreams/io.go
@@ -13,9 +13,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 
 	"github.com/muesli/termenv"
 	"golang.org/x/term"
@@ -177,20 +175,13 @@ func (s *system) ReadSecret() ([]byte, error) {
 	}
 	errorChannel := make(chan Buffer, 1)
 
-	// SIGINT and SIGTERM restore the terminal, otherwise the no-echo mode would remain intact
-	interruptChannel := make(chan os.Signal, 1)
-	signal.Notify(interruptChannel, syscall.SIGINT, syscall.SIGTERM)
-	defer func() {
-		signal.Stop(interruptChannel)
-		close(interruptChannel)
-	}()
+	// Cancelled context restores the terminal, otherwise the no-echo mode would remain intact
 	go func() {
-		for range interruptChannel {
-			if oldState != nil {
-				_ = term.Restore(fd, oldState)
-			}
-			errorChannel <- Buffer{Buffer: make([]byte, 0), Error: ErrInterrupt}
+		<-s.ctx.Done()
+		if oldState != nil {
+			_ = term.Restore(fd, oldState)
 		}
+		errorChannel <- Buffer{Buffer: make([]byte, 0), Error: ErrInterrupt}
 	}()
 
 	go func() {

--- a/internal/pkg/iostreams/io.go
+++ b/internal/pkg/iostreams/io.go
@@ -157,12 +157,10 @@ func (s *system) ReadSecret() ([]byte, error) {
 	}
 
 	go func() {
-		select {
-		case <-s.ctx.Done():
-			fmt.Fprintf(s.Err(), "\n%v\n", context.Cause(s.ctx))
+		<-s.ctx.Done()
+		fmt.Fprintf(s.Err(), "\n%v\n", context.Cause(s.ctx))
 
-			os.Exit(1)
-		}
+		os.Exit(1)
 	}()
 
 	return term.ReadPassword(int(s.in.Fd()))

--- a/internal/pkg/iostreams/io.go
+++ b/internal/pkg/iostreams/io.go
@@ -19,7 +19,6 @@ import (
 	"golang.org/x/term"
 )
 
-var ErrInterrupt = errors.New("interrupted")
 
 // IOStreams is an interface for interacting with IO and general terminal
 // output. Commands should not directly interact with os.Stdout/Stderr/Stdin but

--- a/internal/pkg/iostreams/io.go
+++ b/internal/pkg/iostreams/io.go
@@ -9,7 +9,6 @@ package iostreams
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,7 +17,6 @@ import (
 	"github.com/muesli/termenv"
 	"golang.org/x/term"
 )
-
 
 // IOStreams is an interface for interacting with IO and general terminal
 // output. Commands should not directly interact with os.Stdout/Stderr/Stdin but
@@ -178,12 +176,12 @@ func (s *system) ReadSecret() ([]byte, error) {
 
 	// Cancelled context restores the terminal, otherwise the no-echo mode would remain intact
 	go func() {
-		select {	
+		select {
 		case <-doneChannel:
 			return
 		case <-s.ctx.Done():
 		}
-		
+
 		if oldState != nil {
 			_ = term.Restore(fd, oldState)
 		}

--- a/internal/pkg/iostreams/io.go
+++ b/internal/pkg/iostreams/io.go
@@ -9,6 +9,7 @@ package iostreams
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -19,6 +20,8 @@ import (
 	"github.com/muesli/termenv"
 	"golang.org/x/term"
 )
+
+var ErrInterrupt = errors.New("interrupted")
 
 // IOStreams is an interface for interacting with IO and general terminal
 // output. Commands should not directly interact with os.Stdout/Stderr/Stdin but

--- a/internal/pkg/iostreams/io.go
+++ b/internal/pkg/iostreams/io.go
@@ -156,7 +156,16 @@ func (s *system) ReadSecret() ([]byte, error) {
 		return nil, fmt.Errorf("prompting is disabled")
 	}
 
-	return term.ReadPassword(int(s.in.Fd()))
+    go func() {
+        select {
+        case <-s.ctx.Done():
+            fmt.Fprintf(s.Err(), "\n%v\n", context.Cause(s.ctx))
+
+            os.Exit(1)
+        }
+    }()
+
+    return term.ReadPassword(int(s.in.Fd()))
 }
 
 func (s *system) PromptConfirm(prompt string) (confirmed bool, err error) {

--- a/internal/pkg/iostreams/io.go
+++ b/internal/pkg/iostreams/io.go
@@ -156,16 +156,16 @@ func (s *system) ReadSecret() ([]byte, error) {
 		return nil, fmt.Errorf("prompting is disabled")
 	}
 
-    go func() {
-        select {
-        case <-s.ctx.Done():
-            fmt.Fprintf(s.Err(), "\n%v\n", context.Cause(s.ctx))
+	go func() {
+		select {
+		case <-s.ctx.Done():
+			fmt.Fprintf(s.Err(), "\n%v\n", context.Cause(s.ctx))
 
-            os.Exit(1)
-        }
-    }()
+			os.Exit(1)
+		}
+	}()
 
-    return term.ReadPassword(int(s.in.Fd()))
+	return term.ReadPassword(int(s.in.Fd()))
 }
 
 func (s *system) PromptConfirm(prompt string) (confirmed bool, err error) {

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 func realMain() int {
 	args := os.Args[1:]
 
-	// Listen for interupts
+	// Listen for interrupts
 	shutdownCtx, shutdown := context.WithCancelCause(context.Background())
 	defer shutdown(nil)
 	go func() {


### PR DESCRIPTION
### Changes proposed in this PR:
* Relates to https://github.com/hashicorp/hcp/issues/68 and HCPCP-1620
* Updates the `ReadSecret` method to listen for the canceled context signaled by `os.Interrupt`, logs the cancel cause and exits the program.

### How I've tested this PR:
* NOTE: This bug was surfaced with vault secrets having the option for STDIN password. This has since be removed but is being addressed for future use. Due to this, it was tested on a historical git commit. 

<img width="402" alt="Screenshot 2024-05-20 at 9 52 52 AM" src="https://github.com/hashicorp/hcp/assets/11759003/c0a76e65-392e-4af3-acc6-d1cc1caba6ae">

### How I expect reviewers to test this PR:
Tested with Iterm and Bash:
```
$ git checkout test-jason

$ ./bin/hcp auth login
$ ./bin/hcp profile init --profile=vault-secrets
$ ./bin/hcp profile set vault-secrets/app_name <app_name>
$ ./bin/hcp vault-secrets secrets create test

^c
```

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
