### PR TITLE
vault-secrets: enhances dynamic secret output

### DIFF
--- a/.changelog/129.txt
+++ b/.changelog/129.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+vault-secrets: Enhances dynamic secrets output
+```

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -122,7 +122,7 @@ func createRun(opts *CreateOpts) error {
 		return fmt.Errorf("failed to create secret with name %q: %w", opts.SecretName, err)
 	}
 
-	displayer := newDisplayer().Secrets(resp.Payload.Secret).SetSingleSecret(secretTypeKV)
+	displayer := newDisplayer().Secrets(resp.Payload.Secret).SetSecretType(secretTypeKV)
 	if err := opts.Output.Display(displayer); err != nil {
 		return err
 	}

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -122,7 +122,8 @@ func createRun(opts *CreateOpts) error {
 		return fmt.Errorf("failed to create secret with name %q: %w", opts.SecretName, err)
 	}
 
-	if err := opts.Output.Display(newDisplayer(true).Secrets(resp.Payload.Secret)); err != nil {
+	displayer := newDisplayer().Secrets(resp.Payload.Secret).SetSingleSecret(secretTypeKV)
+	if err := opts.Output.Display(displayer); err != nil {
 		return err
 	}
 

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -122,8 +122,7 @@ func createRun(opts *CreateOpts) error {
 		return fmt.Errorf("failed to create secret with name %q: %w", opts.SecretName, err)
 	}
 
-	displayer := newDisplayer().Secrets(resp.Payload.Secret).SetSecretType(secretTypeKV)
-	if err := opts.Output.Display(displayer); err != nil {
+	if err := opts.Output.Display(newDisplayer().Secrets(resp.Payload.Secret)); err != nil {
 		return err
 	}
 

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -58,10 +58,6 @@ func (d *displayer) SetSecretType(s string) *displayer {
 	return d
 }
 
-func (d *displayer) single() bool {
-	return d.secretType != ""
-}
-
 func (d *displayer) DefaultFormat() format.Format {
 	return d.format
 }
@@ -192,31 +188,31 @@ func (d *displayer) openAppSecretsFieldTemplate() []format.Field {
 }
 
 func (d *displayer) secretsPayload() any {
-	if d.single() {
-		if len(d.secrets) != 1 {
-			return nil
-		}
+	if len(d.secrets) > 1 {
+		return d.secrets
+	}
+	if len(d.secrets) == 1 {
 		return d.secrets[0]
 	}
-	return d.secrets
+	return nil
 }
 
 func (d *displayer) previewSecretsPayload() any {
-	if d.single() {
-		if len(d.previewSecrets) != 1 {
-			return nil
-		}
+	if len(d.previewSecrets) > 1 {
+		return d.previewSecrets
+	}
+	if len(d.previewSecrets) == 1 {
 		return d.previewSecrets[0]
 	}
-	return d.previewSecrets
+	return nil
 }
 
 func (d *displayer) openAppSecretsPayload() any {
-	if d.single() {
-		if len(d.openAppSecrets) != 1 {
-			return nil
-		}
+	if len(d.openAppSecrets) > 1 {
+		return d.openAppSecrets
+	}
+	if len(d.openAppSecrets) == 1 {
 		return d.openAppSecrets[0]
 	}
-	return d.openAppSecrets
+	return nil
 }

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -197,31 +197,22 @@ func (d *displayer) openAppSecretsFieldTemplate() []format.Field {
 }
 
 func (d *displayer) secretsPayload() any {
-	if len(d.secrets) > 1 {
-		return d.secrets
-	}
 	if len(d.secrets) == 1 {
 		return d.secrets[0]
 	}
-	return nil
+	return d.secrets
 }
 
 func (d *displayer) previewSecretsPayload() any {
-	if len(d.previewSecrets) > 1 {
-		return d.previewSecrets
-	}
 	if len(d.previewSecrets) == 1 {
 		return d.previewSecrets[0]
 	}
-	return nil
+	return d.previewSecrets
 }
 
 func (d *displayer) openAppSecretsPayload() any {
-	if len(d.openAppSecrets) > 1 {
-		return d.openAppSecrets
-	}
 	if len(d.openAppSecrets) == 1 {
 		return d.openAppSecrets[0]
 	}
-	return nil
+	return d.openAppSecrets
 }

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -105,18 +105,16 @@ func (d *displayer) secretsFieldTemplate() []format.Field {
 		})
 	}
 
-	fields = append(fields, format.Field{
-		Name:        "Created At",
-		ValueFormat: "{{ .CreatedAt }}",
-	})
-
-	switch d.secretType {
-	case secretTypeKV, secretTypeRotating:
-		fields = append(fields, format.Field{
+	fields = append(fields, []format.Field{
+		{
+			Name:        "Created At",
+			ValueFormat: "{{ .CreatedAt }}",
+		},
+		{
 			Name:        "Latest Version",
-			ValueFormat: "{{ .LatestVersion }}",
-		})
-	}
+			ValueFormat: "{{ if eq .LatestVersion 0 }}-{{ else }}{{ .LatestVersion }}{{ end }}",
+		},
+	}...)
 
 	return fields
 }

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -112,7 +112,7 @@ func (d *displayer) secretsFieldTemplate() []format.Field {
 		},
 		{
 			Name:        "Latest Version",
-			ValueFormat: "{{ if eq .LatestVersion 0 }}-{{ else }}{{ .LatestVersion }}{{ end }}",
+			ValueFormat: "{{ if eq (printf \"%v\" .LatestVersion) \"0\" }}-{{ else }}{{ .LatestVersion }}{{ end }}",
 		},
 	}...)
 

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -30,16 +30,25 @@ func newDisplayer() *displayer {
 
 func (d *displayer) Secrets(secrets ...*models.Secrets20230613Secret) *displayer {
 	d.secrets = secrets
+	if len(secrets) == 1 {
+		d.secretType = secretTypeKV
+	}
 	return d
 }
 
 func (d *displayer) PreviewSecrets(secrets ...*preview_models.Secrets20231128Secret) *displayer {
 	d.previewSecrets = secrets
+	if len(secrets) == 1 {
+		d.secretType = secrets[0].Type
+	}
 	return d
 }
 
 func (d *displayer) OpenAppSecrets(secrets ...*preview_models.Secrets20231128OpenSecret) *displayer {
 	d.openAppSecrets = secrets
+	if len(secrets) == 1 {
+		d.secretType = secrets[0].Type
+	}
 	return d
 }
 

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -176,6 +176,10 @@ func (d *displayer) openAppSecretsFieldTemplate() []format.Field {
 				ValueFormat: "{{ .CreatedAt }}",
 			},
 			{
+				Name:        "Expires At",
+				ValueFormat: "{{ .RotatingVersion.ExpiresAt }}",
+			},
+			{
 				Name:        "Latest Version",
 				ValueFormat: "{{ .LatestVersion }}",
 			},

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -53,7 +53,7 @@ func (d *displayer) SetDefaultFormat(f format.Format) *displayer {
 	return d
 }
 
-func (d *displayer) SetSingleSecret(s string) *displayer {
+func (d *displayer) SetSecretType(s string) *displayer {
 	d.secretType = s
 	return d
 }

--- a/internal/commands/vaultsecrets/secrets/helper/helper.go
+++ b/internal/commands/vaultsecrets/secrets/helper/helper.go
@@ -14,7 +14,7 @@ import (
 	"github.com/posener/complete"
 )
 
-// PredictAppName returns a predict function for application names.
+// PredictSecretName returns a predict function for secret names.
 func PredictSecretName(ctx *cmd.Context, c *cmd.Command, client preview_secret_service.ClientService) complete.PredictFunc {
 	return func(args complete.Args) []string {
 		// Parse the args

--- a/internal/commands/vaultsecrets/secrets/list.go
+++ b/internal/commands/vaultsecrets/secrets/list.go
@@ -96,5 +96,5 @@ func listRun(opts *ListOpts) error {
 		next := resp.Payload.Pagination.NextPageToken
 		req.PaginationNextPageToken = &next
 	}
-	return opts.Output.Display(newDisplayer(false).PreviewSecrets(secrets...))
+	return opts.Output.Display(newDisplayer().PreviewSecrets(secrets...))
 }

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -147,8 +147,7 @@ func openRun(opts *OpenOpts) (err error) {
 		return nil
 	}
 
-	displayer := newDisplayer().OpenAppSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty).
-		SetSecretType(resp.Payload.Secret.Type)
+	displayer := newDisplayer().OpenAppSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty)
 	return opts.Output.Display(displayer)
 }
 

--- a/internal/commands/vaultsecrets/secrets/open.go
+++ b/internal/commands/vaultsecrets/secrets/open.go
@@ -148,7 +148,7 @@ func openRun(opts *OpenOpts) (err error) {
 	}
 
 	displayer := newDisplayer().OpenAppSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty).
-		SetSingleSecret(resp.Payload.Secret.Type)
+		SetSecretType(resp.Payload.Secret.Type)
 	return opts.Output.Display(displayer)
 }
 

--- a/internal/commands/vaultsecrets/secrets/open_test.go
+++ b/internal/commands/vaultsecrets/secrets/open_test.go
@@ -196,6 +196,7 @@ func TestOpenRun(t *testing.T) {
 									Value:   "my super secret value",
 								},
 								CreatedAt: strfmt.DateTime(time.Now()),
+								Type:      secretTypeKV,
 							},
 						},
 					}, nil).Once()

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -95,7 +95,6 @@ func readRun(opts *ReadOpts) error {
 		return fmt.Errorf("failed to read the secret %q: %w", opts.SecretName, err)
 	}
 
-	displayer := newDisplayer().PreviewSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty).
-		SetSecretType(resp.Payload.Secret.Type)
+	displayer := newDisplayer().PreviewSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty)
 	return opts.Output.Display(displayer)
 }

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -94,5 +94,8 @@ func readRun(opts *ReadOpts) error {
 	if err != nil {
 		return fmt.Errorf("failed to read the secret %q: %w", opts.SecretName, err)
 	}
-	return opts.Output.Display(newDisplayer(true).PreviewSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty))
+
+	displayer := newDisplayer().PreviewSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty).
+		SetSingleSecret(resp.Payload.Secret.Type)
+	return opts.Output.Display(displayer)
 }

--- a/internal/commands/vaultsecrets/secrets/read.go
+++ b/internal/commands/vaultsecrets/secrets/read.go
@@ -96,6 +96,6 @@ func readRun(opts *ReadOpts) error {
 	}
 
 	displayer := newDisplayer().PreviewSecrets(resp.Payload.Secret).SetDefaultFormat(format.Pretty).
-		SetSingleSecret(resp.Payload.Secret.Type)
+		SetSecretType(resp.Payload.Secret.Type)
 	return opts.Output.Display(displayer)
 }

--- a/internal/commands/vaultsecrets/secrets/secret_types.go
+++ b/internal/commands/vaultsecrets/secrets/secret_types.go
@@ -1,0 +1,7 @@
+package secrets
+
+const (
+	secretTypeKV       = "kv"
+	secretTypeDynamic  = "dynamic"
+	secretTypeRotating = "rotating"
+)


### PR DESCRIPTION
### Changes proposed in this PR:

This PR enhances the output for dynamic secrets. Additionally, it makes the `displayer` the single source for fields to better encapsulate them. Adding a "secret type" to the displayer was necessary to be able to conditionally display fields.

List secrets:
- Removes latest version (open to bringing this back for lists)
```shell
# main branch
$ ./bin/hcp vs secrets list                         
Secret Name              Latest Version   Created At                 Type   
foo                      1                2024-06-21T16:11:29.863Z   kv     
s3_reader                0                2024-07-12T20:57:49.570Z   dynamic
service_account_viewer   0                2024-07-12T20:53:49.707Z   dynamic

# PR branch
$ ./bin/hcp vs secrets list                     
Secret Name              Type      Created At              
foo                      kv        2024-06-21T16:11:29.863Z
s3_reader                dynamic   2024-07-12T20:57:49.570Z
service_account_viewer   dynamic   2024-07-12T20:53:49.707Z
```

Read dynamic secret:
- Removes latest version for only dynamic secrets
```shell
# main branch
$ ./bin/hcp vs secrets read --format=table s3_reader
Secret Name   Latest Version   Created At                 Type   
s3_reader     0                2024-07-12T20:57:49.570Z   dynamic

# PR branch
$ ./bin/hcp vs secrets read --format=table s3_reader
Secret Name   Type      Created At              
s3_reader     dynamic   2024-07-12T20:57:49.570Z
```

Open secrets:
- Adds expires at, time-to-live for only dynamic secrets
- Removes latest version for only dynamic secrets
- Fixes created at to be the time the dynamic credential was generated instead of time dynamic secret resource was created
```shell
# main branch
$ ./bin/hcp vs secrets open --format=table s3_reader
Secret Name   Latest Version   Created At                 Values                                                                
s3_reader     0                2024-07-12T20:57:49.570Z   access_key_id: redacted
                                                          assumed_role_user_arn: redacted                                
                                                          secret_access_key: redacted
                                                          session_token: redacted

# PR branch
$ ./bin/hcp vs secrets open --format=table s3_reader
Secret Name   Type      Created At                 Expires At                 Time-to-Live   Values                             
s3_reader     dynamic   2024-07-18T16:12:13.765Z   2024-07-18T17:12:13.765Z   3600s          access_key_id: redacted
                                                                                             assumed_role_user_arn: redacted                                
                                                                                             secret_access_key: redacted           
                                                                                             session_token: redacted
```

### How I've tested this PR:

Ran `make go/test` and manual testing. I will address test coverage once I get feedback this is directionally okay.

### How I expect reviewers to test this PR:

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

Run commands above with different secret types to see if there are any bugs / missing information.

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
