### PR TITLE
[HVS] Warn on run collision

### DIFF
--- a/.changelog/127.txt
+++ b/.changelog/127.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-vault-secrets: issue a warning if formatted secret names collide during a run command
+vault-secrets: issue an error if formatted secret names collide during a run command
 ```

--- a/.changelog/127.txt
+++ b/.changelog/127.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault-secrets: issue a warning if formatted secret names collide during a run command
+```

--- a/internal/commands/vaultsecrets/run/run.go
+++ b/internal/commands/vaultsecrets/run/run.go
@@ -178,7 +178,12 @@ func getAllSecretsForEnv(opts *RunOpts) ([]string, error) {
 		if !collided {
 			delete(collisions, fmtName)
 		} else {
-			opts.Logger.Warn(fmt.Sprintf("environment variable \"%s\" was assigned more than once", fmtName))
+			_, err = fmt.Fprintf(opts.IO.Err(), "%s Environment variable \"%s\" was assigned more than once\n",
+				opts.IO.ColorScheme().WarningLabel(), fmtName)
+			if err != nil {
+				return nil, err
+			}
+
 		}
 	}
 

--- a/internal/commands/vaultsecrets/run/run.go
+++ b/internal/commands/vaultsecrets/run/run.go
@@ -179,16 +179,12 @@ func getAllSecretsForEnv(opts *RunOpts) ([]string, error) {
 	for fmtName, uses := range collisions {
 		if len(uses) > 1 {
 			hasCollisions = true
-			var offenders string
+			offenders := make([]string, len(uses))
 			for i, use := range uses {
-				offenders += fmt.Sprintf("\"%s\" [%s]", use.Name, use.Type)
-				if len(uses)-1 != i {
-					offenders += ", "
-				}
+				offenders[i] = fmt.Sprintf("\"%s\" [%s]", use.Name, use.Type)
 			}
-
 			_, err = fmt.Fprintf(opts.IO.Err(), "%s %s map to the same environment variable \"%s\"\n",
-				opts.IO.ColorScheme().ErrorLabel(), offenders, fmtName)
+				opts.IO.ColorScheme().ErrorLabel(), strings.Join(offenders, ", "), fmtName)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/commands/vaultsecrets/run/run.go
+++ b/internal/commands/vaultsecrets/run/run.go
@@ -179,9 +179,9 @@ func getAllSecretsForEnv(opts *RunOpts) ([]string, error) {
 	for fmtName, uses := range collisions {
 		if len(uses) > 1 {
 			hasCollisions = true
-			offenders := make([]string, len(uses))
-			for i, use := range uses {
-				offenders[i] = fmt.Sprintf("\"%s\" [%s]", use.Name, use.Type)
+			var offenders []string
+			for _, use := range uses {
+				offenders = append(offenders, fmt.Sprintf("\"%s\" [%s]", use.Name, use.Type))
 			}
 			_, err = fmt.Fprintf(opts.IO.Err(), "%s %s map to the same environment variable \"%s\"\n",
 				opts.IO.ColorScheme().ErrorLabel(), strings.Join(offenders, ", "), fmtName)

--- a/internal/commands/vaultsecrets/run/run_test.go
+++ b/internal/commands/vaultsecrets/run/run_test.go
@@ -256,6 +256,7 @@ func TestSetupChildProcess(t *testing.T) {
 }
 
 func Test_processCollisions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		expectedCollision bool

--- a/internal/commands/vaultsecrets/run/run_test.go
+++ b/internal/commands/vaultsecrets/run/run_test.go
@@ -285,6 +285,7 @@ func Test_processCollisions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			collisions := make(map[string]bool, 0)
 			for _, fmtName := range tt.fmtNames {
 				processCollisions(collisions, fmtName)

--- a/internal/commands/vaultsecrets/run/run_test.go
+++ b/internal/commands/vaultsecrets/run/run_test.go
@@ -296,14 +296,12 @@ func Test_processCollisions(t *testing.T) {
 			for _, fmtName := range tt.fmtNames {
 				processCollisions(collisions, fmtName)
 			}
-			t.Log("before: ", collisions)
 			// drop false records
 			for fmtName, collided := range collisions {
 				if !collided {
 					delete(collisions, fmtName)
 				}
 			}
-			t.Log("after: ", collisions)
 			if len(collisions) > 0 != tt.expectedCollision {
 				t.Fail()
 			}


### PR DESCRIPTION
### Changes proposed in this PR:
When running `hcp vault-secrets run` return an error if the fomated secret names collide in the prepared environment.

https://hashicorp.atlassian.net/browse/VAULT-28641

<img width="917" alt="Screenshot 2024-07-08 at 2 28 49 PM" src="https://github.com/hashicorp/hcp/assets/94396874/ce3d64d0-cb4c-4ab7-be60-777319f0dd7a">

### How I've tested this PR:
New tests have been added.
Tested against issue in HCP.

### How I expect reviewers to test this PR:
Set up conflicting secret names in an app and issue a `hcp vault-secrets run` command to see error message.

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
