### PR TITLE
Add support for login via creds file to non-prod envs

### DIFF
--- a/internal/commands/auth/login.go
+++ b/internal/commands/auth/login.go
@@ -178,7 +178,7 @@ func loginRun(opts *LoginOpts) error {
 	var storeCredFile bool
 	options := []hcpconf.HCPConfigOption{hcpconf.WithoutLogging()}
 	if opts.CredentialFile != "" {
-		options = append(options, hcpconf.WithCredentialFilePath(opts.CredentialFile))
+		options = append(options, hcpconf.FromEnv(), hcpconf.WithCredentialFilePath(opts.CredentialFile))
 		storeCredFile = true
 	} else if opts.ClientID != "" {
 		options = append(options, hcpconf.WithClientCredentials(opts.ClientID, opts.ClientSecret))


### PR DESCRIPTION
### Changes proposed in this PR:

If a credentials file is used for login, the env vars were ignored, making it impossible to test in e.g. a PRDE.  Add a call to FromEnv when using creds file.

### How I've tested this PR:

I was trying to test logging in using WIF, and it wasn't finding my WIF provider resource.  Debugging revealed it was connecting to the prod hcp, even when I set the appropriate env vars.  After I made this change and rebuilt, the resource in my PRDE was found and I was able to complete the login to my PRDE using a creds file.

### How I expect reviewers to test this PR:

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
