### PR TITLE
VAULT-29013 Read a Vault Secrets Integration

### DIFF
--- a/internal/commands/vaultsecrets/integrations/displayer.go
+++ b/internal/commands/vaultsecrets/integrations/displayer.go
@@ -8,64 +8,42 @@ import (
 	"github.com/hashicorp/hcp/internal/pkg/format"
 )
 
-type displayer struct {
-	previewTwilioIntegrations  []*preview_models.Secrets20231128TwilioIntegration
-	previewMongoDBIntegrations []*preview_models.Secrets20231128MongoDBAtlasIntegration
+type twilioDisplayer struct {
+	previewTwilioIntegrations []*preview_models.Secrets20231128TwilioIntegration
 
 	single bool
 }
 
-func newTwilioDisplayer(single bool, integrations ...*preview_models.Secrets20231128TwilioIntegration) *displayer {
-	return &displayer{
+func newTwilioDisplayer(single bool, integrations ...*preview_models.Secrets20231128TwilioIntegration) *twilioDisplayer {
+	return &twilioDisplayer{
 		previewTwilioIntegrations: integrations,
 		single:                    single,
 	}
 }
 
-func newMongoDBDisplayer(single bool, integrations ...*preview_models.Secrets20231128MongoDBAtlasIntegration) *displayer {
-	return &displayer{
-		previewMongoDBIntegrations: integrations,
-		single:                     single,
-	}
-}
-
-func (d *displayer) DefaultFormat() format.Format {
+func (t *twilioDisplayer) DefaultFormat() format.Format {
 	return format.Table
 }
 
-func (d *displayer) Payload() any {
-	if d.previewTwilioIntegrations != nil {
-		return d.previewTwilioIntegrationsPayload()
-	}
-
-	if d.previewMongoDBIntegrations != nil {
-		return d.previewMongoDBIntegrationsPayload()
+func (t *twilioDisplayer) Payload() any {
+	if t.previewTwilioIntegrations != nil {
+		return t.previewTwilioIntegrationsPayload()
 	}
 
 	return nil
 }
 
-func (d *displayer) previewTwilioIntegrationsPayload() any {
-	if d.single {
-		if len(d.previewTwilioIntegrations) != 1 {
+func (t *twilioDisplayer) previewTwilioIntegrationsPayload() any {
+	if t.single {
+		if len(t.previewTwilioIntegrations) != 1 {
 			return nil
 		}
-		return d.previewTwilioIntegrations[0]
+		return t.previewTwilioIntegrations[0]
 	}
-	return d.previewTwilioIntegrations
+	return t.previewTwilioIntegrations
 }
 
-func (d *displayer) previewMongoDBIntegrationsPayload() any {
-	if d.single {
-		if len(d.previewMongoDBIntegrations) != 1 {
-			return nil
-		}
-		return d.previewMongoDBIntegrations[0]
-	}
-	return d.previewMongoDBIntegrations
-}
-
-func (d *displayer) FieldTemplates() []format.Field {
+func (t *twilioDisplayer) FieldTemplates() []format.Field {
 	return []format.Field{
 		{
 			Name:        "Integration Name",
@@ -74,6 +52,55 @@ func (d *displayer) FieldTemplates() []format.Field {
 		{
 			Name:        "Account SID",
 			ValueFormat: "{{ .TwilioAccountSid }}",
+		},
+	}
+}
+
+type mongodbDisplayer struct {
+	previewMongoDBIntegrations []*preview_models.Secrets20231128MongoDBAtlasIntegration
+
+	single bool
+}
+
+func newMongoDBDisplayer(single bool, integrations ...*preview_models.Secrets20231128MongoDBAtlasIntegration) *mongodbDisplayer {
+	return &mongodbDisplayer{
+		previewMongoDBIntegrations: integrations,
+		single:                     single,
+	}
+}
+
+func (m *mongodbDisplayer) DefaultFormat() format.Format {
+	return format.Table
+}
+
+func (m *mongodbDisplayer) Payload() any {
+
+	if m.previewMongoDBIntegrations != nil {
+		return m.previewMongoDBIntegrationsPayload()
+	}
+
+	return nil
+}
+
+func (m *mongodbDisplayer) previewMongoDBIntegrationsPayload() any {
+	if m.single {
+		if len(m.previewMongoDBIntegrations) != 1 {
+			return nil
+		}
+		return m.previewMongoDBIntegrations[0]
+	}
+	return m.previewMongoDBIntegrations
+}
+
+func (m *mongodbDisplayer) FieldTemplates() []format.Field {
+	return []format.Field{
+		{
+			Name:        "Integration Name",
+			ValueFormat: "{{ .IntegrationName }}",
+		},
+		{
+			Name:        "API Public Key",
+			ValueFormat: "{{ .APIPublicKey }}",
 		},
 	}
 }

--- a/internal/commands/vaultsecrets/integrations/displayer.go
+++ b/internal/commands/vaultsecrets/integrations/displayer.go
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package integrations
+
+import (
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+)
+
+type displayer struct {
+	previewTwilioIntegrations  []*preview_models.Secrets20231128TwilioIntegration
+	previewMongoDBIntegrations []*preview_models.Secrets20231128MongoDBAtlasIntegration
+
+	single bool
+}
+
+func newTwilioDisplayer(single bool, integrations ...*preview_models.Secrets20231128TwilioIntegration) *displayer {
+	return &displayer{
+		previewTwilioIntegrations: integrations,
+		single:                    single,
+	}
+}
+
+func newMongoDBDisplayer(single bool, integrations ...*preview_models.Secrets20231128MongoDBAtlasIntegration) *displayer {
+	return &displayer{
+		previewMongoDBIntegrations: integrations,
+		single:                     single,
+	}
+}
+
+func (d *displayer) DefaultFormat() format.Format {
+	return format.Table
+}
+
+func (d *displayer) Payload() any {
+	if d.previewTwilioIntegrations != nil {
+		return d.previewTwilioIntegrationsPayload()
+	}
+
+	if d.previewMongoDBIntegrations != nil {
+		return d.previewMongoDBIntegrationsPayload()
+	}
+
+	return nil
+}
+
+func (d *displayer) previewTwilioIntegrationsPayload() any {
+	if d.single {
+		if len(d.previewTwilioIntegrations) != 1 {
+			return nil
+		}
+		return d.previewTwilioIntegrations[0]
+	}
+	return d.previewTwilioIntegrations
+}
+
+func (d *displayer) previewMongoDBIntegrationsPayload() any {
+	if d.single {
+		if len(d.previewMongoDBIntegrations) != 1 {
+			return nil
+		}
+		return d.previewMongoDBIntegrations[0]
+	}
+	return d.previewMongoDBIntegrations
+}
+
+func (d *displayer) FieldTemplates() []format.Field {
+	return []format.Field{
+		{
+			Name:        "Integration Name",
+			ValueFormat: "{{ .IntegrationName }}",
+		},
+		{
+			Name:        "Account SID",
+			ValueFormat: "{{ .TwilioAccountSid }}",
+		},
+	}
+}

--- a/internal/commands/vaultsecrets/integrations/integrations.go
+++ b/internal/commands/vaultsecrets/integrations/integrations.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package integrations
+
+import (
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+)
+
+func NewCmdIntegrations(ctx *cmd.Context) *cmd.Command {
+	cmd := &cmd.Command{
+		Name:      "integrations",
+		ShortHelp: "Manage Vault Secrets integrations.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations" }} command group lets you
+		manage Vault Secrets integrations.
+		`),
+		PersistentPreRun: func(c *cmd.Command, args []string) error {
+			return cmd.RequireOrgAndProject(ctx)
+		},
+	}
+
+	cmd.AddChild(NewCmdRead(ctx, nil))
+	return cmd
+}

--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -30,8 +30,8 @@ type ReadOpts struct {
 }
 
 const (
-	Twilio  string = "twilio"
-	MongoDB        = "mongo"
+	Twilio  = "twilio"
+	MongoDB = "mongo"
 )
 
 func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {

--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -9,7 +9,6 @@ import (
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
-	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/apps/helper"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/format"
@@ -48,9 +47,9 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 		`),
 		Examples: []cmd.Example{
 			{
-				Preamble: `Read an application:`,
+				Preamble: `Read an integration:`,
 				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
-				$ hcp vault-secrets apps read company-card
+				$ hcp vault-secrets integrations read sample-integration --type twilio
 				`),
 			},
 		},
@@ -58,7 +57,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 			Args: []cmd.PositionalArgument{
 				{
 					Name:          "NAME",
-					Documentation: "The name of the app to read.",
+					Documentation: "The name of the integration to read.",
 				},
 			},
 		},
@@ -82,7 +81,6 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 			return readRun(opts)
 		},
 	}
-	cmd.Args.Autocomplete = helper.PredictAppName(ctx, cmd, preview_secret_service.New(ctx.HCP, nil))
 
 	return cmd
 }

--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -66,7 +66,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 				{
 					Name:         "type",
 					DisplayValue: "TYPE",
-					Description:  "A required type for the integration to be read.",
+					Description:  "The type of the integration to read.",
 					Value:        flagvalue.Simple("", &opts.Type),
 					Required:     true,
 				},

--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -29,6 +29,11 @@ type ReadOpts struct {
 	PreviewClient   preview_secret_service.ClientService
 }
 
+const (
+	Twilio  string = "twilio"
+	MongoDB        = "mongo"
+)
+
 func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 	opts := &ReadOpts{
 		Ctx:           ctx.ShutdownCtx,
@@ -87,7 +92,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 
 func readRun(opts *ReadOpts) error {
 	switch opts.Type {
-	case "twilio":
+	case Twilio:
 		resp, err := opts.PreviewClient.GetTwilioIntegration(&preview_secret_service.GetTwilioIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,
@@ -100,7 +105,7 @@ func readRun(opts *ReadOpts) error {
 
 		return opts.Output.Display(newTwilioDisplayer(true, resp.Payload.Integration))
 
-	case "mongodb":
+	case MongoDB:
 		resp, err := opts.PreviewClient.GetMongoDBAtlasIntegration(&preview_secret_service.GetMongoDBAtlasIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,

--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -1,0 +1,121 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package integrations
+
+import (
+	"context"
+	"fmt"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/apps/helper"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+type ReadOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	Output  *format.Outputter
+	IO      iostreams.IOStreams
+
+	IntegrationName string
+	Type            string
+	Client          secret_service.ClientService
+	PreviewClient   preview_secret_service.ClientService
+}
+
+func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
+	opts := &ReadOpts{
+		Ctx:           ctx.ShutdownCtx,
+		Profile:       ctx.Profile,
+		Output:        ctx.Output,
+		IO:            ctx.IO,
+		Client:        secret_service.New(ctx.HCP, nil),
+		PreviewClient: preview_secret_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "read",
+		ShortHelp: "Read a Vault Secrets integration.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations read" }} command gets a Vault Secrets integration.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: `Read an application:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp vault-secrets apps read company-card
+				`),
+			},
+		},
+		Args: cmd.PositionalArguments{
+			Args: []cmd.PositionalArgument{
+				{
+					Name:          "NAME",
+					Documentation: "The name of the app to read.",
+				},
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "type",
+					DisplayValue: "TYPE",
+					Description:  "A required type for the integration to be read.",
+					Value:        flagvalue.Simple("", &opts.Type),
+					Required:     true,
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			opts.IntegrationName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return readRun(opts)
+		},
+	}
+	cmd.Args.Autocomplete = helper.PredictAppName(ctx, cmd, preview_secret_service.New(ctx.HCP, nil))
+
+	return cmd
+}
+
+func readRun(opts *ReadOpts) error {
+	switch opts.Type {
+	case "twilio":
+		resp, err := opts.PreviewClient.GetTwilioIntegration(&preview_secret_service.GetTwilioIntegrationParams{
+			Context:         opts.Ctx,
+			ProjectID:       opts.Profile.ProjectID,
+			OrganizationID:  opts.Profile.OrganizationID,
+			IntegrationName: opts.IntegrationName,
+		}, nil)
+		if err != nil {
+			return fmt.Errorf("failed to read integration: %w", err)
+		}
+
+		return opts.Output.Display(newTwilioDisplayer(true, resp.Payload.Integration))
+
+	case "mongodb":
+		resp, err := opts.PreviewClient.GetMongoDBAtlasIntegration(&preview_secret_service.GetMongoDBAtlasIntegrationParams{
+			Context:         opts.Ctx,
+			ProjectID:       opts.Profile.ProjectID,
+			OrganizationID:  opts.Profile.OrganizationID,
+			IntegrationName: opts.IntegrationName,
+		}, nil)
+		if err != nil {
+			return fmt.Errorf("failed to read integration: %w", err)
+		}
+
+		return opts.Output.Display(newMongoDBDisplayer(true, resp.Payload.Integration))
+
+	default:
+		return fmt.Errorf("not a valid integration type")
+	}
+}

--- a/internal/commands/vaultsecrets/integrations/read_test.go
+++ b/internal/commands/vaultsecrets/integrations/read_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package integrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func TestNewCmdRead(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *ReadOpts
+	}{
+		{
+			Name: "Good",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args: []string{"sample-integration", "--type", "twilio"},
+			Expect: &ReadOpts{
+				IntegrationName: "sample-integration",
+			},
+		},
+		{
+			Name: "Missing type flag",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args:  []string{"sample-integration"},
+			Error: "ERROR: missing required flag: --type=TYPE",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+
+			r := require.New(t)
+			io := iostreams.Test()
+
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				ShutdownCtx: context.Background(),
+				HCP:         &client.Runtime{},
+				Output:      format.New(io),
+			}
+
+			var readOpts *ReadOpts
+			readCmd := NewCmdRead(ctx, func(o *ReadOpts) error {
+				readOpts = o
+				return nil
+			})
+			readCmd.SetIO(io)
+
+			code := readCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(readOpts)
+			r.Equal(c.Expect.IntegrationName, readOpts.IntegrationName)
+		})
+	}
+}
+
+func TestReadRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name            string
+		ErrMsg          string
+		IntegrationName string
+		Type            string
+	}{
+		{
+			Name:   "Failed: Integration not found",
+			ErrMsg: "[GET /secrets/2023-11-28/organizations/{organization_id}/projects/{project_id}/integrations/twilio/config/{integration_name}][403] GetTwilioIntegration",
+			Type:   "twilio",
+		},
+		{
+			Name:            "Success: Read integration",
+			IntegrationName: "sample-integration",
+			Type:            "twilio",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			vs := mock_preview_secret_service.NewMockClientService(t)
+
+			opts := &ReadOpts{
+				Ctx:             context.Background(),
+				Profile:         profile.TestProfile(t).SetOrgID("123").SetProjectID("abc"),
+				IO:              io,
+				PreviewClient:   vs,
+				Output:          format.New(io),
+				IntegrationName: c.IntegrationName,
+				Type:            c.Type,
+			}
+
+			if c.ErrMsg != "" {
+				vs.EXPECT().GetTwilioIntegration(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
+			} else {
+				vs.EXPECT().GetTwilioIntegration(&preview_secret_service.GetTwilioIntegrationParams{
+					OrganizationID:  "123",
+					ProjectID:       "abc",
+					IntegrationName: opts.IntegrationName,
+					Context:         opts.Ctx,
+				}, nil).Return(&preview_secret_service.GetTwilioIntegrationOK{
+					Payload: &preview_models.Secrets20231128GetTwilioIntegrationResponse{
+						Integration: &preview_models.Secrets20231128TwilioIntegration{
+							IntegrationName: opts.IntegrationName,
+						},
+					},
+				}, nil).Once()
+			}
+
+			// Run the command
+			err := readRun(opts)
+			if c.ErrMsg != "" {
+				r.Contains(err.Error(), c.ErrMsg)
+				return
+			}
+
+			r.NoError(err)
+			r.Contains(io.Output.String(), fmt.Sprintf("Integration Name     Account SID\n%s              \n", opts.IntegrationName))
+		})
+	}
+}

--- a/internal/commands/vaultsecrets/integrations/read_test.go
+++ b/internal/commands/vaultsecrets/integrations/read_test.go
@@ -9,18 +9,17 @@ import (
 	"fmt"
 	"testing"
 
-	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
-	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/go-openapi/runtime/client"
 	"github.com/stretchr/testify/require"
 
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
 	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestNewCmdRead(t *testing.T) {

--- a/internal/commands/vaultsecrets/vault_secrets.go
+++ b/internal/commands/vaultsecrets/vault_secrets.go
@@ -6,6 +6,7 @@ package vaultsecrets
 import (
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/apps"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/gatewaypools"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/integrations"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/run"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
@@ -26,6 +27,7 @@ func NewCmdVaultSecrets(ctx *cmd.Context) *cmd.Command {
 	}
 
 	cmd.AddChild(apps.NewCmdApps(ctx))
+	cmd.AddChild(integrations.NewCmdIntegrations(ctx))
 	cmd.AddChild(secrets.NewCmdSecrets(ctx))
 	cmd.AddChild(gatewaypools.NewCmdGatewayPools(ctx))
 	cmd.AddChild(run.NewCmdRun(ctx, nil))


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds the read command for hvs integrations for ticket https://hashicorp.atlassian.net/browse/VAULT-29013


### How I've tested this PR:
Ran `make go/build` to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Read an integration `./bin/hcp vault-secrets integrations read {YOUR_INTEGRATION_NAME} --type {YOUR_INTEGRATION_TYPE}`

### Output of affected commands:
```
❯ ./bin/hcp vs integrations --help                                                                                                                                                                           ─╯
USAGE
  hcp vault-secrets integrations <command> [Optional Flags]

DESCRIPTION
  The hcp vault-secrets integrations command group lets you manage Vault Secrets
  integrations.

COMMANDS
  read:  Read a Vault Secrets integration.

❯ ./bin/hcp vs integrations read --help                                                                                                                                                                      ─╯
USAGE
  hcp vault-secrets integrations read NAME --type=TYPE [Optional Flags]

DESCRIPTION
  The hcp vault-secrets integrations read command gets a Vault Secrets
  integration.

EXAMPLES
  Read an integration:
  
  $ hcp vault-secrets integrations read sample-integration --type twilio

POSITIONAL ARGUMENTS
  NAME
    The name of the integration to read.

REQUIRED FLAGS
  --type=TYPE
    The type of the integration to read.

GLOBAL FLAGS
  --debug, --format=FORMAT, --profile=NAME, --project=ID, --quiet
  
  For more global flag details, run $ hcp --help

❯ ./bin/hcp vs integrations read Twil-Int --type twilio                                                                                                                                                      ─╯
Integration Name   Account SID                       
Twil-Int           {TWILIO_SID}
```


### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
