### PR TITLE
VAULT-26817 - Implements vault-secrets app updates

### DIFF
--- a/internal/commands/vaultsecrets/apps/apps.go
+++ b/internal/commands/vaultsecrets/apps/apps.go
@@ -25,5 +25,6 @@ func NewCmdApps(ctx *cmd.Context) *cmd.Command {
 	cmd.AddChild(NewCmdDelete(ctx, nil))
 	cmd.AddChild(NewCmdRead(ctx, nil))
 	cmd.AddChild(NewCmdList(ctx, nil))
+	cmd.AddChild(NewCmdUpdate(ctx, nil))
 	return cmd
 }

--- a/internal/commands/vaultsecrets/apps/update_test.go
+++ b/internal/commands/vaultsecrets/apps/update_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package apps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/models"
+	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func TestNewCmdUpdate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *UpdateOpts
+	}{
+		{
+			Name: "Good",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args: []string{"company-card", "--description", "Stores corporate card info."},
+			Expect: &UpdateOpts{
+				AppName:     "company-card",
+				Description: "Stores corporate card info.",
+			},
+		},
+		{
+			Name: "No description",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args:  []string{"company-card"},
+			Error: "ERROR: missing required flag: --description=DESCRIPTION",
+		},
+		{
+			Name: "No app name",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args:  []string{"--description", "Stores corporate card info."},
+			Error: "accepts 1 arg(s), received 0",
+		},
+		{
+			Name: "Too many args",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args:  []string{"company-card", "additional-arg", "--description", "Stores corporate card info."},
+			Error: "ERROR: accepts 1 arg(s), received 2",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+
+			r := require.New(t)
+			io := iostreams.Test()
+
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				ShutdownCtx: context.Background(),
+				HCP:         &client.Runtime{},
+				Output:      format.New(io),
+			}
+
+			var updateOpts *UpdateOpts
+			updateCmd := NewCmdUpdate(ctx, func(o *UpdateOpts) error {
+				updateOpts = o
+				return nil
+			})
+			updateCmd.SetIO(io)
+
+			code := updateCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(updateOpts)
+			r.Equal(c.Expect.AppName, updateOpts.AppName)
+			r.Equal(c.Expect.Description, updateOpts.Description)
+		})
+	}
+}
+
+func TestUpdateRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name           string
+		AppName        string
+		AppDescription string
+		Error          string
+	}{
+		{
+			Name:           "Good",
+			AppName:        "company-card",
+			AppDescription: "Stores corporate card info.",
+		},
+		{
+			Name:           "Missing app name",
+			AppDescription: "Stores corporate card info.",
+			Error:          "missing required app name",
+		},
+		{
+			Name:    "Missing description",
+			AppName: "company-card",
+			Error:   "missing required description",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			vs := mock_secret_service.NewMockClientService(t)
+
+			opts := &UpdateOpts{
+				Ctx:         context.Background(),
+				Profile:     profile.TestProfile(t).SetOrgID("123").SetProjectID("abc"),
+				IO:          io,
+				Client:      vs,
+				Output:      format.New(io),
+				AppName:     c.AppName,
+				Description: c.AppDescription,
+			}
+
+			if c.Error != "" {
+				vs.EXPECT().UpdateApp(mock.Anything, mock.Anything).Return(nil, errors.New(c.Error)).Once()
+			} else {
+				vs.EXPECT().UpdateApp(&secret_service.UpdateAppParams{
+					Context:                opts.Ctx,
+					LocationOrganizationID: "123",
+					LocationProjectID:      "abc",
+					Name:                   opts.AppName,
+					Body: secret_service.UpdateAppBody{
+						Description: opts.Description,
+					},
+				}, nil).Return(&secret_service.UpdateAppOK{
+					Payload: &models.Secrets20230613UpdateAppResponse{
+						App: &models.Secrets20230613App{
+							Name:        opts.AppName,
+							Description: opts.Description,
+						},
+					},
+				}, nil).Once()
+			}
+
+			// Run the command
+			err := updateRun(opts)
+			if c.Error != "" {
+				r.ErrorContains(err, c.Error)
+				return
+			}
+
+			r.NoError(err)
+			r.Contains(io.Error.String(), fmt.Sprintf("✓ Successfully updated application with name %q\n", opts.AppName))
+		})
+	}
+}

--- a/internal/commands/vaultsecrets/apps/updates.go
+++ b/internal/commands/vaultsecrets/apps/updates.go
@@ -1,0 +1,106 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package apps
+
+import (
+	"context"
+	"fmt"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+type UpdateOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	Output  *format.Outputter
+	IO      iostreams.IOStreams
+
+	AppName       string
+	Description   string
+	Client        secret_service.ClientService
+	PreviewClient preview_secret_service.ClientService
+}
+
+func NewCmdUpdate(ctx *cmd.Context, runF func(*UpdateOpts) error) *cmd.Command {
+	opts := &UpdateOpts{
+		Ctx:           ctx.ShutdownCtx,
+		Profile:       ctx.Profile,
+		Output:        ctx.Output,
+		IO:            ctx.IO,
+		Client:        secret_service.New(ctx.HCP, nil),
+		PreviewClient: preview_secret_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "update",
+		ShortHelp: "Update a Vault Secrets application.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets apps update" }} command updates the description of a Vault Secrets application.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: `Update an application:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp vault-secrets apps update company-card --description "Visa card info"
+				`),
+			},
+		},
+		Args: cmd.PositionalArguments{
+			Args: []cmd.PositionalArgument{
+				{
+					Name:          "NAME",
+					Documentation: "The name of the app to update.",
+					Optional:      false,
+				},
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "description",
+					DisplayValue: "DESCRIPTION",
+					Description:  "The updated app description.",
+					Value:        flagvalue.Simple("", &opts.Description),
+					Required:     true,
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			opts.AppName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return updateRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+func updateRun(opts *UpdateOpts) error {
+	_, err := opts.Client.UpdateApp(&secret_service.UpdateAppParams{
+		Context:                opts.Ctx,
+		LocationProjectID:      opts.Profile.ProjectID,
+		Name:                   opts.AppName,
+		LocationOrganizationID: opts.Profile.OrganizationID,
+		Body: secret_service.UpdateAppBody{
+			Description: opts.Description,
+		},
+	}, nil)
+
+	if err != nil {
+		return fmt.Errorf("failed to update application: %w", err)
+	}
+
+	fmt.Fprintf(opts.IO.Err(), "%s Successfully updated application with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.AppName)
+	return nil
+}

--- a/internal/commands/vaultsecrets/apps/updates.go
+++ b/internal/commands/vaultsecrets/apps/updates.go
@@ -58,7 +58,6 @@ func NewCmdUpdate(ctx *cmd.Context, runF func(*UpdateOpts) error) *cmd.Command {
 				{
 					Name:          "NAME",
 					Documentation: "The name of the app to update.",
-					Optional:      false,
 				},
 			},
 		},


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds the hcp vault-secrets apps list command to the hcp CLI for ticket https://hashicorp.atlassian.net/browse/VAULT-26817

### How I've tested this PR:
Ran `make go/build` to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Create an app using `./bin/hcp vault-secrets apps create {YOUR_APP_NAME} --description "original description"`
4. Update the app using `./bin/hcp vault-secrets apps update {YOUR_APP_NAME} --description "updated description"`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
<img width="825" alt="Screenshot 2024-05-20 at 3 19 28 PM" src="https://github.com/hashicorp/hcp/assets/19840012/d6548fe4-2a58-4bc0-98b9-789a64d0a329">


### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
