### PR TITLE
Add core property for setting quiet.

### DIFF
--- a/.changelog/121.txt
+++ b/.changelog/121.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+profile: Add a core/quiet property which allows disabling prompting in the profile.
+```

--- a/internal/commands/profile/property_docs.go
+++ b/internal/commands/profile/property_docs.go
@@ -38,6 +38,7 @@ func addCoreProperties(b *availablePropertiesBuilder) {
 	This can be overridden by using the global {{ template "mdCodeOrBold" "--project" }} flag.`)
 
 	b.AddProperty("core", "no_color", "If True, color will not be used when printing messages in the terminal.")
+	b.AddProperty("core", "quiet", "If True, prompts will be disabled and output will be minimized.")
 	b.AddProperty("core", "verbosity", `
 		Default logging verbosity for {{ template "mdCodeOrBold" "hcp" }} commands. This is the
 		equivalent of using the global {{ template "mdCodeOrBold" "--verbosity" }} flag. Supported log levels:

--- a/internal/pkg/profile/profile.go
+++ b/internal/pkg/profile/profile.go
@@ -244,6 +244,9 @@ type Core struct {
 	// NoColor disables color output
 	NoColor *bool `hcl:"no_color,optional" json:",omitempty"`
 
+	// Quiet disables prompting for user input and minimizes output.
+	Quiet *bool `hcl:"quiet,optional" json:",omitempty"`
+
 	// OutputFormat dictates the default output format if unspecified.
 	OutputFormat *string `hcl:"output_format,optional" json:",omitempty"`
 
@@ -254,6 +257,7 @@ type Core struct {
 func (c *Core) Predict(args complete.Args) []string {
 	properties := map[string][]string{
 		"core/no_color":      {"true", "false"},
+		"core/quiet":         {"true", "false"},
 		"core/output_format": {"pretty", "table", "json"},
 		"core/verbosity":     {"trace", "debug", "info", "warn", "error"},
 	}
@@ -300,7 +304,8 @@ func (c *Core) isEmpty() bool {
 		return true
 	}
 
-	if c.NoColor != nil || c.OutputFormat != nil || c.Verbosity != nil {
+	if c.NoColor != nil || c.OutputFormat != nil || c.Verbosity != nil ||
+		c.Quiet != nil {
 		return false
 	}
 
@@ -333,4 +338,17 @@ func (c *Core) GetVerbosity() string {
 	}
 
 	return *c.Verbosity
+}
+
+// IsQueit returns whether the quiet property has been configured to be quiet.
+func (c *Core) IsQuiet() bool {
+	if c == nil {
+		return false
+	}
+
+	if c.Quiet == nil {
+		return false
+	}
+
+	return *c.Quiet
 }

--- a/internal/pkg/profile/profile_test.go
+++ b/internal/pkg/profile/profile_test.go
@@ -20,6 +20,7 @@ func TestPropertyNames(t *testing.T) {
 	r.Contains(properties, "organization_id")
 	r.Contains(properties, "project_id")
 	r.Contains(properties, "core/no_color")
+	r.Contains(properties, "core/quiet")
 	r.Contains(properties, "core/verbosity")
 	r.Contains(properties, "vault-secrets/app")
 }
@@ -111,14 +112,7 @@ func TestProfile_Predict(t *testing.T) {
 			Args: complete.Args{
 				All: []string{"core/"},
 			},
-			Expected: []string{"core/no_color", "core/output_format", "core/verbosity"},
-		},
-		{
-			Name: "core",
-			Args: complete.Args{
-				All: []string{"core/"},
-			},
-			Expected: []string{"core/no_color", "core/output_format", "core/verbosity"},
+			Expected: []string{"core/no_color", "core/output_format", "core/quiet", "core/verbosity"},
 		},
 		{
 			Name: "vault-secrets",
@@ -207,7 +201,7 @@ func TestCore_Predict(t *testing.T) {
 			Args: complete.Args{
 				All: []string{"core/"},
 			},
-			Expected: []string{"core/no_color", "core/output_format", "core/verbosity"},
+			Expected: []string{"core/no_color", "core/output_format", "core/quiet", "core/verbosity"},
 		},
 		{
 			Name: "no_color",


### PR DESCRIPTION
### Changes proposed in this PR:
Add a property to disable prompting. This is useful when scripting using HCP.

### How I've tested this PR:
I set the property and ran a command that outputs additional output. When set to true, the output was omitted and when false or unset the help output was shown.

Also checked that the `hcp profile set --help` output shows the new property.

```
$ echo -n "test" | hcp vs secrets create quiet_test --data-file=-
Secret Name   Latest Version   Created At
quiet_test   1                2024-06-21T23:55:39.442Z

✓ Successfully created secret with name "quiet_test"

To read your secret, run:
  $ hcp vault-secrets secrets read quiet_test6 --app cli

$ hcp profile set core/quiet true
✓ Property "core/quiet" updated

$ echo -n "t" | hcp vs secrets create quiet_test2 --data-file=-
Secret Name   Latest Version   Created At
quiet_test2   1                2024-06-21T23:55:51.291Z
```

### How I expect reviewers to test this PR:
Code review.


### Checklist:
- [X] Tests added if applicable
- [X] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
