### PR TITLE
VAULT-26822 - Add hcp vault-secrets secrets update

### DIFF
--- a/internal/commands/vaultsecrets/secrets/secrets.go
+++ b/internal/commands/vaultsecrets/secrets/secrets.go
@@ -36,6 +36,7 @@ func NewCmdSecrets(ctx *cmd.Context) *cmd.Command {
 
 	cmd.AddChild(NewCmdCreate(ctx, nil))
 	cmd.AddChild(NewCmdRead(ctx, nil))
+	cmd.AddChild(NewCmdUpdate(ctx, nil))
 	cmd.AddChild(NewCmdDelete(ctx, nil))
 	cmd.AddChild(NewCmdList(ctx, nil))
 	cmd.AddChild(NewCmdOpen(ctx, nil))

--- a/internal/commands/vaultsecrets/secrets/update.go
+++ b/internal/commands/vaultsecrets/secrets/update.go
@@ -108,7 +108,7 @@ func updateRun(opts *UpdateOpts) error {
 
 	_, err := opts.Client.GetAppSecret(getReq, nil)
 	if err != nil {
-		return fmt.Errorf("secret %q not found: %w", opts.SecretName, err)
+		return fmt.Errorf("secret with name %q not found: %w", opts.SecretName, err)
 	}
 
 	opts.SecretValuePlaintext, err = readPlainTextSecret(opts.SecretValuePlaintext, opts.SecretFilePath, opts.IO.In())

--- a/internal/commands/vaultsecrets/secrets/update.go
+++ b/internal/commands/vaultsecrets/secrets/update.go
@@ -29,10 +29,10 @@ func NewCmdUpdate(ctx *cmd.Context, runF func(*UpdateOpts) error) *cmd.Command {
 	}
 
 	cmd := &cmd.Command{
-		Name:      "delete",
+		Name:      "update",
 		ShortHelp: "Update a static secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets delete" }} command updates a static secret under an Vault Secrets application.`),
+		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets update" }} command updates a static secret under an Vault Secrets application.`),
 		Examples: []cmd.Example{
 			{
 				Preamble: `Update a new secret in Vault Secrets application on active profile:`,

--- a/internal/commands/vaultsecrets/secrets/update_test.go
+++ b/internal/commands/vaultsecrets/secrets/update_test.go
@@ -5,14 +5,22 @@ package secrets
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
 
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/models"
+	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
 	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,131 +98,152 @@ func TestNewCmdUpdate(t *testing.T) {
 	}
 }
 
-// func TestUpdateRun(t *testing.T) {
-// 	t.Parallel()
+func TestUpdateRun(t *testing.T) {
+	t.Parallel()
 
-// 	testProfile := func(t *testing.T) *profile.Profile {
-// 		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
-// 		tp.VaultSecrets = &profile.VaultSecretsConf{
-// 			AppName: "test-app",
-// 		}
-// 		return tp
-// 	}
-// 	testSecretValue := "my super secret value"
+	testProfile := func(t *testing.T) *profile.Profile {
+		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+		tp.VaultSecrets = &profile.VaultSecretsConf{
+			AppName: "test-app",
+		}
+		return tp
+	}
+	testSecretValue := "my super secret value"
 
-// 	cases := []struct {
-// 		Name             string
-// 		RespErr          bool
-// 		ReadViaStdin     bool
-// 		EmptySecretValue bool
-// 		ErrMsg           string
-// 		MockCalled       bool
-// 		AugmentOpts      func(*CreateOpts)
-// 	}{
-// 		{
-// 			Name:   "Failed: Read via stdin as hypen not supplied for --data-file flag",
-// 			ErrMsg: "data file path is required",
-// 		},
-// 		{
-// 			Name:             "Failed: Read empty secret value via stdin",
-// 			EmptySecretValue: true,
-// 			ReadViaStdin:     true,
-// 			RespErr:          true,
-// 			AugmentOpts:      func(o *CreateOpts) { o.SecretFilePath = "-" },
-// 			ErrMsg:           "secret value cannot be empty",
-// 		},
-// 		{
-// 			Name:         "Success: Create secret via stdin",
-// 			ReadViaStdin: true,
-// 			AugmentOpts:  func(o *CreateOpts) { o.SecretFilePath = "-" },
-// 			MockCalled:   true,
-// 		},
-// 		{
-// 			Name:        "Failed: Max secret versions reached",
-// 			RespErr:     true,
-// 			ErrMsg:      "[POST /secrets/2023-11-28/organizations/{organization_id}/projects/{project_id}/apps/{app_name}/secret/kv][429] CreateAppKVSecret default  &{Code:8 Details:[] Message:maximum number of secret versions reached}",
-// 			AugmentOpts: func(o *CreateOpts) { o.SecretValuePlaintext = testSecretValue },
-// 			MockCalled:  true,
-// 		},
-// 		{
-// 			Name:        "Success: Created secret",
-// 			RespErr:     false,
-// 			AugmentOpts: func(o *CreateOpts) { o.SecretValuePlaintext = testSecretValue },
-// 			MockCalled:  true,
-// 		},
-// 	}
+	cases := []struct {
+		Name             string
+		RespErr          bool
+		ExpectGetErr     bool
+		ReadViaStdin     bool
+		EmptySecretValue bool
+		ErrMsg           string
+		MockCalled       bool
+		AugmentOpts      func(*UpdateOpts)
+	}{
+		{
+			Name:   "Failed: Read via stdin as hypen not supplied for --data-file flag",
+			ErrMsg: "data file path is required",
+		},
+		// {
+		// 	Name:             "Failed: Read empty secret value via stdin",
+		// 	EmptySecretValue: true,
+		// 	ReadViaStdin:     true,
+		// 	RespErr:          true,
+		// 	AugmentOpts:      func(o *CreateOpts) { o.SecretFilePath = "-" },
+		// 	ErrMsg:           "secret value cannot be empty",
+		// },
+		// {
+		// 	Name:         "Success: Create secret via stdin",
+		// 	ReadViaStdin: true,
+		// 	AugmentOpts:  func(o *CreateOpts) { o.SecretFilePath = "-" },
+		// 	MockCalled:   true,
+		// },
+		// {
+		// 	Name:        "Failed: Max secret versions reached",
+		// 	RespErr:     true,
+		// 	ErrMsg:      "[POST /secrets/2023-11-28/organizations/{organization_id}/projects/{project_id}/apps/{app_name}/secret/kv][429] CreateAppKVSecret default  &{Code:8 Details:[] Message:maximum number of secret versions reached}",
+		// 	AugmentOpts: func(o *CreateOpts) { o.SecretValuePlaintext = testSecretValue },
+		// 	MockCalled:  true,
+		// },
+		// {
+		// 	Name:        "Success: Created secret",
+		// 	RespErr:     false,
+		// 	AugmentOpts: func(o *CreateOpts) { o.SecretValuePlaintext = testSecretValue },
+		// 	MockCalled:  true,
+		// },
+	}
 
-// 	for _, c := range cases {
-// 		c := c
-// 		t.Run(c.Name, func(t *testing.T) {
-// 			t.Parallel()
-// 			r := require.New(t)
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
 
-// 			io := iostreams.Test()
-// 			if c.ReadViaStdin {
-// 				io.InputTTY = true
-// 				io.ErrorTTY = true
+			io := iostreams.Test()
+			if c.ReadViaStdin {
+				io.InputTTY = true
+				io.ErrorTTY = true
 
-// 				if !c.EmptySecretValue {
-// 					_, err := io.Input.WriteString(testSecretValue)
-// 					r.NoError(err)
-// 				}
-// 			}
-// 			vs := mock_secret_service.NewMockClientService(t)
-// 			opts := &CreateOpts{
-// 				Ctx:        context.Background(),
-// 				IO:         io,
-// 				Profile:    testProfile(t),
-// 				Output:     format.New(io),
-// 				Client:     vs,
-// 				AppName:    testProfile(t).VaultSecrets.AppName,
-// 				SecretName: "test_secret",
-// 			}
+				if !c.EmptySecretValue {
+					_, err := io.Input.WriteString(testSecretValue)
+					r.NoError(err)
+				}
+			}
+			vs := mock_secret_service.NewMockClientService(t)
+			opts := &UpdateOpts{
+				Ctx:        context.Background(),
+				IO:         io,
+				Profile:    testProfile(t),
+				Output:     format.New(io),
+				Client:     vs,
+				AppName:    testProfile(t).VaultSecrets.AppName,
+				SecretName: "test_secret",
+			}
 
-// 			if c.AugmentOpts != nil {
-// 				c.AugmentOpts(opts)
-// 			}
+			if c.AugmentOpts != nil {
+				c.AugmentOpts(opts)
+			}
 
-// 			dt := strfmt.NewDateTime()
-// 			if c.MockCalled {
-// 				if c.RespErr {
-// 					vs.EXPECT().CreateAppKVSecret(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
-// 				} else {
-// 					vs.EXPECT().CreateAppKVSecret(&secret_service.CreateAppKVSecretParams{
-// 						LocationOrganizationID: testProfile(t).OrganizationID,
-// 						LocationProjectID:      testProfile(t).ProjectID,
-// 						AppName:                testProfile(t).VaultSecrets.AppName,
-// 						Body: secret_service.CreateAppKVSecretBody{
-// 							Name:  opts.SecretName,
-// 							Value: testSecretValue,
-// 						},
-// 						Context: opts.Ctx,
-// 					}, mock.Anything).Return(&secret_service.CreateAppKVSecretOK{
-// 						Payload: &models.Secrets20230613CreateAppKVSecretResponse{
-// 							Secret: &models.Secrets20230613Secret{
-// 								Name:      opts.SecretName,
-// 								CreatedAt: dt,
-// 								Version: &models.Secrets20230613SecretVersion{
-// 									Version:   "2",
-// 									CreatedAt: dt,
-// 									Type:      "kv",
-// 								},
-// 								LatestVersion: "2",
-// 							},
-// 						},
-// 					}, nil).Once()
-// 				}
-// 			}
+			dt := strfmt.NewDateTime()
+			if c.MockCalled {
+				if c.RespErr {
+					if c.ExpectGetErr {
+						vs.EXPECT().GetAppSecret(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
+					} else {
+						vs.EXPECT().GetAppSecret(&secret_service.GetAppSecretParams{
+							LocationOrganizationID: testProfile(t).OrganizationID,
+							LocationProjectID:      testProfile(t).ProjectID,
+							AppName:                testProfile(t).VaultSecrets.AppName,
+							SecretName:             opts.SecretName,
+							Context:                opts.Ctx,
+						}, mock.Anything).Return(&secret_service.GetAppSecretOK{
+							Payload: &models.Secrets20230613GetAppSecretResponse{
+								Secret: &models.Secrets20230613Secret{
+									Name:          opts.SecretName,
+									LatestVersion: "2",
+									CreatedAt:     strfmt.DateTime(time.Now()),
+								},
+							},
+						}, nil).Once()
+					}
 
-// 			// Run the command
-// 			err := createRun(opts)
-// 			if c.ErrMsg != "" {
-// 				r.Contains(err.Error(), c.ErrMsg)
-// 				return
-// 			}
+					vs.EXPECT().CreateAppKVSecret(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
+				} else {
+					vs.EXPECT().CreateAppKVSecret(&secret_service.CreateAppKVSecretParams{
+						LocationOrganizationID: testProfile(t).OrganizationID,
+						LocationProjectID:      testProfile(t).ProjectID,
+						AppName:                testProfile(t).VaultSecrets.AppName,
+						Body: secret_service.CreateAppKVSecretBody{
+							Name:  opts.SecretName,
+							Value: testSecretValue,
+						},
+						Context: opts.Ctx,
+					}, mock.Anything).Return(&secret_service.CreateAppKVSecretOK{
+						Payload: &models.Secrets20230613CreateAppKVSecretResponse{
+							Secret: &models.Secrets20230613Secret{
+								Name:      opts.SecretName,
+								CreatedAt: dt,
+								Version: &models.Secrets20230613SecretVersion{
+									Version:   "3",
+									CreatedAt: dt,
+									Type:      "kv",
+								},
+								LatestVersion: "3",
+							},
+						},
+					}, nil).Once()
+				}
+			}
 
-// 			r.NoError(err)
-// 			r.Contains(io.Error.String(), fmt.Sprintf("✓ Successfully created secret with name %q\n", opts.SecretName))
-// 		})
-// 	}
-// }
+			// Run the command
+			err := updateRun(opts)
+			if c.ErrMsg != "" {
+				r.Contains(err.Error(), c.ErrMsg)
+				return
+			}
+
+			r.NoError(err)
+			r.Contains(io.Error.String(), fmt.Sprintf("✓ Successfully updated secret with name %q\n", opts.SecretName))
+		})
+	}
+}

--- a/internal/commands/vaultsecrets/secrets/update_test.go
+++ b/internal/commands/vaultsecrets/secrets/update_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package secrets
+
+// import (
+// 	"context"
+// 	"errors"
+// 	"fmt"
+// 	"testing"
+
+// 	"github.com/go-openapi/runtime/client"
+
+// 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+// 	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+// 	"github.com/hashicorp/hcp/internal/pkg/cmd"
+// 	"github.com/hashicorp/hcp/internal/pkg/format"
+// 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+// 	"github.com/hashicorp/hcp/internal/pkg/profile"
+// 	"github.com/stretchr/testify/mock"
+// 	"github.com/stretchr/testify/require"
+// )
+
+// func TestNewCmdUpdate(t *testing.T) {
+// 	t.Parallel()
+
+// 	testProfile := func(t *testing.T) *profile.Profile {
+// 		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+// 		tp.VaultSecrets = &profile.VaultSecretsConf{
+// 			AppName: "test-app",
+// 		}
+// 		return tp
+// 	}
+
+// 	cases := []struct {
+// 		Name    string
+// 		Args    []string
+// 		Profile func(t *testing.T) *profile.Profile
+// 		Error   string
+// 		Expect  *UpdateOpts
+// 	}{
+// 		{
+// 			Name:    "Failed: No secret name arg specified",
+// 			Profile: testProfile,
+// 			Args:    []string{},
+// 			Error:   "ERROR: accepts 1 arg(s), received 0",
+// 		},
+// 		{
+// 			Name:    "Good: Secret name arg specified",
+// 			Profile: testProfile,
+// 			Args:    []string{"test"},
+// 			Expect: &UpdateOpts{
+// 				AppName:    testProfile(t).VaultSecrets.AppName,
+// 				SecretName: "test",
+// 			},
+// 		},
+// 	}
+
+// 	for _, c := range cases {
+// 		c := c
+// 		t.Run(c.Name, func(t *testing.T) {
+// 			t.Parallel()
+// 			r := require.New(t)
+
+// 			// Create a context.
+// 			io := iostreams.Test()
+// 			ctx := &cmd.Context{
+// 				IO:          io,
+// 				Profile:     c.Profile(t),
+// 				Output:      format.New(io),
+// 				HCP:         &client.Runtime{},
+// 				ShutdownCtx: context.Background(),
+// 			}
+
+// 			var gotOpts *UpdateOpts
+// 			deleteCmd := NewCmdUpdate(ctx, func(o *UpdateOpts) error {
+// 				gotOpts = o
+// 				gotOpts.AppName = c.Profile(t).VaultSecrets.AppName
+// 				return nil
+// 			})
+// 			deleteCmd.SetIO(io)
+
+// 			code := deleteCmd.Run(c.Args)
+// 			if c.Error != "" {
+// 				r.NotZero(code)
+// 				r.Contains(io.Error.String(), c.Error)
+// 				return
+// 			}
+
+// 			r.Zero(code, io.Error.String())
+// 			r.NotNil(gotOpts)
+// 			r.Equal(c.Expect.AppName, gotOpts.AppName)
+// 			r.Equal(c.Expect.SecretName, gotOpts.SecretName)
+// 		})
+// 	}
+// }
+
+// func TestUpdateRun(t *testing.T) {
+// 	t.Parallel()
+
+// 	testProfile := func(t *testing.T) *profile.Profile {
+// 		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+// 		tp.VaultSecrets = &profile.VaultSecretsConf{
+// 			AppName: "test-app",
+// 		}
+// 		return tp
+// 	}
+
+// 	cases := []struct {
+// 		Name    string
+// 		RespErr bool
+// 		ErrMsg  string
+// 	}{
+// 		{
+// 			Name:    "Failed: Secret not found",
+// 			RespErr: true,
+// 			ErrMsg:  "[DELETE /secrets/2023-06-13/organizations/{location.organization_id}/projects/{location.project_id}/apps/{app_name}/secrets/{secret_name}][404]UpdateAppSecret default  &{Code:5 Details:[] Message:secret not found}",
+// 		},
+// 		{
+// 			Name:    "Success: Update secret",
+// 			RespErr: false,
+// 		},
+// 	}
+
+// 	for _, c := range cases {
+// 		c := c
+// 		t.Run(c.Name, func(t *testing.T) {
+// 			t.Parallel()
+// 			r := require.New(t)
+
+// 			io := iostreams.Test()
+// 			io.ErrorTTY = true
+// 			vs := mock_secret_service.NewMockClientService(t)
+// 			opts := &UpdateOpts{
+// 				Ctx:        context.Background(),
+// 				IO:         io,
+// 				Profile:    testProfile(t),
+// 				Output:     format.New(io),
+// 				Client:     vs,
+// 				AppName:    testProfile(t).VaultSecrets.AppName,
+// 				SecretName: "test_secret",
+// 			}
+
+// 			if c.RespErr {
+// 				vs.EXPECT().UpdateAppSecret(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
+// 			} else {
+// 				vs.EXPECT().UpdateAppSecret(&secret_service.UpdateAppSecretParams{
+// 					LocationOrganizationID: testProfile(t).OrganizationID,
+// 					LocationProjectID:      testProfile(t).ProjectID,
+// 					AppName:                testProfile(t).VaultSecrets.AppName,
+// 					SecretName:             opts.SecretName,
+// 					Context:                opts.Ctx,
+// 				}, mock.Anything).Return(&secret_service.UpdateAppSecretOK{}, nil).Once()
+// 			}
+
+// 			// Run the command
+// 			err := deleteRun(opts)
+// 			if c.ErrMsg != "" {
+// 				r.Contains(err.Error(), c.ErrMsg)
+// 				return
+// 			}
+
+// 			r.NoError(err)
+// 			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name %q\n", opts.SecretName))
+// 		})
+// 	}
+// }

--- a/internal/commands/vaultsecrets/secrets/update_test.go
+++ b/internal/commands/vaultsecrets/secrets/update_test.go
@@ -137,7 +137,7 @@ func TestUpdateRun(t *testing.T) {
 			ReadViaStdin: true,
 			ExpectGetErr: true,
 			AugmentOpts:  func(o *UpdateOpts) { o.SecretFilePath = "-" },
-			ErrMsg:       "secret not found",
+			ErrMsg:       "[GET] /secrets/2023-06-13/organizations/{location.organization_id}/projects{location.project_id}/apps/{app_name}/secrets/{secret_name}][404] GetAppSecret default  &{Code:5 Details:[] Message:secret not found}",
 		},
 		{
 			Name:             "Success: Update secret via stdin",

--- a/internal/commands/vaultsecrets/secrets/update_test.go
+++ b/internal/commands/vaultsecrets/secrets/update_test.go
@@ -3,97 +3,92 @@
 
 package secrets
 
-// import (
-// 	"context"
-// 	"errors"
-// 	"fmt"
-// 	"testing"
+import (
+	"context"
+	"testing"
 
-// 	"github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/runtime/client"
 
-// 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
-// 	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
-// 	"github.com/hashicorp/hcp/internal/pkg/cmd"
-// 	"github.com/hashicorp/hcp/internal/pkg/format"
-// 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
-// 	"github.com/hashicorp/hcp/internal/pkg/profile"
-// 	"github.com/stretchr/testify/mock"
-// 	"github.com/stretchr/testify/require"
-// )
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/require"
+)
 
-// func TestNewCmdUpdate(t *testing.T) {
-// 	t.Parallel()
+func TestNewCmdUpdate(t *testing.T) {
+	t.Parallel()
 
-// 	testProfile := func(t *testing.T) *profile.Profile {
-// 		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
-// 		tp.VaultSecrets = &profile.VaultSecretsConf{
-// 			AppName: "test-app",
-// 		}
-// 		return tp
-// 	}
+	testProfile := func(t *testing.T) *profile.Profile {
+		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+		tp.VaultSecrets = &profile.VaultSecretsConf{
+			AppName: "test-app",
+		}
+		return tp
+	}
 
-// 	cases := []struct {
-// 		Name    string
-// 		Args    []string
-// 		Profile func(t *testing.T) *profile.Profile
-// 		Error   string
-// 		Expect  *UpdateOpts
-// 	}{
-// 		{
-// 			Name:    "Failed: No secret name arg specified",
-// 			Profile: testProfile,
-// 			Args:    []string{},
-// 			Error:   "ERROR: accepts 1 arg(s), received 0",
-// 		},
-// 		{
-// 			Name:    "Good: Secret name arg specified",
-// 			Profile: testProfile,
-// 			Args:    []string{"test"},
-// 			Expect: &UpdateOpts{
-// 				AppName:    testProfile(t).VaultSecrets.AppName,
-// 				SecretName: "test",
-// 			},
-// 		},
-// 	}
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *UpdateOpts
+	}{
+		{
+			Name:    "Failed: No secret name arg specified",
+			Profile: testProfile,
+			Args:    []string{},
+			Error:   "ERROR: accepts 1 arg(s), received 0",
+		},
+		{
+			Name:    "Good: Secret name arg specified",
+			Profile: testProfile,
+			Args:    []string{"test"},
+			Expect: &UpdateOpts{
+				AppName:    testProfile(t).VaultSecrets.AppName,
+				SecretName: "test",
+			},
+		},
+	}
 
-// 	for _, c := range cases {
-// 		c := c
-// 		t.Run(c.Name, func(t *testing.T) {
-// 			t.Parallel()
-// 			r := require.New(t)
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
 
-// 			// Create a context.
-// 			io := iostreams.Test()
-// 			ctx := &cmd.Context{
-// 				IO:          io,
-// 				Profile:     c.Profile(t),
-// 				Output:      format.New(io),
-// 				HCP:         &client.Runtime{},
-// 				ShutdownCtx: context.Background(),
-// 			}
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
 
-// 			var gotOpts *UpdateOpts
-// 			deleteCmd := NewCmdUpdate(ctx, func(o *UpdateOpts) error {
-// 				gotOpts = o
-// 				gotOpts.AppName = c.Profile(t).VaultSecrets.AppName
-// 				return nil
-// 			})
-// 			deleteCmd.SetIO(io)
+			var gotOpts *UpdateOpts
+			createCmd := NewCmdUpdate(ctx, func(o *UpdateOpts) error {
+				gotOpts = o
+				gotOpts.AppName = "test-app"
+				return nil
+			})
+			createCmd.SetIO(io)
 
-// 			code := deleteCmd.Run(c.Args)
-// 			if c.Error != "" {
-// 				r.NotZero(code)
-// 				r.Contains(io.Error.String(), c.Error)
-// 				return
-// 			}
+			code := createCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
 
-// 			r.Zero(code, io.Error.String())
-// 			r.NotNil(gotOpts)
-// 			r.Equal(c.Expect.AppName, gotOpts.AppName)
-// 			r.Equal(c.Expect.SecretName, gotOpts.SecretName)
-// 		})
-// 	}
-// }
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+			r.Equal(c.Expect.AppName, gotOpts.AppName)
+			r.Equal(c.Expect.SecretName, gotOpts.SecretName)
+		})
+	}
+}
 
 // func TestUpdateRun(t *testing.T) {
 // 	t.Parallel()
@@ -105,20 +100,47 @@ package secrets
 // 		}
 // 		return tp
 // 	}
+// 	testSecretValue := "my super secret value"
 
 // 	cases := []struct {
-// 		Name    string
-// 		RespErr bool
-// 		ErrMsg  string
+// 		Name             string
+// 		RespErr          bool
+// 		ReadViaStdin     bool
+// 		EmptySecretValue bool
+// 		ErrMsg           string
+// 		MockCalled       bool
+// 		AugmentOpts      func(*CreateOpts)
 // 	}{
 // 		{
-// 			Name:    "Failed: Secret not found",
-// 			RespErr: true,
-// 			ErrMsg:  "[DELETE /secrets/2023-06-13/organizations/{location.organization_id}/projects/{location.project_id}/apps/{app_name}/secrets/{secret_name}][404]UpdateAppSecret default  &{Code:5 Details:[] Message:secret not found}",
+// 			Name:   "Failed: Read via stdin as hypen not supplied for --data-file flag",
+// 			ErrMsg: "data file path is required",
 // 		},
 // 		{
-// 			Name:    "Success: Update secret",
-// 			RespErr: false,
+// 			Name:             "Failed: Read empty secret value via stdin",
+// 			EmptySecretValue: true,
+// 			ReadViaStdin:     true,
+// 			RespErr:          true,
+// 			AugmentOpts:      func(o *CreateOpts) { o.SecretFilePath = "-" },
+// 			ErrMsg:           "secret value cannot be empty",
+// 		},
+// 		{
+// 			Name:         "Success: Create secret via stdin",
+// 			ReadViaStdin: true,
+// 			AugmentOpts:  func(o *CreateOpts) { o.SecretFilePath = "-" },
+// 			MockCalled:   true,
+// 		},
+// 		{
+// 			Name:        "Failed: Max secret versions reached",
+// 			RespErr:     true,
+// 			ErrMsg:      "[POST /secrets/2023-11-28/organizations/{organization_id}/projects/{project_id}/apps/{app_name}/secret/kv][429] CreateAppKVSecret default  &{Code:8 Details:[] Message:maximum number of secret versions reached}",
+// 			AugmentOpts: func(o *CreateOpts) { o.SecretValuePlaintext = testSecretValue },
+// 			MockCalled:  true,
+// 		},
+// 		{
+// 			Name:        "Success: Created secret",
+// 			RespErr:     false,
+// 			AugmentOpts: func(o *CreateOpts) { o.SecretValuePlaintext = testSecretValue },
+// 			MockCalled:  true,
 // 		},
 // 	}
 
@@ -129,9 +151,17 @@ package secrets
 // 			r := require.New(t)
 
 // 			io := iostreams.Test()
-// 			io.ErrorTTY = true
+// 			if c.ReadViaStdin {
+// 				io.InputTTY = true
+// 				io.ErrorTTY = true
+
+// 				if !c.EmptySecretValue {
+// 					_, err := io.Input.WriteString(testSecretValue)
+// 					r.NoError(err)
+// 				}
+// 			}
 // 			vs := mock_secret_service.NewMockClientService(t)
-// 			opts := &UpdateOpts{
+// 			opts := &CreateOpts{
 // 				Ctx:        context.Background(),
 // 				IO:         io,
 // 				Profile:    testProfile(t),
@@ -141,27 +171,50 @@ package secrets
 // 				SecretName: "test_secret",
 // 			}
 
-// 			if c.RespErr {
-// 				vs.EXPECT().UpdateAppSecret(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
-// 			} else {
-// 				vs.EXPECT().UpdateAppSecret(&secret_service.UpdateAppSecretParams{
-// 					LocationOrganizationID: testProfile(t).OrganizationID,
-// 					LocationProjectID:      testProfile(t).ProjectID,
-// 					AppName:                testProfile(t).VaultSecrets.AppName,
-// 					SecretName:             opts.SecretName,
-// 					Context:                opts.Ctx,
-// 				}, mock.Anything).Return(&secret_service.UpdateAppSecretOK{}, nil).Once()
+// 			if c.AugmentOpts != nil {
+// 				c.AugmentOpts(opts)
+// 			}
+
+// 			dt := strfmt.NewDateTime()
+// 			if c.MockCalled {
+// 				if c.RespErr {
+// 					vs.EXPECT().CreateAppKVSecret(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
+// 				} else {
+// 					vs.EXPECT().CreateAppKVSecret(&secret_service.CreateAppKVSecretParams{
+// 						LocationOrganizationID: testProfile(t).OrganizationID,
+// 						LocationProjectID:      testProfile(t).ProjectID,
+// 						AppName:                testProfile(t).VaultSecrets.AppName,
+// 						Body: secret_service.CreateAppKVSecretBody{
+// 							Name:  opts.SecretName,
+// 							Value: testSecretValue,
+// 						},
+// 						Context: opts.Ctx,
+// 					}, mock.Anything).Return(&secret_service.CreateAppKVSecretOK{
+// 						Payload: &models.Secrets20230613CreateAppKVSecretResponse{
+// 							Secret: &models.Secrets20230613Secret{
+// 								Name:      opts.SecretName,
+// 								CreatedAt: dt,
+// 								Version: &models.Secrets20230613SecretVersion{
+// 									Version:   "2",
+// 									CreatedAt: dt,
+// 									Type:      "kv",
+// 								},
+// 								LatestVersion: "2",
+// 							},
+// 						},
+// 					}, nil).Once()
+// 				}
 // 			}
 
 // 			// Run the command
-// 			err := deleteRun(opts)
+// 			err := createRun(opts)
 // 			if c.ErrMsg != "" {
 // 				r.Contains(err.Error(), c.ErrMsg)
 // 				return
 // 			}
 
 // 			r.NoError(err)
-// 			r.Equal(io.Error.String(), fmt.Sprintf("✓ Successfully deleted secret with name %q\n", opts.SecretName))
+// 			r.Contains(io.Error.String(), fmt.Sprintf("✓ Successfully created secret with name %q\n", opts.SecretName))
 // 		})
 // 	}
 // }


### PR DESCRIPTION
### Changes proposed in this PR:

This PR adds the `hcp vault-secrets secrets update` command to the `hcp` CLI. 

### How I've tested this PR:
- [x] locally ran the binary to versions a HVS secret
```
> make go/build && ./bin/hcp vault-secrets secrets update -h
USAGE
  hcp vault-secrets secrets update NAME [Optional Flags]

DESCRIPTION
  The hcp vault-secrets secrets update command updates a static secret under an
  Vault Secrets application.

EXAMPLES
  Update a new secret in Vault Secrets application on active profile:
  
  $ hcp vault-secrets secrets update secret_1 --data-file=tmp/secrets1.txt
  
  Update a new secret in Vault Secrets application by piping the plaintext secret
  from a command output:
  
  $ echo -n "my super secret" | hcp vault-secrets secrets update secret_2 --data-file=-
  
  Update a new secret in the specified Vault Secrets application:
  
  $ hcp vault-secrets secrets update secret_3 --app test-app --secret_file=/tmp/secrets2.txt

POSITIONAL ARGUMENTS
  NAME
    The name of the secret to update.

FLAGS
  --data-file=DATA_FILE_PATH
    File path to read secret data from. Set this to '-' to read the secret data from
    stdin.

INHERITED FLAGS
  -a, --app=NAME
    The name of the Vault Secrets application. If not specified, the value from the
    active profile will be used.

GLOBAL FLAGS

> make go/build && echo "temp" | ./bin/hcp vault-secrets secrets update no_found --data-file=-
ERROR: secret with name "no_found" not found: [GET
/secrets/2023-06-13/organizations/{location.organization_id}/projects/{location.project_id}/apps/{app_name}/secrets/{secret_name}][404]
GetAppSecret default  &{Code:5 Details:[] Message:secret not found}

> make go/build &&  ./bin/hcp vault-secrets secrets update test_secret --data-file ../secret_data_file
Secret Name  Latest Version  Created At                
test_secret  4               2024-05-17T17:12:08.096Z  

✓ Successfully updated secret with name "test_secret"

To read your secret, run:
  $ hcp vault-secrets secrets read test_secret --app test-gs

> make go/build &&  ./bin/hcp vault-secrets secrets update test_secret --data-file ../secret_data_file --quiet
Secret Name  Latest Version  Created At                
test_secret  5               2024-05-17T17:12:08.096Z  
```

- [x] Unit test

### How I expect reviewers to test this PR:
```
$ make go/build 
$ ./bin/hcp auth login 
$ ./bin/hcp profile init --vault-secrets
$ ./bin/hcp vault-secrets secrets update
```

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
