### PR TITLE
Drop the short hand for --app flag as it is not supported well

### DIFF
--- a/internal/commands/vaultsecrets/secrets/secrets.go
+++ b/internal/commands/vaultsecrets/secrets/secrets.go
@@ -27,7 +27,6 @@ func NewCmdSecrets(ctx *cmd.Context) *cmd.Command {
 					Name:         "app",
 					DisplayValue: "NAME",
 					Description:  "The name of the Vault Secrets application. If not specified, the value from the active profile will be used.",
-					Shorthand:    "a",
 					Value:        appname.Flag(),
 				},
 			},


### PR DESCRIPTION
### Changes proposed in this PR:

This PR removes the shorthand for the `--app` flag due to the error mentioned [here](https://github.com/spf13/pflag/issues/314).

```
hcp vs secrets --app=foo list -> AppName: "foo"
hcp vs secrets -a foo list    -> AppName: "foo"
hcp vs secrets -afoo list     -> AppName: "foo"
hcp vs secrets -app=foo list  -> AppName: "pp=foo"
```
### How I've tested this PR:
Existing test suite is sufficient here.

### How I expect reviewers to test this PR:
```
$ make go/build
$ ./bin/hcp vs s read test -a="" should not work
$ /bin/hcp vs s read test --app="" should not work
```

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
