### PR TITLE
Add autocomplete for the apps/secrets -> read/delete command

### DIFF
--- a/internal/commands/vaultsecrets/apps/delete.go
+++ b/internal/commands/vaultsecrets/apps/delete.go
@@ -9,6 +9,7 @@ import (
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/apps/helper"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -58,6 +59,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 					Documentation: "The name of the app to delete.",
 				},
 			},
+			Autocomplete: helper.PredictAppName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = args[0]

--- a/internal/commands/vaultsecrets/apps/delete.go
+++ b/internal/commands/vaultsecrets/apps/delete.go
@@ -59,7 +59,6 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 					Documentation: "The name of the app to delete.",
 				},
 			},
-			Autocomplete: helper.PredictAppName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = args[0]
@@ -70,6 +69,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 			return deleteRun(opts)
 		},
 	}
+	cmd.Args.Autocomplete = helper.PredictAppName(ctx, cmd, preview_secret_service.New(ctx.HCP, nil))
 
 	return cmd
 }

--- a/internal/commands/vaultsecrets/apps/helper/helper.go
+++ b/internal/commands/vaultsecrets/apps/helper/helper.go
@@ -1,0 +1,58 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/posener/complete"
+)
+
+// PredictAppName returns a predict function for application names.
+func PredictAppName(ctx *cmd.Context, orgID, projectID string, client preview_secret_service.ClientService) complete.PredictFunc {
+	return func(args complete.Args) []string {
+		if len(args.Completed) > 1 {
+			return nil
+		}
+
+		apps, err := getApps(ctx.ShutdownCtx, orgID, projectID, client)
+		if err != nil {
+			return nil
+		}
+
+		names := make([]string, len(apps))
+		for i, d := range apps {
+			names[i] = d.Name
+		}
+
+		return names
+	}
+}
+
+func getApps(ctx context.Context, orgID, projectID string, client preview_secret_service.ClientService) ([]*preview_models.Secrets20231128App, error) {
+	req := preview_secret_service.NewListAppsParamsWithContext(ctx)
+	req.OrganizationID = orgID
+	req.ProjectID = projectID
+	var apps []*preview_models.Secrets20231128App
+	for {
+
+		resp, err := client.ListApps(req, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list groups: %w", err)
+		}
+		apps = append(apps, resp.Payload.Apps...)
+		if resp.Payload.Pagination == nil || resp.Payload.Pagination.NextPageToken == "" {
+			break
+		}
+
+		next := resp.Payload.Pagination.NextPageToken
+		req.PaginationNextPageToken = &next
+	}
+
+	return apps, nil
+}

--- a/internal/commands/vaultsecrets/apps/helper/helper.go
+++ b/internal/commands/vaultsecrets/apps/helper/helper.go
@@ -14,13 +14,19 @@ import (
 )
 
 // PredictAppName returns a predict function for application names.
-func PredictAppName(ctx *cmd.Context, orgID, projectID string, client preview_secret_service.ClientService) complete.PredictFunc {
+func PredictAppName(ctx *cmd.Context, c *cmd.Command, client preview_secret_service.ClientService) complete.PredictFunc {
 	return func(args complete.Args) []string {
-		if len(args.Completed) > 1 {
+		// Parse the args
+		remainingArgs, err := ctx.ParseFlags(c, args.All)
+		if err != nil {
 			return nil
 		}
 
-		apps, err := getApps(ctx.ShutdownCtx, orgID, projectID, client)
+		if len(remainingArgs) > 1 {
+			return nil
+		}
+
+		apps, err := getApps(ctx.ShutdownCtx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, client)
 		if err != nil {
 			return nil
 		}

--- a/internal/commands/vaultsecrets/apps/read.go
+++ b/internal/commands/vaultsecrets/apps/read.go
@@ -59,7 +59,6 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 					Documentation: "The name of the app to read.",
 				},
 			},
-			Autocomplete: helper.PredictAppName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = args[0]
@@ -70,6 +69,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 			return readRun(opts)
 		},
 	}
+	cmd.Args.Autocomplete = helper.PredictAppName(ctx, cmd, preview_secret_service.New(ctx.HCP, nil))
 
 	return cmd
 }

--- a/internal/commands/vaultsecrets/apps/read.go
+++ b/internal/commands/vaultsecrets/apps/read.go
@@ -9,6 +9,7 @@ import (
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/apps/helper"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -58,6 +59,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 					Documentation: "The name of the app to read.",
 				},
 			},
+			Autocomplete: helper.PredictAppName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = args[0]

--- a/internal/commands/vaultsecrets/secrets/appname/appname.go
+++ b/internal/commands/vaultsecrets/secrets/appname/appname.go
@@ -5,6 +5,7 @@ package appname
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
@@ -41,6 +42,7 @@ func Require(ctx *cmd.Context) error {
 
 	if appName == "" && ctx.Profile.VaultSecrets != nil {
 		set(ctx.Profile.VaultSecrets.AppName)
+		fmt.Println("Appname is set", appName)
 	}
 
 	if appName != "" || ctx.Profile.VaultSecrets != nil && ctx.Profile.VaultSecrets.AppName != "" {

--- a/internal/commands/vaultsecrets/secrets/appname/appname.go
+++ b/internal/commands/vaultsecrets/secrets/appname/appname.go
@@ -5,7 +5,6 @@ package appname
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
@@ -42,7 +41,6 @@ func Require(ctx *cmd.Context) error {
 
 	if appName == "" && ctx.Profile.VaultSecrets != nil {
 		set(ctx.Profile.VaultSecrets.AppName)
-		fmt.Println("Appname is set", appName)
 	}
 
 	if appName != "" || ctx.Profile.VaultSecrets != nil && ctx.Profile.VaultSecrets.AppName != "" {

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
 	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/posener/complete"
 )
 
 func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
@@ -72,6 +73,7 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 					DisplayValue: "DATA_FILE_PATH",
 					Description:  "File path to read secret data from. Set this to '-' to read the secret data from stdin.",
 					Value:        flagvalue.Simple("", &opts.SecretFilePath),
+					Autocomplete: complete.PredictFiles("*.json"),
 				},
 			},
 		},

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -73,7 +73,10 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 					DisplayValue: "DATA_FILE_PATH",
 					Description:  "File path to read secret data from. Set this to '-' to read the secret data from stdin.",
 					Value:        flagvalue.Simple("", &opts.SecretFilePath),
-					Autocomplete: complete.PredictFiles("*.json"),
+					Autocomplete: complete.PredictOr(
+						complete.PredictFiles("*"),
+						complete.PredictSet("-"),
+					),
 				},
 			},
 		},

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -54,7 +54,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 					Documentation: "The name of the secret to create.",
 				},
 			},
-			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, appname.Get(), opts.PreviewClient),
+			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = appname.Get()

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -10,6 +10,7 @@ import (
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/helper"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -53,7 +54,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 					Documentation: "The name of the secret to create.",
 				},
 			},
-			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, appName, opts.PreviewClient),
+			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, appname.Get(), opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = appname.Get()

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -53,6 +53,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 					Documentation: "The name of the secret to create.",
 				},
 			},
+			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, appName, opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = appname.Get()

--- a/internal/commands/vaultsecrets/secrets/delete.go
+++ b/internal/commands/vaultsecrets/secrets/delete.go
@@ -54,7 +54,6 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 					Documentation: "The name of the secret to create.",
 				},
 			},
-			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = appname.Get()
@@ -66,6 +65,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 			return deleteRun(opts)
 		},
 	}
+	cmd.Args.Autocomplete = helper.PredictSecretName(ctx, cmd, opts.PreviewClient)
 
 	return cmd
 }

--- a/internal/commands/vaultsecrets/secrets/helper/helper.go
+++ b/internal/commands/vaultsecrets/secrets/helper/helper.go
@@ -15,17 +15,21 @@ import (
 )
 
 // PredictAppName returns a predict function for application names.
-func PredictSecretName(ctx *cmd.Context, orgID, projectID string, client preview_secret_service.ClientService) complete.PredictFunc {
+func PredictSecretName(ctx *cmd.Context, c *cmd.Command, client preview_secret_service.ClientService) complete.PredictFunc {
 	return func(args complete.Args) []string {
-		if len(args.Completed) > 1 {
+		// Parse the args
+		remainingArgs, err := ctx.ParseFlags(c, args.All)
+		if err != nil {
 			return nil
 		}
 
-		appName := appname.Get()
-		if ctx.Profile.VaultSecrets != nil && appName == "" {
-			appName = ctx.Profile.VaultSecrets.AppName
+		if len(remainingArgs) > 1 {
+			return nil
 		}
-		secrets, err := getSecrets(ctx.ShutdownCtx, orgID, projectID, appName, client)
+
+		appname.Require(ctx)
+		appName := appname.Get()
+		secrets, err := getSecrets(ctx.ShutdownCtx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, appName, client)
 		if err != nil {
 			return nil
 		}

--- a/internal/commands/vaultsecrets/secrets/helper/helper.go
+++ b/internal/commands/vaultsecrets/secrets/helper/helper.go
@@ -27,7 +27,11 @@ func PredictSecretName(ctx *cmd.Context, c *cmd.Command, client preview_secret_s
 			return nil
 		}
 
-		appname.Require(ctx)
+		// Parse the app name from the flags or profile
+		if err := appname.Require(ctx); err != nil {
+			return nil
+		}
+
 		appName := appname.Get()
 		secrets, err := getSecrets(ctx.ShutdownCtx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, appName, client)
 		if err != nil {

--- a/internal/commands/vaultsecrets/secrets/helper/helper.go
+++ b/internal/commands/vaultsecrets/secrets/helper/helper.go
@@ -1,0 +1,59 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/posener/complete"
+)
+
+// PredictAppName returns a predict function for application names.
+func PredictSecretName(ctx *cmd.Context, orgID, projectID, appName string, client preview_secret_service.ClientService) complete.PredictFunc {
+	return func(args complete.Args) []string {
+		if len(args.Completed) > 1 {
+			return nil
+		}
+
+		secrets, err := getSecrets(ctx.ShutdownCtx, orgID, projectID, appName, client)
+		if err != nil {
+			return nil
+		}
+
+		names := make([]string, len(secrets))
+		for i, d := range secrets {
+			names[i] = d.Name
+		}
+		return names
+	}
+}
+
+func getSecrets(ctx context.Context, orgID, projectID, appName string, client preview_secret_service.ClientService) ([]*preview_models.Secrets20231128Secret, error) {
+	req := preview_secret_service.NewListAppSecretsParamsWithContext(ctx)
+	req.OrganizationID = orgID
+	req.ProjectID = projectID
+	req.AppName = appName
+
+	var secrets []*preview_models.Secrets20231128Secret
+	for {
+
+		resp, err := client.ListAppSecrets(req, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list groups: %w", err)
+		}
+		secrets = append(secrets, resp.Payload.Secrets...)
+		if resp.Payload.Pagination == nil || resp.Payload.Pagination.NextPageToken == "" {
+			break
+		}
+
+		next := resp.Payload.Pagination.NextPageToken
+		req.PaginationNextPageToken = &next
+	}
+
+	return secrets, nil
+}

--- a/internal/commands/vaultsecrets/secrets/helper/helper.go
+++ b/internal/commands/vaultsecrets/secrets/helper/helper.go
@@ -9,17 +9,22 @@ import (
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/posener/complete"
 )
 
 // PredictAppName returns a predict function for application names.
-func PredictSecretName(ctx *cmd.Context, orgID, projectID, appName string, client preview_secret_service.ClientService) complete.PredictFunc {
+func PredictSecretName(ctx *cmd.Context, orgID, projectID string, client preview_secret_service.ClientService) complete.PredictFunc {
 	return func(args complete.Args) []string {
 		if len(args.Completed) > 1 {
 			return nil
 		}
 
+		appName := appname.Get()
+		if ctx.Profile.VaultSecrets != nil && appName == "" {
+			appName = ctx.Profile.VaultSecrets.AppName
+		}
 		secrets, err := getSecrets(ctx.ShutdownCtx, orgID, projectID, appName, client)
 		if err != nil {
 			return nil

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -12,6 +12,7 @@ import (
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/helper"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/format"
@@ -51,6 +52,7 @@ func NewCmdOpen(ctx *cmd.Context, runF func(*OpenOpts) error) *cmd.Command {
 					Documentation: "The name of the secret to open.",
 				},
 			},
+			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, opts.PreviewClient),
 		},
 		Flags: cmd.Flags{
 			Local: []*cmd.Flag{

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -52,7 +52,6 @@ func NewCmdOpen(ctx *cmd.Context, runF func(*OpenOpts) error) *cmd.Command {
 					Documentation: "The name of the secret to open.",
 				},
 			},
-			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, opts.PreviewClient),
 		},
 		Flags: cmd.Flags{
 			Local: []*cmd.Flag{
@@ -75,6 +74,7 @@ func NewCmdOpen(ctx *cmd.Context, runF func(*OpenOpts) error) *cmd.Command {
 			return openRun(opts)
 		},
 	}
+	cmd.Args.Autocomplete = helper.PredictSecretName(ctx, cmd, opts.PreviewClient)
 
 	return cmd
 }

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -55,7 +55,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 					Documentation: "The name of the secret to read.",
 				},
 			},
-			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, appname.Get(), opts.PreviewClient),
+			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = appname.Get()

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -10,6 +10,7 @@ import (
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/helper"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -54,7 +55,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 					Documentation: "The name of the secret to read.",
 				},
 			},
-			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, appName, opts.PreviewClient),
+			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, appname.Get(), opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = appname.Get()

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -55,7 +55,6 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 					Documentation: "The name of the secret to read.",
 				},
 			},
-			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = appname.Get()
@@ -67,6 +66,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 			return readRun(opts)
 		},
 	}
+	cmd.Args.Autocomplete = helper.PredictSecretName(ctx, cmd, opts.PreviewClient)
 
 	return cmd
 }

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -54,6 +54,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 					Documentation: "The name of the secret to read.",
 				},
 			},
+			Autocomplete: helper.PredictSecretName(ctx, ctx.Profile.OrganizationID, ctx.Profile.ProjectID, appName, opts.PreviewClient),
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			opts.AppName = appname.Get()

--- a/internal/commands/vaultsecrets/secrets/secrets.go
+++ b/internal/commands/vaultsecrets/secrets/secrets.go
@@ -4,6 +4,8 @@
 package secrets
 
 import (
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/apps/helper"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/versions"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
@@ -33,6 +35,13 @@ func NewCmdSecrets(ctx *cmd.Context) *cmd.Command {
 		PersistentPreRun: func(c *cmd.Command, args []string) error {
 			return appname.Require(ctx)
 		},
+	}
+
+	// Autocomplete the persistent flag.
+	for _, f := range cmd.Flags.Persistent {
+		if f.Name == "app" {
+			f.Autocomplete = helper.PredictAppName(ctx, cmd, preview_secret_service.New(ctx.HCP, nil))
+		}
 	}
 
 	cmd.AddChild(NewCmdCreate(ctx, nil))

--- a/internal/commands/vaultsecrets/secrets/secrets.go
+++ b/internal/commands/vaultsecrets/secrets/secrets.go
@@ -4,13 +4,8 @@
 package secrets
 
 import (
-<<<<<<< HEAD
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/versions"
-=======
-	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/apps/helper"
->>>>>>> 16ec8bc (allow things so as to pass on CI/CD)
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 )

--- a/internal/commands/vaultsecrets/secrets/secrets.go
+++ b/internal/commands/vaultsecrets/secrets/secrets.go
@@ -4,8 +4,13 @@
 package secrets
 
 import (
+<<<<<<< HEAD
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/versions"
+=======
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/apps/helper"
+>>>>>>> 16ec8bc (allow things so as to pass on CI/CD)
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 )

--- a/internal/commands/vaultsecrets/secrets/secrets.go
+++ b/internal/commands/vaultsecrets/secrets/secrets.go
@@ -18,6 +18,7 @@ func NewCmdSecrets(ctx *cmd.Context) *cmd.Command {
 		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets" }} command group lets you
 		manage Vault Secrets application secrets.
 		`),
+		Aliases: []string{"s"},
 		Flags: cmd.Flags{
 			Persistent: []*cmd.Flag{
 				{

--- a/internal/commands/vaultsecrets/vault_secrets.go
+++ b/internal/commands/vaultsecrets/vault_secrets.go
@@ -16,7 +16,7 @@ func NewCmdVaultSecrets(ctx *cmd.Context) *cmd.Command {
 		ShortHelp: "Manage Vault Secrets.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets" }} command group lets you manage Vault Secrets
-		resources through the CLI (in Beta).
+		resources through the CLI.
 		`),
 		Aliases: []string{
 			"vs",


### PR DESCRIPTION
### Changes proposed in this PR:

The PR makes follwoing changes 

1. adds a `s` alias for the `secrets` subcommand
2. adds auto complete functionality for `--app` flag
3. adds auto complete fucntionality for `app` and `secret name` args on apps/secrets read/delete paths.
4. Removes any references to Beta
5. Added an autocomplete for --data-file flag under `hcp vs s create` similar to [this](https://github.com/hashicorp/hcp/blob/b59b5ece6ed275fdec5f35e1046b17d601503411/internal/commands/auth/login.go#L110)

### How I've tested this PR:
-[x] built locally and exercised tab to see autocomplete pick up/show the values

### How I expect reviewers to test this PR:
```
$ make go/build
$ ./bin/hcp v...keep entering tab until you craft the command you need
```

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
