### PR TITLE
Improved Organization detection

### DIFF
--- a/.changelog/122.txt
+++ b/.changelog/122.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Run auto-detection of organization ID even if project ID is configured in the profile.
+```

--- a/main.go
+++ b/main.go
@@ -188,10 +188,10 @@ func loadProfile(ctx context.Context, iam iam_service.ClientService, tokenSource
 		}
 	}
 
-	// If the profile has an org/project, or we don't have a valid access
+	// If the profile has an org, or we don't have a valid access
 	// token, skip trying to infer the organization and project.
 	tkn, err := tokenSource.Token()
-	if p.OrganizationID != "" || p.ProjectID != "" || err != nil || !tkn.Expiry.After(time.Now()) {
+	if p.OrganizationID != "" || err != nil || !tkn.Expiry.After(time.Now()) {
 		return p, nil
 	}
 
@@ -210,9 +210,13 @@ func loadProfile(ctx context.Context, iam iam_service.ClientService, tokenSource
 		return p, nil
 	}
 
-	// Set the organization and project. Project may be empty.
+	// Set the organization.
 	p.OrganizationID = ident.Payload.Principal.Service.OrganizationID
-	p.ProjectID = ident.Payload.Principal.Service.ProjectID
+
+	// Only set the project if it is not already set.
+	if p.ProjectID == "" {
+		p.ProjectID = ident.Payload.Principal.Service.ProjectID
+	}
 
 	// Save the profile.
 	if err := p.Write(); err != nil {


### PR DESCRIPTION
### Changes proposed in this PR:
Previously, the organization was only auto-detected if both the organization and project ID were unset. Now if the organization is not set, it will be detected regardless of the project ID.

### How I've tested this PR:

```
# Create a project SP and configure the cli to use it by setting the env vars
$ hcp iam sp keys create <sp-name>
$ export HCP_CLIENT_ID="..."
$ export HCP_CLIENT_SECRET="..."

# Override my active profile to have a bogus project ID and no org ID
$ printf 'name = "test"\norganization_id = ""\nproject_id = "2CDCE738-DB42-4FD4-8418-FDCF3A29B066"\n' > ~/.config/hcp/profiles/test.hcl
$ cat ~/.config/hcp/profiles/test.hcl && hcp profile display
name = "test"
organization_id = ""
project_id = "2CDCE738-DB42-4FD4-8418-FDCF3A29B066"

# Display the profile. This will run the detection logic because the organization ID isn't set.
# We can see it detected and set the org id but didn't touch the project ID as desired.
$ hcp profile display
name            = "test"
organization_id = "11ea8f23-1571-a43d-84e2-0242ac110007"
project_id      = "2CDCE738-DB42-4FD4-8418-FDCF3A29B066"
```

### How I expect reviewers to test this PR:
Code review

### Checklist:
- [X] Tests added if applicable
- [X] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
