### PR TITLE
Fix panic displaying invoked command

### DIFF
--- a/.changelog/98.txt
+++ b/.changelog/98.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix rare panic that could occur on authentication error when running a command that had quoted arguments.
+```

--- a/internal/pkg/cmd/command_internal_test.go
+++ b/internal/pkg/cmd/command_internal_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthErrorHelp(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	io := iostreams.Test()
+
+	commandPath := "hcp example"
+	args := []string{"simple", "'single-quote'", `escaped \"inner\"`}
+
+	// Get the help text
+	helpText := authErrorHelp(io, commandPath, args)
+	r.Contains(helpText, `$ hcp example simple 'single-quote' "escaped \\\"inner\\\""`)
+}


### PR DESCRIPTION
### Changes proposed in this PR:
When the command recieves an error because the authentication token expired and wasn't able to be refreshed, we display a help error informing the user to logout, login, and re-run the command.

A panic was occuring if the previous command had escaped quoted inputs, since the string was being directly added to a template that itself had quotes. This was causing the template string to become invalid, and then rendering the template would error.

This commit causes the command to be properly escaped before it is injected into the template.

### How I've tested this PR:
Added a test that failed before the change, and now works. Also caused the new error message to be displayed for every command being run to verify no more panics.

### How I expect reviewers to test this PR:
Does the code logic look correct.

### Checklist:
- [X] Tests added if applicable
- [X] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
