### PR TITLE
HCPCP-1615: upgrade hashicorp owned actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@v1
+        uses: hashicorp/actions-docker-build@v2
         with:
           smoke_test: |
             TEST_VERSION="$(docker run "${IMAGE_NAME}" hcp version | awk '/hcp v/{print $2}')"


### PR DESCRIPTION
### Changes proposed in this PR:

This upgrades any of the hashicorp owned actions that were giving warnings about Node 16.

<img width="1128" alt="Screenshot 2024-05-24 at 1 42 09 PM" src="https://github.com/hashicorp/hcp/assets/5448834/34344cb5-d65b-4e03-bf6c-a0c5dcf87971">

[HCPCP-1615](https://hashicorp.atlassian.net/browse/HCPCP-1615)

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)


[HCPCP-1615]: https://hashicorp.atlassian.net/browse/HCPCP-1615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ