### PR TITLE
Implement iam groups iam delete-binding

### DIFF
--- a/internal/commands/iam/groups/iam/delete_binding.go
+++ b/internal/commands/iam/groups/iam/delete_binding.go
@@ -1,0 +1,136 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/groups_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/iam_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/organization_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/resource_service"
+	"github.com/hashicorp/hcp/internal/commands/iam/groups/helper"
+	"github.com/hashicorp/hcp/internal/pkg/api/iampolicy"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func NewCmdDeleteBinding(ctx *cmd.Context, runF func(*DeleteBindingOpts) error) *cmd.Command {
+	opts := &DeleteBindingOpts{
+		Ctx:     ctx.ShutdownCtx,
+		Profile: ctx.Profile,
+		IO:      ctx.IO,
+
+		GroupsClient:   groups_service.New(ctx.HCP, nil),
+		ResourceClient: resource_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "delete-binding",
+		ShortHelp: "Delete an IAM policy binding for a group.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp iam groups iam delete-binding" }}
+		command deletes an IAM policy binding for the given group. A binding consists of a
+		principal and a role.
+
+		To view the existing role bindings, run {{ template "mdCodeOrBold" "hcp iam groups iam read-policy" }}.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: heredoc.New(ctx.IO).Must(`Delete a role binding for a principal's previously granted role {{ template "mdCodeOrBold" "roles/iam.group-manager" }}:`),
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp iam groups iam delete-binding \
+				  --group=Group-Name \
+				  --member=ef938a22-09cf-4be9-b4d0-1f4587f80f53 \
+				  --role=roles/iam.group-manager
+				`),
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "group",
+					Shorthand:    "g",
+					DisplayValue: "NAME",
+					Description:  "The name of the group to remove the role binding from.",
+					Value:        flagvalue.Simple("", &opts.GroupName),
+					Autocomplete: helper.PredictGroupResourceNameSuffix(opts.Ctx, opts.Profile.OrganizationID, opts.GroupsClient),
+					Required:     true,
+				},
+				{
+					Name:         "member",
+					Shorthand:    "m",
+					DisplayValue: "PRINCIPAL_ID",
+					Description:  "The ID of the principal to remove the role binding from.",
+					Value:        flagvalue.Simple("", &opts.PrincipalID),
+					Required:     true,
+				},
+				{
+					Name:         "role",
+					Shorthand:    "r",
+					DisplayValue: "ROLE_ID",
+					Description:  `The role ID (e.g. "roles/admin", "roles/contributor", "roles/viewer") to remove the member from.`,
+					Value:        flagvalue.Simple("", &opts.Role),
+					Required:     true,
+					Autocomplete: iampolicy.AutocompleteRoles(opts.Ctx, ctx.Profile.OrganizationID, organization_service.New(ctx.HCP, nil)),
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			resourceName := helper.ResourceName(opts.GroupName, ctx.Profile.OrganizationID)
+
+			// Create our group IAM Updater
+			u := &iamUpdater{
+				resourceName: resourceName,
+				client:       opts.ResourceClient,
+			}
+
+			// Create the policy setter
+			opts.Setter = iampolicy.NewSetter(
+				ctx.Profile.OrganizationID,
+				u,
+				iam_service.New(ctx.HCP, nil),
+				c.Logger())
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return deleteBindingRun(opts)
+		},
+		PersistentPreRun: func(c *cmd.Command, args []string) error {
+			return cmd.RequireOrganization(ctx)
+		},
+	}
+
+	return cmd
+}
+
+type DeleteBindingOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	IO      iostreams.IOStreams
+
+	Setter         iampolicy.Setter
+	GroupName      string
+	PrincipalID    string
+	Role           string
+	GroupsClient   groups_service.ClientService
+	ResourceClient resource_service.ClientService
+}
+
+func deleteBindingRun(opts *DeleteBindingOpts) error {
+	_, err := opts.Setter.DeleteBinding(opts.Ctx, opts.PrincipalID, opts.Role)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(opts.IO.Err(), "%s Principal %q binding to role %q deleted.\n",
+		opts.IO.ColorScheme().SuccessIcon(), opts.PrincipalID, opts.Role)
+	return nil
+}

--- a/internal/commands/iam/groups/iam/delete_binding_test.go
+++ b/internal/commands/iam/groups/iam/delete_binding_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
+	"github.com/hashicorp/hcp/internal/pkg/api/iampolicy"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdDeleteBinding(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *AddBindingOpts
+	}{
+		{
+			Name:    "No Org",
+			Profile: profile.TestProfile,
+			Args: []string{
+				"--group=test-group",
+				"--member=123",
+				"--role=roles/iam.group-manager",
+			},
+			Error: "Organization ID must be configured",
+		},
+		{
+			Name: "Too many args",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args: []string{
+				"--group=test-group",
+				"--member=123",
+				"--role=iam.group-manager",
+				"foo",
+				"bar",
+			},
+			Error: "no arguments allowed, but received 2",
+		},
+		{
+			Name: "Missing group",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args: []string{
+				"--member=123",
+				"--role=roles/iam.group-manager",
+			},
+			Error: "ERROR: missing required flag: --group=NAME",
+		},
+		{
+			Name: "Missing member",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args: []string{
+				"--group=test-group",
+				"--role=roles/iam.group-manager",
+			},
+			Error: "ERROR: missing required flag: --member=PRINCIPAL_ID",
+		},
+		{
+			Name: "Missing role",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args: []string{
+				"--group=test-group",
+				"--member=123",
+			},
+			Error: "ERROR: missing required flag: --role=ROLE_ID",
+		},
+		{
+			Name: "Good",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123")
+			},
+			Args: []string{"--group=test-group", "--member=123", "--role=admin"},
+			Expect: &AddBindingOpts{
+				GroupName:   "test-group",
+				PrincipalID: "123",
+				Role:        "admin",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts *DeleteBindingOpts
+			deleteCmd := NewCmdDeleteBinding(ctx, func(o *DeleteBindingOpts) error {
+				gotOpts = o
+				return nil
+			})
+			deleteCmd.SetIO(io)
+
+			code := deleteCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+			r.Equal(c.Expect.PrincipalID, gotOpts.PrincipalID)
+			r.Equal(c.Expect.Role, gotOpts.Role)
+			r.NotNil(gotOpts.Setter)
+		})
+	}
+}
+
+func TestDeleteBindingRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		RespErr error
+		Error   string
+	}{
+		{
+			Name:    "Server error",
+			RespErr: fmt.Errorf("failed to add policy"),
+			Error:   "failed to add policy",
+		},
+		{
+			Name: "Good",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			setter := iampolicy.NewMockSetter(t)
+			opts := &DeleteBindingOpts{
+				Ctx:         context.Background(),
+				IO:          io,
+				Setter:      setter,
+				GroupName:   "test-group",
+				PrincipalID: "principal-123",
+				Role:        "roles/test",
+			}
+
+			// Expect a request to add a binding.
+			call := setter.EXPECT().DeleteBinding(mock.Anything, opts.PrincipalID, opts.Role).Once()
+
+			if c.RespErr != nil {
+				call.Return(nil, c.RespErr)
+			} else {
+				call.Return(&models.HashicorpCloudResourcemanagerPolicy{}, nil)
+			}
+
+			// Run the command
+			err := deleteBindingRun(opts)
+			if c.Error != "" {
+				r.ErrorContains(err, c.Error)
+				return
+			}
+
+			// Check we outputted the project
+			r.NoError(err)
+			r.Contains(io.Error.String(), `Principal "principal-123" binding to role "roles/test" deleted.`)
+		})
+	}
+}

--- a/internal/commands/iam/groups/iam/iam.go
+++ b/internal/commands/iam/groups/iam/iam.go
@@ -30,7 +30,7 @@ func NewCmdIAM(ctx *cmd.Context) *cmd.Command {
 
 	// TODO: Uncomment as subcommands are added
 	cmd.AddChild(NewCmdAddBinding(ctx, nil))
-	// cmd.AddChild(NewCmdDeleteBinding(ctx, nil))
+	cmd.AddChild(NewCmdDeleteBinding(ctx, nil))
 	cmd.AddChild(NewCmdReadPolicy(ctx, nil))
 	// cmd.AddChild(NewCmdSetPolicy(ctx, nil))
 	return cmd


### PR DESCRIPTION
### Changes proposed in this PR:

Adds the `delete-binding` subcommand to `hcp iam groups iam` which allows a user to delete an IAM role binding within a group.

### How I've tested this PR:

Ran tests and ran the CLI commands in my prod account.

```
❯ hcp iam groups iam read-policy --group=Cool-Group
Role ID                   Principal Name                            Principal ID                           Principal Type
roles/iam.group-manager   email@hashicorp.com   3be9dd66-bc21-4320-0000-5a7dad4c0000   USER          

❯ hcp iam groups iam delete-binding --group=Cool-Group --member=3be9dd66-bc21-4320-0000-5a7dad4c0000 --role=roles/iam.group-manager
✓ Principal "3be9dd66-bc21-4320-0000-5a7dad4c0000" binding to role "roles/iam.group-manager" deleted.

❯ hcp iam groups iam read-policy --group=Cool-Group                                                                                
Role ID   Principal Name   Principal ID   Principal Type
```

### How I expect reviewers to test this PR:

- `hcp iam groups iam read-policy`
- `hcp iam groups iam delete-binding`
- `hcp iam groups iam read-policy` Binding should be gone

### Output of affected commands:

```
hcp iam groups iam delete-binding \
--group=Cool-Group \
--member=3be9dd66-bc21-4320-0000-5a7dad4c0000 \
--role=roles/iam.group-manager
```

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
