### PR TITLE
VAULT-27941 support read rotating secrets

### DIFF
--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -12,12 +12,10 @@ import (
 type displayer struct {
 	secrets        []*models.Secrets20230613Secret
 	previewSecrets []*preview_models.Secrets20231128Secret
-	openAppSecrets []*models.Secrets20230613OpenSecret
-	//previewOpenAppSecrets []*preview_models.Secrets20231128OpenSecret
-	previewOpenAppSecrets []*preview_models.Secrets20231128OpenSecret
-	single                bool
-	fields                []format.Field
-	format                format.Format
+	openAppSecrets []*preview_models.Secrets20231128OpenSecret
+	single         bool
+	fields         []format.Field
+	format         format.Format
 }
 
 func newDisplayer(single bool) *displayer {
@@ -37,13 +35,8 @@ func (d *displayer) PreviewSecrets(secrets ...*preview_models.Secrets20231128Sec
 	return d
 }
 
-func (d *displayer) OpenAppSecrets(secrets ...*models.Secrets20230613OpenSecret) *displayer {
+func (d *displayer) OpenAppSecrets(secrets ...*preview_models.Secrets20231128OpenSecret) *displayer {
 	d.openAppSecrets = secrets
-	return d
-}
-
-func (d *displayer) PreviewOpenAppSecrets(secrets ...*preview_models.Secrets20231128OpenSecret) *displayer {
-	d.previewOpenAppSecrets = secrets
 	return d
 }
 
@@ -70,10 +63,6 @@ func (d *displayer) Payload() any {
 		return d.openAppSecretsPayload()
 	}
 
-	if d.previewOpenAppSecrets != nil {
-		return d.openAppSecretsPayload()
-	}
-
 	if d.secrets == nil {
 		return nil
 	}
@@ -82,10 +71,6 @@ func (d *displayer) Payload() any {
 
 func (d *displayer) FieldTemplates() []format.Field {
 	if d.openAppSecrets != nil {
-		return d.openAppSecretsFieldTemplate()
-	}
-
-	if d.previewOpenAppSecrets != nil {
 		return d.openAppSecretsFieldTemplate()
 	}
 
@@ -106,20 +91,21 @@ func (d *displayer) secretsFieldTemplate() []format.Field {
 			Name:        "Created At",
 			ValueFormat: "{{ .CreatedAt }}",
 		},
-		{
-			Name:        "Type",
-			ValueFormat: "{{ .Type }}",
-		},
 	}
 }
 
 func (d *displayer) openAppSecretsFieldTemplate() []format.Field {
 	fields := d.secretsFieldTemplate()
 
-	fields = append(fields, format.Field{
-		Name:        "Value",
-		ValueFormat: "{{ .Version.Value }}",
-	})
+	fields = append(fields, []format.Field{
+		{
+			Name:        "Value",
+			ValueFormat: "{{ .StaticVersion.Value }}",
+		}, {
+			Name:        "Type",
+			ValueFormat: "{{ .Type }}",
+		},
+	}...)
 	return fields
 }
 
@@ -151,14 +137,4 @@ func (d *displayer) openAppSecretsPayload() any {
 		return d.openAppSecrets[0]
 	}
 	return d.openAppSecrets
-}
-
-func (d *displayer) previewOpenAppSecretsPayload() any {
-	if d.single {
-		if len(d.previewOpenAppSecrets) != 1 {
-			return nil
-		}
-		return d.previewOpenAppSecrets[0]
-	}
-	return d.previewOpenAppSecrets
 }

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -10,9 +10,10 @@ import (
 )
 
 type displayer struct {
-	secrets               []*models.Secrets20230613Secret
-	previewSecrets        []*preview_models.Secrets20231128Secret
-	openAppSecrets        []*models.Secrets20230613OpenSecret
+	secrets        []*models.Secrets20230613Secret
+	previewSecrets []*preview_models.Secrets20231128Secret
+	openAppSecrets []*models.Secrets20230613OpenSecret
+	//previewOpenAppSecrets []*preview_models.Secrets20231128OpenSecret
 	previewOpenAppSecrets []*preview_models.Secrets20231128OpenSecret
 	single                bool
 	fields                []format.Field
@@ -69,6 +70,10 @@ func (d *displayer) Payload() any {
 		return d.openAppSecretsPayload()
 	}
 
+	if d.previewOpenAppSecrets != nil {
+		return d.openAppSecretsPayload()
+	}
+
 	if d.secrets == nil {
 		return nil
 	}
@@ -77,6 +82,10 @@ func (d *displayer) Payload() any {
 
 func (d *displayer) FieldTemplates() []format.Field {
 	if d.openAppSecrets != nil {
+		return d.openAppSecretsFieldTemplate()
+	}
+
+	if d.previewOpenAppSecrets != nil {
 		return d.openAppSecretsFieldTemplate()
 	}
 
@@ -97,11 +106,16 @@ func (d *displayer) secretsFieldTemplate() []format.Field {
 			Name:        "Created At",
 			ValueFormat: "{{ .CreatedAt }}",
 		},
+		{
+			Name:        "Type",
+			ValueFormat: "{{ .Type }}",
+		},
 	}
 }
 
 func (d *displayer) openAppSecretsFieldTemplate() []format.Field {
 	fields := d.secretsFieldTemplate()
+
 	fields = append(fields, format.Field{
 		Name:        "Value",
 		ValueFormat: "{{ .Version.Value }}",
@@ -137,4 +151,14 @@ func (d *displayer) openAppSecretsPayload() any {
 		return d.openAppSecrets[0]
 	}
 	return d.openAppSecrets
+}
+
+func (d *displayer) previewOpenAppSecretsPayload() any {
+	if d.single {
+		if len(d.previewOpenAppSecrets) != 1 {
+			return nil
+		}
+		return d.previewOpenAppSecrets[0]
+	}
+	return d.previewOpenAppSecrets
 }

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -10,12 +10,13 @@ import (
 )
 
 type displayer struct {
-	secrets        []*models.Secrets20230613Secret
-	previewSecrets []*preview_models.Secrets20231128Secret
-	openAppSecrets []*models.Secrets20230613OpenSecret
-	single         bool
-	fields         []format.Field
-	format         format.Format
+	secrets               []*models.Secrets20230613Secret
+	previewSecrets        []*preview_models.Secrets20231128Secret
+	openAppSecrets        []*models.Secrets20230613OpenSecret
+	previewOpenAppSecrets []*preview_models.Secrets20231128OpenSecret
+	single                bool
+	fields                []format.Field
+	format                format.Format
 }
 
 func newDisplayer(single bool) *displayer {
@@ -37,6 +38,11 @@ func (d *displayer) PreviewSecrets(secrets ...*preview_models.Secrets20231128Sec
 
 func (d *displayer) OpenAppSecrets(secrets ...*models.Secrets20230613OpenSecret) *displayer {
 	d.openAppSecrets = secrets
+	return d
+}
+
+func (d *displayer) PreviewOpenAppSecrets(secrets ...*preview_models.Secrets20231128OpenSecret) *displayer {
+	d.previewOpenAppSecrets = secrets
 	return d
 }
 

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -99,11 +99,11 @@ func (d *displayer) openAppSecretsFieldTemplate() []format.Field {
 
 	fields = append(fields, []format.Field{
 		{
-			Name:        "Value",
-			ValueFormat: "{{ .StaticVersion.Value }}",
-		}, {
 			Name:        "Type",
 			ValueFormat: "{{ .Type }}",
+		}, {
+			Name:        "Value",
+			ValueFormat: "{{ .StaticVersion.Value }}",
 		},
 	}...)
 	return fields

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -5,9 +5,12 @@ package secrets
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
 	"os"
+	"strings"
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
@@ -117,14 +120,49 @@ func openRun(opts *OpenOpts) (err error) {
 		return fmt.Errorf("failed to read the secret %q: %w", opts.SecretName, err)
 	}
 
+	var secretValue string
+
+	switch {
+	case resp.Payload.Secret.RotatingVersion != nil:
+		secretValue, err = formatSecretMap(resp.Payload.Secret.RotatingVersion.Values)
+		if err != nil {
+			secretValue = "<< COULD NOT ENCODE TO JSON >>"
+		}
+	case resp.Payload.Secret.StaticVersion != nil:
+		secretValue = resp.Payload.Secret.StaticVersion.Value
+	default:
+		secretValue = "<< SECRET TYPE NOT SUPPORTED >>"
+	}
+
+	secret := &models.Secrets20231128OpenSecret{
+		Name:          resp.Payload.Secret.Name,
+		CreatedAt:     resp.Payload.Secret.CreatedAt,
+		LatestVersion: resp.Payload.Secret.LatestVersion,
+		Type:          resp.Payload.Secret.Type,
+		// Doesn't matter if its static or rotating, this simplifies the output format
+		StaticVersion: &models.Secrets20231128OpenSecretStaticVersion{
+			Value: secretValue,
+		},
+	}
+
 	if opts.OutputFilePath != "" {
-		_, err = fd.WriteString(resp.Payload.Secret.StaticVersion.Value)
+		_, err = fd.WriteString(secret.StaticVersion.Value)
 		if err != nil {
 			return fmt.Errorf("failed to write the secret value to the output file %q: %w", opts.OutputFilePath, err)
 		}
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully wrote plaintext secret with name %q to path %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName, opts.OutputFilePath)
 		return nil
 	}
-	d := newDisplayer(true).PreviewOpenAppSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty)
-	return opts.Output.Display(d.PreviewOpenAppSecrets(resp.Payload.Secret))
+
+	d := newDisplayer(true).OpenAppSecrets(secret).SetDefaultFormat(format.Pretty)
+	return opts.Output.Display(d.OpenAppSecrets(secret))
+}
+
+func formatSecretMap(secretMap map[string]string) (string, error) {
+	var buf strings.Builder
+	encoder := json.NewEncoder(&buf)
+	if err := encoder.Encode(secretMap); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -106,25 +106,25 @@ func openRun(opts *OpenOpts) (err error) {
 		}
 	}()
 
-	req := secret_service.NewOpenAppSecretParamsWithContext(opts.Ctx)
-	req.LocationOrganizationID = opts.Profile.OrganizationID
-	req.LocationProjectID = opts.Profile.ProjectID
+	req := preview_secret_service.NewOpenAppSecretParams()
+	req.OrganizationID = opts.Profile.OrganizationID
+	req.ProjectID = opts.Profile.ProjectID
 	req.AppName = opts.AppName
 	req.SecretName = opts.SecretName
 
-	resp, err := opts.Client.OpenAppSecret(req, nil)
+	resp, err := opts.PreviewClient.OpenAppSecret(req, nil)
 	if err != nil {
 		return fmt.Errorf("failed to read the secret %q: %w", opts.SecretName, err)
 	}
 
 	if opts.OutputFilePath != "" {
-		_, err = fd.WriteString(resp.Payload.Secret.Version.Value)
+		_, err = fd.WriteString(resp.Payload.Secret.StaticVersion.Value)
 		if err != nil {
 			return fmt.Errorf("failed to write the secret value to the output file %q: %w", opts.OutputFilePath, err)
 		}
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully wrote plaintext secret with name %q to path %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName, opts.OutputFilePath)
 		return nil
 	}
-	d := newDisplayer(true).OpenAppSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty)
-	return opts.Output.Display(d.OpenAppSecrets(resp.Payload.Secret))
+	d := newDisplayer(true).PreviewOpenAppSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty)
+	return opts.Output.Display(d.PreviewOpenAppSecrets(resp.Payload.Secret))
 }

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -8,11 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
 	"os"
 	"strings"
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/helper"

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -106,7 +106,7 @@ func openRun(opts *OpenOpts) (err error) {
 		}
 	}()
 
-	req := preview_secret_service.NewOpenAppSecretParams()
+	req := preview_secret_service.NewOpenAppSecretParamsWithContext(opts.Ctx)
 	req.OrganizationID = opts.Profile.OrganizationID
 	req.ProjectID = opts.Profile.ProjectID
 	req.AppName = opts.AppName

--- a/internal/commands/vaultsecrets/secrets/open_test.go
+++ b/internal/commands/vaultsecrets/secrets/open_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/models"
-	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
@@ -154,15 +154,15 @@ func TestOpenRun(t *testing.T) {
 
 			io := iostreams.Test()
 			io.ErrorTTY = true
-			vs := mock_secret_service.NewMockClientService(t)
+			vs := mock_preview_secret_service.NewMockClientService(t)
 			opts := &OpenOpts{
-				Ctx:        context.Background(),
-				IO:         io,
-				Profile:    testProfile(t),
-				Output:     format.New(io),
-				Client:     vs,
-				AppName:    testProfile(t).VaultSecrets.AppName,
-				SecretName: testSecretName,
+				Ctx:           context.Background(),
+				IO:            io,
+				Profile:       testProfile(t),
+				Output:        format.New(io),
+				PreviewClient: vs,
+				AppName:       testProfile(t).VaultSecrets.AppName,
+				SecretName:    testSecretName,
 			}
 
 			if c.WriteToFile {
@@ -180,19 +180,19 @@ func TestOpenRun(t *testing.T) {
 				if c.RespErr {
 					vs.EXPECT().OpenAppSecret(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
 				} else {
-					vs.EXPECT().OpenAppSecret(&secret_service.OpenAppSecretParams{
-						LocationOrganizationID: testProfile(t).OrganizationID,
-						LocationProjectID:      testProfile(t).ProjectID,
-						AppName:                testProfile(t).VaultSecrets.AppName,
-						SecretName:             opts.SecretName,
-						Context:                opts.Ctx,
-					}, mock.Anything).Return(&secret_service.OpenAppSecretOK{
-						Payload: &models.Secrets20230613OpenAppSecretResponse{
-							Secret: &models.Secrets20230613OpenSecret{
+					vs.EXPECT().OpenAppSecret(&preview_secret_service.OpenAppSecretParams{
+						OrganizationID: testProfile(t).OrganizationID,
+						ProjectID:      testProfile(t).ProjectID,
+						AppName:        testProfile(t).VaultSecrets.AppName,
+						SecretName:     opts.SecretName,
+						Context:        opts.Ctx,
+					}, mock.Anything).Return(&preview_secret_service.OpenAppSecretOK{
+						Payload: &preview_models.Secrets20231128OpenAppSecretResponse{
+							Secret: &preview_models.Secrets20231128OpenSecret{
 								Name:          opts.SecretName,
-								LatestVersion: "3",
-								Version: &models.Secrets20230613OpenSecretVersion{
-									Version: "3",
+								LatestVersion: 3,
+								StaticVersion: &preview_models.Secrets20231128OpenSecretStaticVersion{
+									Version: 3,
 									Value:   "my super secret value",
 								},
 								CreatedAt: strfmt.DateTime(time.Now()),

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -89,17 +89,17 @@ func readRun(opts *ReadOpts) error {
 		return runOpenAppSecret(opts)
 	}
 
-	req := secret_service.NewGetAppSecretParamsWithContext(opts.Ctx)
-	req.LocationOrganizationID = opts.Profile.OrganizationID
-	req.LocationProjectID = opts.Profile.ProjectID
-	req.AppName = opts.AppName
-	req.SecretName = opts.SecretName
+	params := preview_secret_service.NewGetAppSecretParams()
+	params.OrganizationID = opts.Profile.OrganizationID
+	params.ProjectID = opts.Profile.ProjectID
+	params.AppName = opts.AppName
+	params.SecretName = opts.SecretName
 
-	resp, err := opts.Client.GetAppSecret(req, nil)
+	resp, err := opts.PreviewClient.GetAppSecret(params, nil)
 	if err != nil {
 		return fmt.Errorf("failed to read the secret %q: %w", opts.SecretName, err)
 	}
-	return opts.Output.Display(newDisplayer(true).Secrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty))
+	return opts.Output.Display(newDisplayer(true).PreviewSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty))
 }
 
 func runOpenAppSecret(opts *ReadOpts) error {

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -79,16 +79,11 @@ type ReadOpts struct {
 
 	AppName       string
 	SecretName    string
-	OpenSecret    bool
 	PreviewClient preview_secret_service.ClientService
 	Client        secret_service.ClientService
 }
 
 func readRun(opts *ReadOpts) error {
-	if opts.OpenSecret {
-		return runOpenAppSecret(opts)
-	}
-
 	params := preview_secret_service.NewGetAppSecretParams()
 	params.OrganizationID = opts.Profile.OrganizationID
 	params.ProjectID = opts.Profile.ProjectID
@@ -100,20 +95,4 @@ func readRun(opts *ReadOpts) error {
 		return fmt.Errorf("failed to read the secret %q: %w", opts.SecretName, err)
 	}
 	return opts.Output.Display(newDisplayer(true).PreviewSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty))
-}
-
-func runOpenAppSecret(opts *ReadOpts) error {
-	req := secret_service.NewOpenAppSecretParamsWithContext(opts.Ctx)
-	req.LocationOrganizationID = opts.Profile.OrganizationID
-	req.LocationProjectID = opts.Profile.ProjectID
-	req.AppName = opts.AppName
-	req.SecretName = opts.SecretName
-
-	resp, err := opts.Client.OpenAppSecret(req, nil)
-	if err != nil {
-		return fmt.Errorf("failed to read the secret %q: %w", opts.SecretName, err)
-	}
-
-	d := newDisplayer(true).OpenAppSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty)
-	return opts.Output.Display(d.OpenAppSecrets(resp.Payload.Secret))
 }

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -84,13 +84,13 @@ type ReadOpts struct {
 }
 
 func readRun(opts *ReadOpts) error {
-	params := preview_secret_service.NewGetAppSecretParams()
-	params.OrganizationID = opts.Profile.OrganizationID
-	params.ProjectID = opts.Profile.ProjectID
-	params.AppName = opts.AppName
-	params.SecretName = opts.SecretName
+	req := preview_secret_service.NewGetAppSecretParamsWithContext(opts.Ctx)
+	req.OrganizationID = opts.Profile.OrganizationID
+	req.ProjectID = opts.Profile.ProjectID
+	req.AppName = opts.AppName
+	req.SecretName = opts.SecretName
 
-	resp, err := opts.PreviewClient.GetAppSecret(params, nil)
+	resp, err := opts.PreviewClient.GetAppSecret(req, nil)
 	if err != nil {
 		return fmt.Errorf("failed to read the secret %q: %w", opts.SecretName, err)
 	}

--- a/internal/commands/vaultsecrets/secrets/read_test.go
+++ b/internal/commands/vaultsecrets/secrets/read_test.go
@@ -6,15 +6,15 @@ package secrets
 import (
 	"context"
 	"errors"
-	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
-	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"

--- a/internal/commands/vaultsecrets/secrets/read_test.go
+++ b/internal/commands/vaultsecrets/secrets/read_test.go
@@ -6,15 +6,15 @@ package secrets
 import (
 	"context"
 	"errors"
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/models"
-	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
@@ -144,32 +144,32 @@ func TestReadRun(t *testing.T) {
 
 			io := iostreams.Test()
 			io.ErrorTTY = true
-			vs := mock_secret_service.NewMockClientService(t)
+			vs := mock_preview_secret_service.NewMockClientService(t)
 			opts := &ReadOpts{
-				Ctx:        context.Background(),
-				IO:         io,
-				Profile:    testProfile(t),
-				Output:     format.New(io),
-				Client:     vs,
-				AppName:    testProfile(t).VaultSecrets.AppName,
-				SecretName: testSecretName,
+				Ctx:           context.Background(),
+				IO:            io,
+				Profile:       testProfile(t),
+				Output:        format.New(io),
+				PreviewClient: vs,
+				AppName:       testProfile(t).VaultSecrets.AppName,
+				SecretName:    testSecretName,
 			}
 
 			if c.MockCalled {
 				if c.RespErr {
 					vs.EXPECT().GetAppSecret(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
 				} else {
-					vs.EXPECT().GetAppSecret(&secret_service.GetAppSecretParams{
-						LocationOrganizationID: testProfile(t).OrganizationID,
-						LocationProjectID:      testProfile(t).ProjectID,
-						AppName:                testProfile(t).VaultSecrets.AppName,
-						SecretName:             opts.SecretName,
-						Context:                opts.Ctx,
-					}, mock.Anything).Return(&secret_service.GetAppSecretOK{
-						Payload: &models.Secrets20230613GetAppSecretResponse{
-							Secret: &models.Secrets20230613Secret{
+					vs.EXPECT().GetAppSecret(&preview_secret_service.GetAppSecretParams{
+						OrganizationID: testProfile(t).OrganizationID,
+						ProjectID:      testProfile(t).ProjectID,
+						AppName:        testProfile(t).VaultSecrets.AppName,
+						SecretName:     opts.SecretName,
+						Context:        opts.Ctx,
+					}, mock.Anything).Return(&preview_secret_service.GetAppSecretOK{
+						Payload: &preview_models.Secrets20231128GetAppSecretResponse{
+							Secret: &preview_models.Secrets20231128Secret{
 								Name:          opts.SecretName,
-								LatestVersion: "2",
+								LatestVersion: 2,
 								CreatedAt:     strfmt.DateTime(time.Now()),
 							},
 						},


### PR DESCRIPTION
### Changes proposed in this PR:
Adds support for reading/opening rotating secrets. Followed the [vlt execution](https://github.com/hashicorp/vlt/pull/141) pretty closely

### How I've tested this PR:
Ran `make go/build` and executed test commands

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Run `./bin/hcp vs secrets open {ROTATING_SECRET_NAME}`
4. Run `./bin/hcp vs secrets read {ROTATING_SECRET_NAME}`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
<img width="706" alt="Screenshot 2024-06-10 at 12 26 08 PM" src="https://github.com/hashicorp/hcp/assets/19840012/cf336e7e-845d-4ce6-9a82-c515b63d6288">

### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
