### PR TITLE
Support opening HVS dynamic secrets and enhance formatting

### DIFF
--- a/.changelog/119.txt
+++ b/.changelog/119.txt
@@ -1,0 +1,6 @@
+```release-note:feature
+vault-secrets: Adds support for dynamic secrets to the `secrets open` and `run` commands.
+```
+```release-note:improvement
+vault-secrets: Adds secret type to the `secrets read` and `secrets list` output.
+```

--- a/internal/commands/vaultsecrets/run/run.go
+++ b/internal/commands/vaultsecrets/run/run.go
@@ -156,6 +156,10 @@ func getAllSecretsForEnv(opts *RunOpts) ([]string, error) {
 			for name, value := range secret.RotatingVersion.Values {
 				result = append(result, fmt.Sprintf("%v_%v=%v", strings.ToUpper(secret.Name), strings.ToUpper(name), value))
 			}
+		case secret.DynamicInstance != nil:
+			for name, value := range secret.DynamicInstance.Values {
+				result = append(result, fmt.Sprintf("%v_%v=%v", strings.ToUpper(secret.Name), strings.ToUpper(name), value))
+			}
 		case secret.StaticVersion != nil:
 			result = append(result, fmt.Sprintf("%v=%v", strings.ToUpper(secret.Name), secret.StaticVersion.Value))
 		}

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -91,19 +91,15 @@ func (d *displayer) secretsFieldTemplate() []format.Field {
 			Name:        "Created At",
 			ValueFormat: "{{ .CreatedAt }}",
 		},
+		{
+			Name:        "Type",
+			ValueFormat: "{{ .Type }}",
+		},
 	}
 }
 
 func (d *displayer) openAppSecretsFieldTemplate() []format.Field {
 	fields := d.secretsFieldTemplate()
-
-	fields = append(fields, []format.Field{
-		{
-			Name:        "Type",
-			ValueFormat: "{{ .Type }}",
-		},
-	}...)
-
 	return append(fields, d.fields...)
 }
 

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -40,9 +40,9 @@ func (d *displayer) OpenAppSecrets(secrets ...*preview_models.Secrets20231128Ope
 	return d
 }
 
-func (d *displayer) AddFields(fields []format.Field) []format.Field {
+func (d *displayer) AddFields(fields ...format.Field) *displayer {
 	d.fields = append(d.fields, fields...)
-	return d.fields
+	return d
 }
 
 func (d *displayer) SetDefaultFormat(f format.Format) *displayer {
@@ -101,12 +101,10 @@ func (d *displayer) openAppSecretsFieldTemplate() []format.Field {
 		{
 			Name:        "Type",
 			ValueFormat: "{{ .Type }}",
-		}, {
-			Name:        "Value",
-			ValueFormat: "{{ .StaticVersion.Value }}",
 		},
 	}...)
-	return fields
+
+	return append(fields, d.fields...)
 }
 
 func (d *displayer) secretsPayload() any {

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -78,7 +78,7 @@ func (d *displayer) FieldTemplates() []format.Field {
 }
 
 func (d *displayer) secretsFieldTemplate() []format.Field {
-	return []format.Field{
+	fields := []format.Field{
 		{
 			Name:        "Secret Name",
 			ValueFormat: "{{ .Name }}",
@@ -91,11 +91,16 @@ func (d *displayer) secretsFieldTemplate() []format.Field {
 			Name:        "Created At",
 			ValueFormat: "{{ .CreatedAt }}",
 		},
-		{
+	}
+
+	if len(d.previewSecrets) > 0 {
+		fields = append(fields, format.Field{
 			Name:        "Type",
 			ValueFormat: "{{ .Type }}",
-		},
+		})
 	}
+
+	return fields
 }
 
 func (d *displayer) openAppSecretsFieldTemplate() []format.Field {

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -37,7 +37,7 @@ func NewCmdOpen(ctx *cmd.Context, runF func(*OpenOpts) error) *cmd.Command {
 		Name:      "open",
 		ShortHelp: "Open a static, rotating, or dynamic secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets open" }} command reads the plaintext value of a static secret from the Vault Secrets application.
+		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets open" }} command reads the plaintext value of a static, rotating, or dynamic secret from the Vault Secrets application.
 		`),
 		Examples: []cmd.Example{
 			{

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -35,7 +35,7 @@ func NewCmdOpen(ctx *cmd.Context, runF func(*OpenOpts) error) *cmd.Command {
 
 	cmd := &cmd.Command{
 		Name:      "open",
-		ShortHelp: "Open a static secret.",
+		ShortHelp: "Open a static, rotating, or dynamic secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets open" }} command reads the plaintext value of a static secret from the Vault Secrets application.
 		`),

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -35,7 +35,7 @@ func NewCmdOpen(ctx *cmd.Context, runF func(*OpenOpts) error) *cmd.Command {
 
 	cmd := &cmd.Command{
 		Name:      "open",
-		ShortHelp: "Open a static, rotating, or dynamic secret.",
+		ShortHelp: "Open a secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets open" }} command reads the plaintext value of a static, rotating, or dynamic secret from the Vault Secrets application.
 		`),

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/helper"
@@ -120,7 +119,10 @@ func openRun(opts *OpenOpts) (err error) {
 		return fmt.Errorf("failed to read the secret %q: %w", opts.SecretName, err)
 	}
 
-	var secretValue string
+	var (
+		secretValue string
+		field       format.Field
+	)
 
 	switch {
 	case resp.Payload.Secret.RotatingVersion != nil:
@@ -128,25 +130,34 @@ func openRun(opts *OpenOpts) (err error) {
 		if err != nil {
 			secretValue = "<< COULD NOT ENCODE TO JSON >>"
 		}
+
+		field = format.Field{
+			Name:        "Values",
+			ValueFormat: `{{ range $key, $value := .RotatingVersion.Values }}{{printf "%s: %s\n" $key $value}}{{ end }}`,
+		}
+	case resp.Payload.Secret.DynamicInstance != nil:
+		secretValue, err = formatSecretMap(resp.Payload.Secret.DynamicInstance.Values)
+		if err != nil {
+			secretValue = "<< COULD NOT ENCODE TO JSON >>"
+		}
+
+		field = format.Field{
+			Name:        "Values",
+			ValueFormat: `{{ range $key, $value := .DynamicInstance.Values }}{{printf "%s: %s\n" $key $value}}{{ end }}`,
+		}
 	case resp.Payload.Secret.StaticVersion != nil:
 		secretValue = resp.Payload.Secret.StaticVersion.Value
+
+		field = format.Field{
+			Name:        "Value",
+			ValueFormat: "{{ .StaticVersion.Value }}",
+		}
 	default:
 		secretValue = "<< SECRET TYPE NOT SUPPORTED >>"
 	}
 
-	secret := &models.Secrets20231128OpenSecret{
-		Name:          resp.Payload.Secret.Name,
-		CreatedAt:     resp.Payload.Secret.CreatedAt,
-		LatestVersion: resp.Payload.Secret.LatestVersion,
-		Type:          resp.Payload.Secret.Type,
-		// Doesn't matter if its static or rotating, this simplifies the output format
-		StaticVersion: &models.Secrets20231128OpenSecretStaticVersion{
-			Value: secretValue,
-		},
-	}
-
 	if opts.OutputFilePath != "" {
-		_, err = fd.WriteString(secret.StaticVersion.Value)
+		_, err = fd.WriteString(secretValue)
 		if err != nil {
 			return fmt.Errorf("failed to write the secret value to the output file %q: %w", opts.OutputFilePath, err)
 		}
@@ -154,8 +165,9 @@ func openRun(opts *OpenOpts) (err error) {
 		return nil
 	}
 
-	d := newDisplayer(true).OpenAppSecrets(secret).SetDefaultFormat(format.Pretty)
-	return opts.Output.Display(d.OpenAppSecrets(secret))
+	displayer := newDisplayer(true).OpenAppSecrets(resp.Payload.Secret).
+		SetDefaultFormat(format.Pretty).AddFields(field)
+	return opts.Output.Display(displayer)
 }
 
 func formatSecretMap(secretMap map[string]string) (string, error) {

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -30,9 +30,9 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 
 	cmd := &cmd.Command{
 		Name:      "read",
-		ShortHelp: "Read a static secret's metatdata.",
+		ShortHelp: "Read a static, rotating, or dynamic secret's metatdata.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets read" }} command reads a static secret's metadata from the Vault Secrets application.
+		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets read" }} command reads a static, rotating, or dynamic secret's metadata from the Vault Secrets application.
 		`),
 		Examples: []cmd.Example{
 			{

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -30,7 +30,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 
 	cmd := &cmd.Command{
 		Name:      "read",
-		ShortHelp: "Read a static, rotating, or dynamic secret's metatdata.",
+		ShortHelp: "Read a secret's metadata.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets read" }} command reads a static, rotating, or dynamic secret's metadata from the Vault Secrets application.
 		`),


### PR DESCRIPTION
### Changes proposed in this PR:

This PR adds support for opening dynamic secrets in HCP Vault Secrets. Additionally, it enhances the formatting for both dynamic and rotating secrets for format `pretty` and `table`. Prior to this change, the format for the secret values was JSON for both formats. In this PR, the format is `<key>: <value>\n`. Happy to consider other formats or change it back to JSON if you all think that's better.

I'll add/fix up tests once we've got a decision on the formatting.

### How I've tested this PR:

Ran `make go/build` and executed test commands. Also stepped through code with the debugger to fix up the Go templates.

### How I expect reviewers to test this PR:

1. Check out this branch
2. Run `make go/build`
3. Run either command
  - `./bin/hcp vault-secrets secrets open --format=pretty <your-dynamic-secret-name>`
  - `./bin/hcp vault-secrets secrets open --format=table <your-dynamic-secret-name>`

## Example output:

```shell
$ ./bin/hcp vault-secrets secrets open --format=table gcp_service_account_reader
Secret Name                  Latest Version   Created At                 Type      Values                                                  
gcp_service_account_reader   0                2024-06-20T23:43:45.264Z   dynamic   access_token: Redacted
                                                                                   token_type: Bearer

$ ./bin/hcp vault-secrets secrets open --format=pretty gcp_service_account_reader
Secret Name:    gcp_service_account_reader
Latest Version: 0
Created At:     2024-06-20T23:43:45.264Z
Type:           dynamic
Values:         access_token: Redacted
                token_type: Bearer
```

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
