### PR TITLE
Implement iam groups iam add-binding Subcommand

### DIFF
--- a/internal/commands/iam/groups/iam/add_binding.go
+++ b/internal/commands/iam/groups/iam/add_binding.go
@@ -1,0 +1,132 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/iam_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/organization_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/resource_service"
+	"github.com/hashicorp/hcp/internal/commands/iam/groups/helper"
+	"github.com/hashicorp/hcp/internal/pkg/api/iampolicy"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+)
+
+func NewCmdAddBinding(ctx *cmd.Context, runF func(*AddBindingOpts) error) *cmd.Command {
+	opts := &AddBindingOpts{
+		Ctx: ctx.ShutdownCtx,
+		IO:  ctx.IO,
+
+		ResourceClient: resource_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "add-binding",
+		ShortHelp: "Add an IAM policy binding for a group.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp iam groups iam add-binding" }}
+		command adds an IAM policy binding for the given group. A binding grants the
+		specified principal the given role on the group.
+
+		To view the available roles to bind, run {{ template "mdCodeOrBold" "hcp iam roles list" }}.
+
+		Currently, the only supported role on a principal in a group is {{ template "mdCodeOrBold" "roles/iam.group-manager" }}.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: heredoc.New(ctx.IO).Must(`Bind a principal to role {{ template "mdCodeOrBold" "roles/iam.group-manager" }}:`),
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp iam groups iam add-binding \
+				  --group=8647ae06-ca65-467a-b72d-edba1f908fc8 \
+				  --member=ef938a22-09cf-4be9-b4d0-1f4587f80f53 \
+				  --role=roles/iam.group-manager
+				`),
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "group",
+					Shorthand:    "g",
+					DisplayValue: "NAME",
+					Description:  "The name of the group to add the role binding to.",
+					Value:        flagvalue.Simple("", &opts.GroupName),
+					Required:     true,
+				},
+				{
+					Name:         "member",
+					Shorthand:    "m",
+					DisplayValue: "PRINCIPAL_ID",
+					Description:  "The ID of the principal to add the role binding to.",
+					Value:        flagvalue.Simple("", &opts.PrincipalID),
+					Required:     true,
+				},
+				{
+					Name:         "role",
+					Shorthand:    "r",
+					DisplayValue: "ROLE_ID",
+					Description:  `The role ID (e.g. "roles/iam.group-manager") to bind the member to.`,
+					Value:        flagvalue.Simple("", &opts.Role),
+					Required:     true,
+					Autocomplete: iampolicy.AutocompleteRoles(opts.Ctx, ctx.Profile.OrganizationID, organization_service.New(ctx.HCP, nil)),
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			resourceName := helper.ResourceName(opts.GroupName, ctx.Profile.OrganizationID)
+
+			// Create the group IAM Updater
+			u := &iamUpdater{
+				resourceName: resourceName,
+				client:       opts.ResourceClient,
+			}
+
+			// Create the policy setter
+			opts.Setter = iampolicy.NewSetter(
+				ctx.Profile.OrganizationID,
+				u,
+				iam_service.New(ctx.HCP, nil),
+				c.Logger())
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return addBindingRun(opts)
+		},
+		PersistentPreRun: func(c *cmd.Command, args []string) error {
+			return cmd.RequireOrganization(ctx)
+		},
+	}
+
+	return cmd
+}
+
+type AddBindingOpts struct {
+	Ctx context.Context
+	IO  iostreams.IOStreams
+
+	Setter         iampolicy.Setter
+	GroupName      string
+	PrincipalID    string
+	Role           string
+	ResourceClient resource_service.ClientService
+}
+
+func addBindingRun(opts *AddBindingOpts) error {
+	_, err := opts.Setter.AddBinding(opts.Ctx, opts.PrincipalID, opts.Role)
+	if err != nil {
+		fmt.Fprintf(opts.IO.Err(), "Principal %q bound to role %q.\n", opts.PrincipalID, opts.Role)
+		return err
+	}
+
+	fmt.Fprintf(opts.IO.Err(), "%s Principal %q bound to role %q.\n",
+		opts.IO.ColorScheme().SuccessIcon(), opts.PrincipalID, opts.Role)
+	return nil
+}

--- a/internal/commands/iam/groups/iam/add_binding_test.go
+++ b/internal/commands/iam/groups/iam/add_binding_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
+	"github.com/hashicorp/hcp/internal/pkg/api/iampolicy"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdAddBinding(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *AddBindingOpts
+	}{
+		{
+			Name:    "No Org",
+			Profile: profile.TestProfile,
+			Args: []string{
+				"--group=test-group",
+				"--member=123",
+				"--role=roles/iam.group-manager",
+			},
+			Error: "Organization ID must be configured",
+		},
+		{
+			Name: "Too many args",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args: []string{
+				"--group=test-group",
+				"--member=123",
+				"--role=roles/iam.group-manager",
+				"foo",
+				"bar",
+			},
+			Error: "no arguments allowed, but received 2",
+		},
+		{
+			Name: "Missing group",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args: []string{
+				"--member=123",
+				"--role=roles/iam.group-manager",
+			},
+			Error: "ERROR: missing required flag: --group=NAME",
+		},
+		{
+			Name: "Missing member",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args: []string{
+				"--group=test-group",
+				"--role=roles/iam.group-manager",
+			},
+			Error: "ERROR: missing required flag: --member=PRINCIPAL_ID",
+		},
+		{
+			Name: "Missing role",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args: []string{
+				"--group=test-group",
+				"--member=123",
+			},
+			Error: "ERROR: missing required flag: --role=ROLE_ID",
+		},
+		{
+			Name: "Good",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args: []string{
+				"--group=test-group",
+				"--member=123",
+				"--role=roles/iam.group-manager"},
+			Expect: &AddBindingOpts{
+				GroupName:   "test-group",
+				PrincipalID: "123",
+				Role:        "roles/iam.group-manager",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts *AddBindingOpts
+			bindingCmd := NewCmdAddBinding(ctx, func(o *AddBindingOpts) error {
+				gotOpts = o
+				return nil
+			})
+			bindingCmd.SetIO(io)
+
+			code := bindingCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+			r.Equal(c.Expect.GroupName, gotOpts.GroupName)
+			r.Equal(c.Expect.PrincipalID, gotOpts.PrincipalID)
+			r.Equal(c.Expect.Role, gotOpts.Role)
+			r.NotNil(gotOpts.Setter)
+		})
+	}
+}
+
+func TestAddBindingRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		RespErr error
+		Error   string
+	}{
+		{
+			Name:    "Server error",
+			RespErr: fmt.Errorf("failed to add policy"),
+			Error:   "failed to add policy",
+		},
+		{
+			Name: "Good",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			setter := iampolicy.NewMockSetter(t)
+			opts := &AddBindingOpts{
+				Ctx:         context.Background(),
+				IO:          io,
+				Setter:      setter,
+				GroupName:   "test-group",
+				PrincipalID: "principal-123",
+				Role:        "roles/test",
+			}
+
+			// Expect a request to add a binding.
+			call := setter.EXPECT().AddBinding(mock.Anything, opts.PrincipalID, opts.Role).Once()
+
+			if c.RespErr != nil {
+				call.Return(nil, c.RespErr)
+			} else {
+				call.Return(&models.HashicorpCloudResourcemanagerPolicy{}, nil)
+			}
+
+			// Run the command
+			err := addBindingRun(opts)
+			if c.Error != "" {
+				r.ErrorContains(err, c.Error)
+				return
+			}
+
+			// Check we outputted the project
+			r.NoError(err)
+			r.Contains(io.Error.String(), `Principal "principal-123" bound to role "roles/test"`)
+		})
+	}
+}

--- a/internal/commands/iam/groups/iam/iam.go
+++ b/internal/commands/iam/groups/iam/iam.go
@@ -19,7 +19,7 @@ func NewCmdIAM(ctx *cmd.Context) *cmd.Command {
 	}
 
 	// TODO: Uncomment as subcommands are added
-	// cmd.AddChild(NewCmdAddBinding(ctx, nil))
+	cmd.AddChild(NewCmdAddBinding(ctx, nil))
 	// cmd.AddChild(NewCmdDeleteBinding(ctx, nil))
 	cmd.AddChild(NewCmdReadPolicy(ctx, nil))
 	// cmd.AddChild(NewCmdSetPolicy(ctx, nil))

--- a/internal/commands/iam/groups/iam/iam.go
+++ b/internal/commands/iam/groups/iam/iam.go
@@ -12,9 +12,16 @@ func NewCmdIAM(ctx *cmd.Context) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "iam",
 		ShortHelp: "Manage a group's IAM policy.",
-		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp iam groups iam" }} command group lets you
-		manage a group's IAM Policy.
+		LongHelp: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+		The {{ template "mdCodeOrBold" "hcp iam groups iam" }} command group lets you manage a group's IAM Policy.
+
+		To set a member as a group manager, you can use the {{ template "mdCodeOrBold" "add-binding" }} subcommand with the {{ template "mdCodeOrBold" "roles/iam.group-manager" }} role.
+
+		$ hcp iam groups iam add-binding \
+			--group=8647ae06-ca65-467a-b72d-edba1f908fc8 \
+			--member=ef938a22-09cf-4be9-b4d0-1f4587f80f53 \
+			--role=roles/iam.group-manager
+
 		`),
 	}
 

--- a/internal/commands/iam/groups/iam/iam.go
+++ b/internal/commands/iam/groups/iam/iam.go
@@ -12,17 +12,20 @@ func NewCmdIAM(ctx *cmd.Context) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "iam",
 		ShortHelp: "Manage a group's IAM policy.",
-		LongHelp: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp iam groups iam" }} command group lets you manage a group's IAM Policy.
-
-		To set a member as a group manager, you can use the {{ template "mdCodeOrBold" "add-binding" }} subcommand with the {{ template "mdCodeOrBold" "roles/iam.group-manager" }} role.
-
-		$ hcp iam groups iam add-binding \
-			--group=8647ae06-ca65-467a-b72d-edba1f908fc8 \
-			--member=ef938a22-09cf-4be9-b4d0-1f4587f80f53 \
-			--role=roles/iam.group-manager
-
 		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: heredoc.New(ctx.IO).Must(`To set a member as a group manager, you can use the {{ template "mdCodeOrBold" "add-binding" }} subcommand with the {{ template "mdCodeOrBold" "roles/iam.group-manager" }} role:`),
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp iam groups iam add-binding \
+				  --group=Group-Name \
+				  --member=ef938a22-09cf-4be9-b4d0-1f4587f80f53 \
+				  --role=roles/iam.group-manager
+				`),
+			},
+		},
 	}
 
 	// TODO: Uncomment as subcommands are added

--- a/internal/commands/iam/groups/iam/read_policy_test.go
+++ b/internal/commands/iam/groups/iam/read_policy_test.go
@@ -38,7 +38,7 @@ func TestNewCmdReadBinding(t *testing.T) {
 			Error: "no arguments allowed, but received 2",
 		},
 		{
-			Name: "No Group Specific",
+			Name: "No Group Specified",
 			Profile: func(t *testing.T) *profile.Profile {
 				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
 			},

--- a/internal/commands/iam/groups/iam/updater.go
+++ b/internal/commands/iam/groups/iam/updater.go
@@ -22,6 +22,7 @@ type iamUpdater struct {
 func (u *iamUpdater) GetIamPolicy(ctx context.Context) (*models.HashicorpCloudResourcemanagerPolicy, error) {
 	params := resource_service.NewResourceServiceGetIamPolicyParams()
 	params.ResourceName = &u.resourceName
+
 	res, err := u.client.ResourceServiceGetIamPolicy(params, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve group IAM policy: %w", err)
@@ -32,8 +33,10 @@ func (u *iamUpdater) GetIamPolicy(ctx context.Context) (*models.HashicorpCloudRe
 
 func (u *iamUpdater) SetIamPolicy(ctx context.Context, policy *models.HashicorpCloudResourcemanagerPolicy) (*models.HashicorpCloudResourcemanagerPolicy, error) {
 	params := resource_service.NewResourceServiceSetIamPolicyParams()
-	params.Body.ResourceName = u.resourceName
-	params.Body.Policy = policy
+	params.Body = &models.HashicorpCloudResourcemanagerResourceSetIamPolicyRequest{
+		ResourceName: u.resourceName,
+		Policy:       policy,
+	}
 
 	res, err := u.client.ResourceServiceSetIamPolicy(params, nil)
 	if err != nil {


### PR DESCRIPTION
### Changes proposed in this PR:

Added the following `add-binding` subcommand to `hcp iam groups iam`

```
hcp iam groups iam add-binding \
    --group=iam/organization/cf8ef907-b9b9-4f2f-0000-e290448f0000/group/Group-Name \
    --member=ef938a22-09cf-4be9-0000-1f4587f80000 \
    --role=roles/iam.group-manager

hcp iam groups iam add-binding \
    --group=Group-Name \
    --member=ef938a22-09cf-4be9-0000-1f4587f80000 \
    --role=roles/iam.group-manager
```

Added some documentation on how to make a principal a group manager:
```
$ hcp iam groups iam
USAGE
  hcp iam groups iam <command> [Optional Flags]

DESCRIPTION
  The hcp iam groups iam command group lets you manage a group's IAM Policy.
  
  To set a member as a group manager, you can use the add-binding subcommand with
  the roles/iam.group-manager role.
  
  $ hcp iam groups iam add-binding \
    --group=8647ae06-ca65-467a-b72d-edba1f908fc8 \
    --member=ef938a22-09cf-4be9-b4d0-1f4587f80f53 \
    --role=roles/iam.group-manager

COMMANDS
  add-binding:  Add an IAM policy binding for a group.
  read-policy:  Read the IAM policy for a group.
```

### How I've tested this PR:

- Added a member to a group and set them as Group Manager
- Added the same binding twice and confirmed that it only set it once
- Tried to set the binding with a non-existing principal ID

### How I expect reviewers to test this PR:

- `make go/test`
- `make go/build && make go/install`
- Add a member to a group (can use UI or CLI)
- `hcp iam groups iam add-binding ...`
- `hcp iam groups iam read-policy ...`

### Output of affected commands:

```
$ hcp iam groups iam add-binding \
    -g=Cool-Group \
    -m=3be9dd66-bc21-4320-0000-5a7dad4c0000 \
    -r=roles/iam.group-manager
✓ Principal "3be9dd66-bc21-4320-0000-5a7dad4c0000" bound to role "roles/iam.group-manager".
```

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
