### PR TITLE
Remove module version flags from Waypoint templates & add-ons

### DIFF
--- a/.changelog/118.txt
+++ b/.changelog/118.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+waypoint: Remove module version flag from templates and add-on definitions commands. Remove module source from update commands.
+```

--- a/internal/commands/waypoint/add-ons/definitions/create.go
+++ b/internal/commands/waypoint/add-ons/definitions/create.go
@@ -32,7 +32,6 @@ $ hcp waypoint add-ons definitions create -n=my-add-on-definition \
   -d="My Add-on Definition description." \
   --readme-markdown-template-file="README.tpl" \
   --tfc-no-code-module-source="app.terraform.io/hashicorp/dir/template" \
-  --tfc-no-code-module-version="1.0.2" \
   --tfc-project-name="my-tfc-project" \
   --tfc-project-id="prj-123456" \
   -l=label1 \
@@ -99,13 +98,6 @@ $ hcp waypoint add-ons definitions create -n=my-add-on-definition \
 					Required: true,
 				},
 				{
-					Name:         "tfc-no-code-module-version",
-					DisplayValue: "TFC_NO_CODE_MODULE_VERSION",
-					Description:  "The version of the Terraform no-code module.",
-					Value:        flagvalue.Simple("", &opts.TerraformNoCodeModuleVersion),
-					Required:     true,
-				},
-				{
 					Name:         "tfc-project-name",
 					DisplayValue: "TFC_PROJECT_NAME",
 					Description: "The name of the Terraform Cloud project where" +
@@ -153,14 +145,11 @@ func addOnDefinitionCreate(opts *AddOnDefinitionOpts) error {
 				Description:            opts.Description,
 				ReadmeMarkdownTemplate: readmeTpl,
 				Labels:                 opts.Labels,
-				TerraformNocodeModule: &models.HashicorpCloudWaypointTerraformNocodeModule{
-					Source:  opts.TerraformNoCodeModuleSource,
-					Version: opts.TerraformNoCodeModuleVersion,
-				},
 				TerraformCloudWorkspaceDetails: &models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 					Name:      opts.TerraformCloudProjectName,
 					ProjectID: opts.TerraformCloudProjectID,
 				},
+				ModuleSource: opts.TerraformNoCodeModuleSource,
 			},
 			Context: opts.Ctx,
 		}, nil)

--- a/internal/commands/waypoint/add-ons/definitions/create_test.go
+++ b/internal/commands/waypoint/add-ons/definitions/create_test.go
@@ -50,21 +50,19 @@ func TestCmdAddOnDefinitionCreate(t *testing.T) {
 				"--tfc-project-id", "prj-abcdefghij",
 				"--tfc-project-name", "test",
 				"--tfc-no-code-module-source", "private/waypoint/waypoint-nocode-module/null",
-				"--tfc-no-code-module-version", "0.0.1",
 				"-l", "cli",
 				"-d", "An add-on definition created with the CLI.",
 				"--readme-markdown-template-file", "readme_test.txt",
 			},
 			Expect: &AddOnDefinitionOpts{
-				Name:                         "cli-test",
-				Summary:                      "An add-on definition created using the CLI.",
-				Description:                  "An add-on definition created with the CLI.",
-				TerraformCloudProjectID:      "prj-abcdefghij",
-				TerraformCloudProjectName:    "test",
-				TerraformNoCodeModuleSource:  "private/waypoint/waypoint-nocode-module/null",
-				TerraformNoCodeModuleVersion: "0.0.1",
-				Labels:                       []string{"cli"},
-				ReadmeMarkdownTemplateFile:   "readme_test.txt",
+				Name:                        "cli-test",
+				Summary:                     "An add-on definition created using the CLI.",
+				Description:                 "An add-on definition created with the CLI.",
+				TerraformCloudProjectID:     "prj-abcdefghij",
+				TerraformCloudProjectName:   "test",
+				TerraformNoCodeModuleSource: "private/waypoint/waypoint-nocode-module/null",
+				Labels:                      []string{"cli"},
+				ReadmeMarkdownTemplateFile:  "readme_test.txt",
 			},
 		},
 	}
@@ -104,7 +102,6 @@ func TestCmdAddOnDefinitionCreate(t *testing.T) {
 				r.Equal(c.Expect.TerraformCloudProjectID, aodOpts.TerraformCloudProjectID)
 				r.Equal(c.Expect.TerraformCloudProjectName, aodOpts.TerraformCloudProjectName)
 				r.Equal(c.Expect.TerraformNoCodeModuleSource, aodOpts.TerraformNoCodeModuleSource)
-				r.Equal(c.Expect.TerraformNoCodeModuleVersion, aodOpts.TerraformNoCodeModuleVersion)
 				r.Equal(c.Expect.ReadmeMarkdownTemplateFile, aodOpts.ReadmeMarkdownTemplateFile)
 				r.Equal(c.Expect.Labels, aodOpts.Labels)
 			}

--- a/internal/commands/waypoint/add-ons/definitions/update.go
+++ b/internal/commands/waypoint/add-ons/definitions/update.go
@@ -31,8 +31,6 @@ $ hcp waypoint add-ons definitions update -n=my-add-on-definition \
   -s="My updated Add-on Definition summary." \
   -d="My updated Add-on Definition description." \
   --readme-markdown-template-file "README.tpl" \
-  --tfc-no-code-module-source="app.terraform.io/hashicorp/dir/template" \
-  --tfc-no-code-module-version="1.0.2" \
   --tfc-project-name="my-tfc-project" \
   --tfc-project-id="prj-123456" \
   -l=label1 \
@@ -88,18 +86,6 @@ $ hcp waypoint add-ons definitions update -n=my-add-on-definition \
 					Value:        flagvalue.SimpleSlice(nil, &opts.Labels),
 				},
 				{
-					Name:         "tfc-no-code-module-source",
-					DisplayValue: "TFC_NO_CODE_MODULE_SOURCE",
-					Description:  "The Terraform Cloud no-code module source.",
-					Value:        flagvalue.Simple("", &opts.TerraformNoCodeModuleSource),
-				},
-				{
-					Name:         "tfc-no-code-module-version",
-					DisplayValue: "TFC_NO_CODE_MODULE_VERSION",
-					Description:  "The Terraform Cloud no-code module version.",
-					Value:        flagvalue.Simple("", &opts.TerraformNoCodeModuleVersion),
-				},
-				{
 					Name:         "tfc-project-id",
 					DisplayValue: "TFC_PROJECT_ID",
 					Description:  "The Terraform Cloud project ID.",
@@ -145,10 +131,6 @@ func addOnDefinitionUpdate(opts *AddOnDefinitionOpts) error {
 				Description:            opts.Description,
 				ReadmeMarkdownTemplate: readmeTpl,
 				Labels:                 opts.Labels,
-				TerraformNocodeModule: &models.HashicorpCloudWaypointTerraformNocodeModule{
-					Source:  opts.TerraformNoCodeModuleSource,
-					Version: opts.TerraformNoCodeModuleVersion,
-				},
 				TerraformCloudWorkspaceDetails: &models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 					ProjectID: opts.TerraformCloudProjectID,
 					Name:      opts.TerraformCloudProjectName,

--- a/internal/commands/waypoint/add-ons/definitions/update_test.go
+++ b/internal/commands/waypoint/add-ons/definitions/update_test.go
@@ -48,22 +48,18 @@ func TestCmdAddOnDefinitionUpdate(t *testing.T) {
 				"-s", "An add-on definition created using the CLI.",
 				"--tfc-project-id", "prj-abcdefghij",
 				"--tfc-project-name", "test",
-				"--tfc-no-code-module-source", "private/waypoint/waypoint-nocode-module/null",
-				"--tfc-no-code-module-version", "0.0.1",
 				"-l", "cli",
 				"-d", "An add-on definition created with the CLI.",
 				"--readme-markdown-template-file", "readme_test.txt",
 			},
 			Expect: &AddOnDefinitionOpts{
-				Name:                         "cli-test",
-				Summary:                      "An add-on definition created using the CLI.",
-				Description:                  "An add-on definition created with the CLI.",
-				TerraformCloudProjectID:      "prj-abcdefghij",
-				TerraformCloudProjectName:    "test",
-				TerraformNoCodeModuleSource:  "private/waypoint/waypoint-nocode-module/null",
-				TerraformNoCodeModuleVersion: "0.0.1",
-				Labels:                       []string{"cli"},
-				ReadmeMarkdownTemplateFile:   "readme_test.txt",
+				Name:                       "cli-test",
+				Summary:                    "An add-on definition created using the CLI.",
+				Description:                "An add-on definition created with the CLI.",
+				TerraformCloudProjectID:    "prj-abcdefghij",
+				TerraformCloudProjectName:  "test",
+				Labels:                     []string{"cli"},
+				ReadmeMarkdownTemplateFile: "readme_test.txt",
 			},
 		},
 	}
@@ -101,8 +97,6 @@ func TestCmdAddOnDefinitionUpdate(t *testing.T) {
 				r.Equal(c.Expect.Description, aodOpts.Description)
 				r.Equal(c.Expect.TerraformCloudProjectID, aodOpts.TerraformCloudProjectID)
 				r.Equal(c.Expect.TerraformCloudProjectName, aodOpts.TerraformCloudProjectName)
-				r.Equal(c.Expect.TerraformNoCodeModuleSource, aodOpts.TerraformNoCodeModuleSource)
-				r.Equal(c.Expect.TerraformNoCodeModuleVersion, aodOpts.TerraformNoCodeModuleVersion)
 				r.Equal(c.Expect.Labels, aodOpts.Labels)
 				r.Equal(c.Expect.ReadmeMarkdownTemplateFile, aodOpts.ReadmeMarkdownTemplateFile)
 			}

--- a/internal/commands/waypoint/applications/create.go
+++ b/internal/commands/waypoint/applications/create.go
@@ -50,10 +50,10 @@ $ hcp waypoint application create -n=my-application -t=my-template
 					Required:     true,
 				},
 				{
-					Name:         "templates-name",
+					Name:         "template-name",
 					Shorthand:    "t",
 					DisplayValue: "TEMPLATE_NAME",
-					Description:  "The name of the templates to use for the application.",
+					Description:  "The name of the template to use for the application.",
 					Value:        flagvalue.Simple("", &opts.TemplateName),
 					Required:     true,
 				},

--- a/internal/commands/waypoint/templates/create.go
+++ b/internal/commands/waypoint/templates/create.go
@@ -32,7 +32,6 @@ $ hcp waypoint templates create -n=my-template \
   -d="My Template Description" \
   --readme-markdown-template-file "README.tpl" \
   --tfc-no-code-module-source="app.terraform.io/hashicorp/dir/template" \
-  --tfc-no-code-module-version="1.0.2" \
   --tfc-project-name="my-tfc-project" \
   --tfc-project-id="prj-123456"" \
   -l="label1" \
@@ -110,13 +109,6 @@ $ hcp waypoint templates create -n=my-template \
 					Required: true,
 				},
 				{
-					Name:         "tfc-no-code-module-version",
-					DisplayValue: "TFC_NO_CODE_MODULE_VERSION",
-					Description:  "The version of the Terraform no-code module.",
-					Value:        flagvalue.Simple("", &opts.TerraformNoCodeModuleVersion),
-					Required:     true,
-				},
-				{
 					Name:         "tfc-project-name",
 					DisplayValue: "TFC_PROJECT_NAME",
 					Description: "The name of the Terraform Cloud project where" +
@@ -175,14 +167,11 @@ func templateCreate(opts *TemplateOpts) error {
 					ReadmeMarkdownTemplate: readmeTpl,
 					Labels:                 opts.Labels,
 					Tags:                   tags,
-					TerraformNocodeModule: &models.HashicorpCloudWaypointTerraformNocodeModule{
-						Source:  opts.TerraformNoCodeModuleSource,
-						Version: opts.TerraformNoCodeModuleVersion,
-					},
 					TerraformCloudWorkspaceDetails: &models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 						Name:      opts.TerraformCloudProjectName,
 						ProjectID: opts.TerraformCloudProjectID,
 					},
+					ModuleSource: opts.TerraformNoCodeModuleSource,
 				},
 			},
 			Context: opts.Ctx,

--- a/internal/commands/waypoint/templates/create_test.go
+++ b/internal/commands/waypoint/templates/create_test.go
@@ -50,23 +50,21 @@ func TestCmdTemplateCreate(t *testing.T) {
 				"--tfc-project-id", "prj-abcdefghij",
 				"--tfc-project-name", "test",
 				"--tfc-no-code-module-source", "private/waypoint/waypoint-nocode-module/null",
-				"--tfc-no-code-module-version", "0.0.1",
 				"-l", "cli",
 				"-d", "A template created with the CLI.",
 				"-t", "cli=true",
 				"--readme-markdown-template-file", "readme_test.txt",
 			},
 			Expect: &TemplateOpts{
-				Name:                         "cli-test",
-				Summary:                      "A template created using the CLI.",
-				Description:                  "A template created with the CLI.",
-				TerraformCloudProjectID:      "prj-abcdefghij",
-				TerraformCloudProjectName:    "test",
-				TerraformNoCodeModuleSource:  "private/waypoint/waypoint-nocode-module/null",
-				TerraformNoCodeModuleVersion: "0.0.1",
-				ReadmeMarkdownTemplateFile:   "readme_test.txt",
-				Labels:                       []string{"cli"},
-				Tags:                         map[string]string{"cli": "true"},
+				Name:                        "cli-test",
+				Summary:                     "A template created using the CLI.",
+				Description:                 "A template created with the CLI.",
+				TerraformCloudProjectID:     "prj-abcdefghij",
+				TerraformCloudProjectName:   "test",
+				TerraformNoCodeModuleSource: "private/waypoint/waypoint-nocode-module/null",
+				ReadmeMarkdownTemplateFile:  "readme_test.txt",
+				Labels:                      []string{"cli"},
+				Tags:                        map[string]string{"cli": "true"},
 			},
 		},
 	}
@@ -106,7 +104,6 @@ func TestCmdTemplateCreate(t *testing.T) {
 				r.Equal(c.Expect.TerraformCloudProjectID, tplOpts.TerraformCloudProjectID)
 				r.Equal(c.Expect.TerraformCloudProjectName, tplOpts.TerraformCloudProjectName)
 				r.Equal(c.Expect.TerraformNoCodeModuleSource, tplOpts.TerraformNoCodeModuleSource)
-				r.Equal(c.Expect.TerraformNoCodeModuleVersion, tplOpts.TerraformNoCodeModuleVersion)
 				r.Equal(c.Expect.ReadmeMarkdownTemplateFile, tplOpts.ReadmeMarkdownTemplateFile)
 				r.Equal(c.Expect.Labels, tplOpts.Labels)
 				r.Equal(c.Expect.Tags, tplOpts.Tags)

--- a/internal/commands/waypoint/templates/template.go
+++ b/internal/commands/waypoint/templates/template.go
@@ -27,10 +27,9 @@ type TemplateOpts struct {
 	Labels                     []string
 	Tags                       map[string]string
 
-	TerraformNoCodeModuleSource  string
-	TerraformNoCodeModuleVersion string
-	TerraformCloudProjectName    string
-	TerraformCloudProjectID      string
+	TerraformNoCodeModuleSource string
+	TerraformCloudProjectName   string
+	TerraformCloudProjectID     string
 
 	// testFunc is used for testing, so that the command can be tested without
 	// using the real API.

--- a/internal/commands/waypoint/templates/update.go
+++ b/internal/commands/waypoint/templates/update.go
@@ -31,7 +31,6 @@ $ hcp waypoint templates update -n=my-template \
   -s="My Template Summary" \
   -d="My Template Description" \
   -readme-markdown-template-file "README.tpl" \
-  --tfc-no-code-module-source="app.terraform.io/hashicorp/dir/template" \
   --tfc-project-name="my-tfc-project" \
   --tfc-project-id="prj-123456 \
   -l="label1" \
@@ -103,17 +102,6 @@ $ hcp waypoint templates update -n=my-template \
 					Hidden:       true,
 				},
 				{
-					Name:         "tfc-no-code-module-source",
-					DisplayValue: "TFC_NO_CODE_MODULE_SOURCE",
-					Description: heredoc.New(ctx.IO).Must(`
-			The source of the Terraform no-code module. 
-			The expected format is "NAMESPACE/NAME/PROVIDER". An
-			optional "HOSTNAME/" can be added at the beginning for
-			a private registry.
-					`),
-					Value: flagvalue.Simple("", &opts.TerraformNoCodeModuleSource),
-				},
-				{
 					Name:         "tfc-project-name",
 					DisplayValue: "TFC_PROJECT_NAME",
 					Description: "The name of the Terraform Cloud project where" +
@@ -169,7 +157,6 @@ func templateUpdate(opts *TemplateOpts) error {
 			Name:      opts.TerraformCloudProjectName,
 			ProjectID: opts.TerraformCloudProjectID,
 		},
-		ModuleSource: opts.TerraformNoCodeModuleSource,
 	}
 
 	_, err = opts.WS.WaypointServiceUpdateApplicationTemplate2(

--- a/internal/commands/waypoint/templates/update.go
+++ b/internal/commands/waypoint/templates/update.go
@@ -32,7 +32,6 @@ $ hcp waypoint templates update -n=my-template \
   -d="My Template Description" \
   -readme-markdown-template-file "README.tpl" \
   --tfc-no-code-module-source="app.terraform.io/hashicorp/dir/template" \
-  --tfc-no-code-module-version="1.0.2" \
   --tfc-project-name="my-tfc-project" \
   --tfc-project-id="prj-123456 \
   -l="label1" \
@@ -115,12 +114,6 @@ $ hcp waypoint templates update -n=my-template \
 					Value: flagvalue.Simple("", &opts.TerraformNoCodeModuleSource),
 				},
 				{
-					Name:         "tfc-no-code-module-version",
-					DisplayValue: "TFC_NO_CODE_MODULE_VERSION",
-					Description:  "The version of the Terraform no-code module.",
-					Value:        flagvalue.Simple("", &opts.TerraformNoCodeModuleVersion),
-				},
-				{
 					Name:         "tfc-project-name",
 					DisplayValue: "TFC_PROJECT_NAME",
 					Description: "The name of the Terraform Cloud project where" +
@@ -172,14 +165,11 @@ func templateUpdate(opts *TemplateOpts) error {
 		ReadmeMarkdownTemplate: readmeTpl,
 		Labels:                 opts.Labels,
 		Tags:                   tags,
-		TerraformNocodeModule: &models.HashicorpCloudWaypointTerraformNocodeModule{
-			Source:  opts.TerraformNoCodeModuleSource,
-			Version: opts.TerraformNoCodeModuleVersion,
-		},
 		TerraformCloudWorkspaceDetails: &models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 			Name:      opts.TerraformCloudProjectName,
 			ProjectID: opts.TerraformCloudProjectID,
 		},
+		ModuleSource: opts.TerraformNoCodeModuleSource,
 	}
 
 	_, err = opts.WS.WaypointServiceUpdateApplicationTemplate2(

--- a/internal/commands/waypoint/templates/update_test.go
+++ b/internal/commands/waypoint/templates/update_test.go
@@ -50,23 +50,21 @@ func TestCmdTemplateUpdate(t *testing.T) {
 				"-s", "A template created using the CLI.",
 				"--tfc-project-id", "prj-abcdefghij",
 				"--tfc-project-name", "test",
-				"--tfc-no-code-module-source", "private/waypoint/waypoint-nocode-module/null",
 				"-l", "cli",
 				"-d", "A template created with the CLI.",
 				"-t", "cli=true",
 				"--readme-markdown-template-file", "readme_test.txt",
 			},
 			Expect: &TemplateOpts{
-				Name:                        "cli-test",
-				UpdatedName:                 "cli-test-new",
-				Summary:                     "A template created using the CLI.",
-				Description:                 "A template created with the CLI.",
-				TerraformCloudProjectID:     "prj-abcdefghij",
-				TerraformCloudProjectName:   "test",
-				TerraformNoCodeModuleSource: "private/waypoint/waypoint-nocode-module/null",
-				ReadmeMarkdownTemplateFile:  "readme_test.txt",
-				Labels:                      []string{"cli"},
-				Tags:                        map[string]string{"cli": "true"},
+				Name:                       "cli-test",
+				UpdatedName:                "cli-test-new",
+				Summary:                    "A template created using the CLI.",
+				Description:                "A template created with the CLI.",
+				TerraformCloudProjectID:    "prj-abcdefghij",
+				TerraformCloudProjectName:  "test",
+				ReadmeMarkdownTemplateFile: "readme_test.txt",
+				Labels:                     []string{"cli"},
+				Tags:                       map[string]string{"cli": "true"},
 			},
 		},
 	}
@@ -106,7 +104,6 @@ func TestCmdTemplateUpdate(t *testing.T) {
 				r.Equal(c.Expect.Summary, tplOpts.Summary)
 				r.Equal(c.Expect.TerraformCloudProjectID, tplOpts.TerraformCloudProjectID)
 				r.Equal(c.Expect.TerraformCloudProjectName, tplOpts.TerraformCloudProjectName)
-				r.Equal(c.Expect.TerraformNoCodeModuleSource, tplOpts.TerraformNoCodeModuleSource)
 				r.Equal(c.Expect.ReadmeMarkdownTemplateFile, tplOpts.ReadmeMarkdownTemplateFile)
 				r.Equal(c.Expect.Labels, tplOpts.Labels)
 				r.Equal(c.Expect.Tags, tplOpts.Tags)

--- a/internal/commands/waypoint/templates/update_test.go
+++ b/internal/commands/waypoint/templates/update_test.go
@@ -51,24 +51,22 @@ func TestCmdTemplateUpdate(t *testing.T) {
 				"--tfc-project-id", "prj-abcdefghij",
 				"--tfc-project-name", "test",
 				"--tfc-no-code-module-source", "private/waypoint/waypoint-nocode-module/null",
-				"--tfc-no-code-module-version", "0.0.1",
 				"-l", "cli",
 				"-d", "A template created with the CLI.",
 				"-t", "cli=true",
 				"--readme-markdown-template-file", "readme_test.txt",
 			},
 			Expect: &TemplateOpts{
-				Name:                         "cli-test",
-				UpdatedName:                  "cli-test-new",
-				Summary:                      "A template created using the CLI.",
-				Description:                  "A template created with the CLI.",
-				TerraformCloudProjectID:      "prj-abcdefghij",
-				TerraformCloudProjectName:    "test",
-				TerraformNoCodeModuleSource:  "private/waypoint/waypoint-nocode-module/null",
-				TerraformNoCodeModuleVersion: "0.0.1",
-				ReadmeMarkdownTemplateFile:   "readme_test.txt",
-				Labels:                       []string{"cli"},
-				Tags:                         map[string]string{"cli": "true"},
+				Name:                        "cli-test",
+				UpdatedName:                 "cli-test-new",
+				Summary:                     "A template created using the CLI.",
+				Description:                 "A template created with the CLI.",
+				TerraformCloudProjectID:     "prj-abcdefghij",
+				TerraformCloudProjectName:   "test",
+				TerraformNoCodeModuleSource: "private/waypoint/waypoint-nocode-module/null",
+				ReadmeMarkdownTemplateFile:  "readme_test.txt",
+				Labels:                      []string{"cli"},
+				Tags:                        map[string]string{"cli": "true"},
 			},
 		},
 	}
@@ -109,7 +107,6 @@ func TestCmdTemplateUpdate(t *testing.T) {
 				r.Equal(c.Expect.TerraformCloudProjectID, tplOpts.TerraformCloudProjectID)
 				r.Equal(c.Expect.TerraformCloudProjectName, tplOpts.TerraformCloudProjectName)
 				r.Equal(c.Expect.TerraformNoCodeModuleSource, tplOpts.TerraformNoCodeModuleSource)
-				r.Equal(c.Expect.TerraformNoCodeModuleVersion, tplOpts.TerraformNoCodeModuleVersion)
 				r.Equal(c.Expect.ReadmeMarkdownTemplateFile, tplOpts.ReadmeMarkdownTemplateFile)
 				r.Equal(c.Expect.Labels, tplOpts.Labels)
 				r.Equal(c.Expect.Tags, tplOpts.Tags)


### PR DESCRIPTION
This PR removes the flags which let users configured the version # of a no-code module for Waypoint templates & add-ons. It also removes the module source flag.