### PR TITLE
Add sentinel error that can set command exit code

### DIFF
--- a/internal/pkg/cmd/command.go
+++ b/internal/pkg/cmd/command.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -290,3 +291,29 @@ func (c *Command) Logger() hclog.Logger {
 	c.logger = hclog.New(logOpt)
 	return c.logger
 }
+
+// ExitCodeError is an error that includes an exit code. If returned by a
+// command run, the command will exit using the specified exit code.
+type ExitCodeError struct {
+	Err  error
+	Code int
+}
+
+// NewExitError returns an ExitCodError. This can be returned to have the
+// command exit code be set to a specific value.
+func NewExitError(code int, wrapErr error) error {
+	return &ExitCodeError{
+		Err:  wrapErr,
+		Code: code,
+	}
+}
+
+func (e *ExitCodeError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("exit code %d: %v", e.Code, e.Err)
+	}
+
+	return fmt.Sprintf("exit code %d", e.Code)
+}
+
+func (e *ExitCodeError) Unwrap() error { return e.Err }

--- a/internal/pkg/cmd/command_internal.go
+++ b/internal/pkg/cmd/command_internal.go
@@ -100,7 +100,9 @@ func (c *Command) Run(args []string) int {
 
 	// Run the command
 	if err := c.RunF(c, parsedArgs); err != nil {
+		exitCode := 1
 		var runtimeErr runtime.ClientResponseStatus
+		var exitCodeErr *ExitCodeError
 		if errors.Is(err, ErrDisplayHelp) {
 			return cli.RunResultHelp
 		} else if errors.Is(err, ErrDisplayUsage) {
@@ -110,10 +112,12 @@ func (c *Command) Run(args []string) int {
 			// Request failed because of authentication issues.
 			fmt.Fprintf(io.Err(), "%s %s\n\n", cs.ErrorLabel(), authErrorHelp(io, c.commandPath(), args))
 			return 1
+		} else if errors.As(err, &exitCodeErr) {
+			exitCode = exitCodeErr.Code
 		}
 
 		fmt.Fprintf(io.Err(), "%s %s\n", cs.ErrorLabel(), wordWrap(err.Error(), 120))
-		return 1
+		return exitCode
 	}
 
 	return 0

--- a/internal/pkg/cmd/command_test.go
+++ b/internal/pkg/cmd/command_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
@@ -110,4 +111,23 @@ func TestCommand_Logger(t *testing.T) {
 	root.AddChild(child)
 	r.Zero(child.Run([]string{}))
 	r.Contains(io.Error.String(), "hcp.child: hello, world!")
+}
+
+func TestCommand_ExitCode(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	// Create the command tree
+	io := iostreams.Test()
+	code := 42
+	err := fmt.Errorf("bad bad bad")
+	root := &Command{
+		Name: "root",
+		io:   io,
+		RunF: func(c *Command, args []string) error {
+			return NewExitError(code, err)
+		},
+	}
+	r.Equal(code, root.Run([]string{}))
+	r.Contains(io.Error.String(), err.Error())
 }


### PR DESCRIPTION
### Changes proposed in this PR:
Add sentinel error that can set command exit code

### How I've tested this PR:
Added unit test

### How I expect reviewers to test this PR:
Review code 

### Checklist:
- [X] Tests added if applicable
- [X] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
