### PR TITLE
Add IAM updater and read-policy for IAM Groups

### DIFF
--- a/internal/commands/iam/groups/groups.go
+++ b/internal/commands/iam/groups/groups.go
@@ -4,6 +4,7 @@
 package groups
 
 import (
+	"github.com/hashicorp/hcp/internal/commands/iam/groups/iam"
 	"github.com/hashicorp/hcp/internal/commands/iam/groups/members"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -30,5 +31,6 @@ func NewCmdGroups(ctx *cmd.Context) *cmd.Command {
 	cmd.AddChild(NewCmdDelete(ctx, nil))
 	cmd.AddChild(NewCmdUpdate(ctx, nil))
 	cmd.AddChild(members.NewCmdMembers(ctx))
+	cmd.AddChild(iam.NewCmdIAM(ctx))
 	return cmd
 }

--- a/internal/commands/iam/groups/helper/groups.go
+++ b/internal/commands/iam/groups/helper/groups.go
@@ -68,19 +68,6 @@ func PredictGroupResourceNameSuffix(ctx context.Context, orgID string, client gr
 	}
 }
 
-// GetResourceIDFromResourceName retrieves the resource name from a group ID.
-func GetResourceIDFromResourceName(ctx context.Context, resourceName string, client groups_service.ClientService) (string, error) {
-	req := groups_service.NewGroupsServiceGetGroupParamsWithContext(ctx)
-	req.ResourceName = resourceName
-
-	resp, err := client.GroupsServiceGetGroup(req, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to get group: %w", err)
-	}
-
-	return resp.Payload.Group.ResourceID, nil
-}
-
 // GetGroups retrieves the groups in the organization.
 func GetGroups(ctx context.Context, orgID string, client groups_service.ClientService) ([]*models.HashicorpCloudIamGroup, error) {
 	req := groups_service.NewGroupsServiceListGroupsParamsWithContext(ctx)

--- a/internal/commands/iam/groups/helper/groups.go
+++ b/internal/commands/iam/groups/helper/groups.go
@@ -68,6 +68,19 @@ func PredictGroupResourceNameSuffix(ctx context.Context, orgID string, client gr
 	}
 }
 
+// GetResourceIDFromResourceName retrieves the resource name from a group ID.
+func GetResourceIDFromResourceName(ctx context.Context, resourceName string, client groups_service.ClientService) (string, error) {
+	req := groups_service.NewGroupsServiceGetGroupParamsWithContext(ctx)
+	req.ResourceName = resourceName
+
+	resp, err := client.GroupsServiceGetGroup(req, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get group: %w", err)
+	}
+
+	return resp.Payload.Group.ResourceID, nil
+}
+
 // GetGroups retrieves the groups in the organization.
 func GetGroups(ctx context.Context, orgID string, client groups_service.ClientService) ([]*models.HashicorpCloudIamGroup, error) {
 	req := groups_service.NewGroupsServiceListGroupsParamsWithContext(ctx)

--- a/internal/commands/iam/groups/iam/iam.go
+++ b/internal/commands/iam/groups/iam/iam.go
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+)
+
+func NewCmdIAM(ctx *cmd.Context) *cmd.Command {
+	cmd := &cmd.Command{
+		Name:      "iam",
+		ShortHelp: "Manage a group's IAM policy.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp iam groups iam" }} command group lets you
+		manage a group's IAM Policy.
+		`),
+	}
+
+	// TODO: Uncomment as subcommands are added
+	// cmd.AddChild(NewCmdAddBinding(ctx, nil))
+	// cmd.AddChild(NewCmdDeleteBinding(ctx, nil))
+	cmd.AddChild(NewCmdReadPolicy(ctx, nil))
+	// cmd.AddChild(NewCmdSetPolicy(ctx, nil))
+	return cmd
+}

--- a/internal/commands/iam/groups/iam/read_policy.go
+++ b/internal/commands/iam/groups/iam/read_policy.go
@@ -1,0 +1,119 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/groups_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/iam_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/resource_service"
+	"github.com/hashicorp/hcp/internal/commands/iam/groups/helper"
+	"github.com/hashicorp/hcp/internal/pkg/api/iampolicy"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func NewCmdReadPolicy(ctx *cmd.Context, runF func(*ReadPolicyOpts) error) *cmd.Command {
+	opts := &ReadPolicyOpts{
+		Ctx:            ctx.ShutdownCtx,
+		Profile:        ctx.Profile,
+		IO:             ctx.IO,
+		Output:         ctx.Output,
+		ResourceClient: resource_service.New(ctx.HCP, nil),
+		GroupsClient:   groups_service.New(ctx.HCP, nil),
+		IAMClient:      iam_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "read-policy",
+		ShortHelp: "Read the IAM policy for a group.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp iam groups iam read-policy" }} command reads the IAM policy for a group.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: "Read the IAM Policy for a group:",
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp iam groups iam read-policy \
+				  --group=iam/organization/cf8ef907-b9b9-4f2f-b675-e290448f0000/group/Group-Name
+				`),
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "group",
+					Shorthand:    "g",
+					DisplayValue: "NAME",
+					Description:  heredoc.New(ctx.IO).Mustf(helper.GroupNameArgDoc, "read the IAM policy for"),
+					Value:        flagvalue.Simple("", &opts.GroupName),
+					Autocomplete: helper.PredictGroupResourceNameSuffix(opts.Ctx, opts.Profile.OrganizationID, opts.GroupsClient),
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			if opts.GroupName == "" {
+				return fmt.Errorf("a group resource name must be specified")
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return readPolicyRun(opts)
+		},
+		PersistentPreRun: func(c *cmd.Command, args []string) error {
+			return cmd.RequireOrgAndProject(ctx)
+		},
+	}
+
+	return cmd
+}
+
+type ReadPolicyOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	IO      iostreams.IOStreams
+	Output  *format.Outputter
+
+	GroupName      string
+	ResourceClient resource_service.ClientService
+	GroupsClient   groups_service.ClientService
+	IAMClient      iam_service.ClientService
+}
+
+func readPolicyRun(opts *ReadPolicyOpts) error {
+	resourceName := helper.ResourceName(opts.GroupName, opts.Profile.OrganizationID)
+
+	resourceID, err := helper.GetResourceIDFromResourceName(opts.Ctx, resourceName, opts.GroupsClient)
+	if err != nil {
+		return err
+	}
+
+	// Create our group IAM Updater
+	u := &iamUpdater{
+		groupID: resourceID,
+		client:  opts.ResourceClient,
+	}
+
+	// Get the existing policy
+	p, err := u.GetIamPolicy(opts.Ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get the displayer
+	d, err := iampolicy.NewDisplayer(opts.Ctx, opts.Profile.OrganizationID, p, opts.IAMClient)
+	if err != nil {
+		return err
+	}
+
+	return opts.Output.Display(d)
+}

--- a/internal/commands/iam/groups/iam/read_policy.go
+++ b/internal/commands/iam/groups/iam/read_policy.go
@@ -70,7 +70,7 @@ func NewCmdReadPolicy(ctx *cmd.Context, runF func(*ReadPolicyOpts) error) *cmd.C
 			return readPolicyRun(opts)
 		},
 		PersistentPreRun: func(c *cmd.Command, args []string) error {
-			return cmd.RequireOrgAndProject(ctx)
+			return cmd.RequireOrganization(ctx)
 		},
 	}
 
@@ -92,15 +92,10 @@ type ReadPolicyOpts struct {
 func readPolicyRun(opts *ReadPolicyOpts) error {
 	resourceName := helper.ResourceName(opts.GroupName, opts.Profile.OrganizationID)
 
-	resourceID, err := helper.GetResourceIDFromResourceName(opts.Ctx, resourceName, opts.GroupsClient)
-	if err != nil {
-		return err
-	}
-
-	// Create our group IAM Updater
+	// Create the group IAM Updater
 	u := &iamUpdater{
-		groupID: resourceID,
-		client:  opts.ResourceClient,
+		resourceName: resourceName,
+		client:       opts.ResourceClient,
 	}
 
 	// Get the existing policy

--- a/internal/commands/iam/groups/iam/read_policy_test.go
+++ b/internal/commands/iam/groups/iam/read_policy_test.go
@@ -38,7 +38,7 @@ func TestNewCmdReadBinding(t *testing.T) {
 			Error: "no arguments allowed, but received 2",
 		},
 		{
-			Name: "No Group Specific",
+			Name: "No Group Specified",
 			Profile: func(t *testing.T) *profile.Profile {
 				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
 			},

--- a/internal/commands/iam/groups/iam/read_policy_test.go
+++ b/internal/commands/iam/groups/iam/read_policy_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdReadBinding(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+	}{
+		{
+			Name:    "No Org",
+			Profile: profile.TestProfile,
+			Error:   "Organization ID and Project ID must be configured",
+		},
+		{
+			Name: "No Project passed/profile",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Error: "Organization ID and Project ID must be configured",
+		},
+		{
+			Name: "Too many args",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args:  []string{"foo", "bar"},
+			Error: "no arguments allowed, but received 2",
+		},
+		{
+			Name: "No Group Specific",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Error: "ERROR: a group resource name must be specified",
+		},
+		{
+			Name: "Good full resource name",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args: []string{"-g=iam/organization/123/group/456"},
+		},
+		{
+			Name: "Good suffix resource name",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args: []string{"-g=456"},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts *ReadPolicyOpts
+			readCmd := NewCmdReadPolicy(ctx, func(o *ReadPolicyOpts) error {
+				gotOpts = o
+				return nil
+			})
+			readCmd.SetIO(io)
+
+			code := readCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+		})
+	}
+}

--- a/internal/commands/iam/groups/iam/read_policy_test.go
+++ b/internal/commands/iam/groups/iam/read_policy_test.go
@@ -27,14 +27,7 @@ func TestNewCmdReadBinding(t *testing.T) {
 		{
 			Name:    "No Org",
 			Profile: profile.TestProfile,
-			Error:   "Organization ID and Project ID must be configured",
-		},
-		{
-			Name: "No Project passed/profile",
-			Profile: func(t *testing.T) *profile.Profile {
-				return profile.TestProfile(t).SetOrgID("123")
-			},
-			Error: "Organization ID and Project ID must be configured",
+			Error:   "Organization ID must be configured",
 		},
 		{
 			Name: "Too many args",

--- a/internal/commands/iam/groups/iam/updater.go
+++ b/internal/commands/iam/groups/iam/updater.go
@@ -22,6 +22,7 @@ type iamUpdater struct {
 func (u *iamUpdater) GetIamPolicy(ctx context.Context) (*models.HashicorpCloudResourcemanagerPolicy, error) {
 	params := resource_service.NewResourceServiceGetIamPolicyParams()
 	params.ResourceName = &u.resourceName
+
 	res, err := u.client.ResourceServiceGetIamPolicy(params, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve group IAM policy: %w", err)
@@ -32,8 +33,10 @@ func (u *iamUpdater) GetIamPolicy(ctx context.Context) (*models.HashicorpCloudRe
 
 func (u *iamUpdater) SetIamPolicy(ctx context.Context, policy *models.HashicorpCloudResourcemanagerPolicy) (*models.HashicorpCloudResourcemanagerPolicy, error) {
 	params := resource_service.NewResourceServiceSetIamPolicyParams()
-	params.Body.ResourceName = u.resourceName
-	params.Body.Policy = policy
+	params.Body = &models.HashicorpCloudResourcemanagerResourceSetIamPolicyRequest{
+		ResourceName: u.resourceName,
+		Policy:       policy,
+	}
 
 	res, err := u.client.ResourceServiceSetIamPolicy(params, nil)
 	if err != nil {

--- a/internal/commands/iam/groups/iam/updater.go
+++ b/internal/commands/iam/groups/iam/updater.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/resource_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
+	"github.com/hashicorp/hcp/internal/pkg/api/iampolicy"
+)
+
+// iamUpdater meets the iampolicy.ResourceUpdater interface. It is used to
+// manage IAM bindings.
+type iamUpdater struct {
+	groupID string
+	client  resource_service.ClientService
+}
+
+func (u *iamUpdater) GetIamPolicy(ctx context.Context) (*models.HashicorpCloudResourcemanagerPolicy, error) {
+	params := resource_service.NewResourceServiceGetIamPolicyParams()
+	params.ResourceID = &u.groupID
+	res, err := u.client.ResourceServiceGetIamPolicy(params, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve group IAM policy: %w", err)
+	}
+
+	return res.GetPayload().Policy, nil
+}
+
+func (u *iamUpdater) SetIamPolicy(ctx context.Context, policy *models.HashicorpCloudResourcemanagerPolicy) (*models.HashicorpCloudResourcemanagerPolicy, error) {
+	params := resource_service.NewResourceServiceSetIamPolicyParams()
+	params.Body.ResourceID = u.groupID
+	params.Body.Policy = policy
+
+	res, err := u.client.ResourceServiceSetIamPolicy(params, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set group IAM policy: %w", err)
+	}
+
+	return res.GetPayload().Policy, nil
+}
+
+// Ensure we meet the interface.
+var _ iampolicy.ResourceUpdater = &iamUpdater{}

--- a/internal/commands/iam/groups/iam/updater.go
+++ b/internal/commands/iam/groups/iam/updater.go
@@ -15,13 +15,13 @@ import (
 // iamUpdater meets the iampolicy.ResourceUpdater interface. It is used to
 // manage IAM bindings.
 type iamUpdater struct {
-	groupID string
-	client  resource_service.ClientService
+	resourceName string
+	client       resource_service.ClientService
 }
 
 func (u *iamUpdater) GetIamPolicy(ctx context.Context) (*models.HashicorpCloudResourcemanagerPolicy, error) {
 	params := resource_service.NewResourceServiceGetIamPolicyParams()
-	params.ResourceID = &u.groupID
+	params.ResourceName = &u.resourceName
 	res, err := u.client.ResourceServiceGetIamPolicy(params, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve group IAM policy: %w", err)
@@ -32,7 +32,7 @@ func (u *iamUpdater) GetIamPolicy(ctx context.Context) (*models.HashicorpCloudRe
 
 func (u *iamUpdater) SetIamPolicy(ctx context.Context, policy *models.HashicorpCloudResourcemanagerPolicy) (*models.HashicorpCloudResourcemanagerPolicy, error) {
 	params := resource_service.NewResourceServiceSetIamPolicyParams()
-	params.Body.ResourceID = u.groupID
+	params.Body.ResourceName = u.resourceName
 	params.Body.Policy = policy
 
 	res, err := u.client.ResourceServiceSetIamPolicy(params, nil)


### PR DESCRIPTION
### Changes proposed in this PR:

Sets up the IAM updater as well as the read-policy command for IAM Groups.

### How I've tested this PR:

- Added tests
- Confirmed the command worked manually in prod

### How I expect reviewers to test this PR:

**Make sure your go bin directory is in your $PATH**

- Clone the branch
- `make go/build`
- `make go/install`
- `hcp auth login`
- `hcp iam groups iam read-policy --group=[RESOURCE_NAME]`

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
