### PR TITLE
Add surfaces team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Individual command groups will be owned by product teams but the overall CLI
 # will be owned as follows.
-* @dadgar
+* @dadgar @hashicorp/cloud-core-platform-surfaces
 
 # Files that all teams can contribute to
 .changelog


### PR DESCRIPTION
### Changes proposed in this PR:

Adds `@hashicorp/cloud-core-platform-surfaces` to the wildcard codeowners.


<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
