### PR TITLE
Actions/Agents: Remove commands from release

### DIFF
--- a/.changelog/100.txt
+++ b/.changelog/100.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+Removing waypoint actions and agents sub-command
+```

--- a/internal/commands/waypoint/waypoint.go
+++ b/internal/commands/waypoint/waypoint.go
@@ -4,9 +4,7 @@
 package waypoint
 
 import (
-	"github.com/hashicorp/hcp/internal/commands/waypoint/actions"
 	addon "github.com/hashicorp/hcp/internal/commands/waypoint/add-ons"
-	"github.com/hashicorp/hcp/internal/commands/waypoint/agent"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/applications"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/templates"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/tfcconfig"
@@ -17,7 +15,7 @@ import (
 func NewCmdWaypoint(ctx *cmd.Context) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "waypoint",
-		ShortHelp: "Manage Waypoint.",
+		ShortHelp: "Manage HCP Waypoint.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp waypoint" }} command group lets you
 		manage HCP Waypoint resources through the CLI. These commands let you to interact
@@ -26,8 +24,9 @@ func NewCmdWaypoint(ctx *cmd.Context) *cmd.Command {
 	}
 
 	cmd.AddChild(tfcconfig.NewCmdTFCConfig(ctx))
-	cmd.AddChild(actions.NewCmdActionConfig(ctx))
-	cmd.AddChild(agent.NewCmdAgent(ctx))
+	// TODO: Enable later
+	// cmd.AddChild(actions.NewCmdActionConfig(ctx))
+	// cmd.AddChild(agent.NewCmdAgent(ctx))
 	cmd.AddChild(templates.NewCmdTemplate(ctx))
 	cmd.AddChild(addon.NewCmdAddOn(ctx))
 	cmd.AddChild(applications.NewCmdApplications(ctx))


### PR DESCRIPTION
### Changes proposed in this PR:

Disabling the HCP Actions CLI for now

### How I've tested this PR:

Built the CLI and ran `-help` to show sub-commands no longer in built cli.

### How I expect reviewers to test this PR:


<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
