### PR TITLE
VAULT-29014 - Delete a HVS integration

### DIFF
--- a/internal/commands/vaultsecrets/integrations/delete.go
+++ b/internal/commands/vaultsecrets/integrations/delete.go
@@ -87,7 +87,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 
 func deleteRun(opts *DeleteOpts) error {
 	switch opts.Type {
-	case "twilio":
+	case Twilio:
 		_, err := opts.PreviewClient.DeleteTwilioIntegration(&preview_secret_service.DeleteTwilioIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,
@@ -101,7 +101,7 @@ func deleteRun(opts *DeleteOpts) error {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
 		return nil
 
-	case "mongodb":
+	case MongoDB:
 		_, err := opts.PreviewClient.DeleteMongoDBAtlasIntegration(&preview_secret_service.DeleteMongoDBAtlasIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,

--- a/internal/commands/vaultsecrets/integrations/delete.go
+++ b/internal/commands/vaultsecrets/integrations/delete.go
@@ -87,7 +87,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 
 func deleteRun(opts *DeleteOpts) error {
 	switch opts.Type {
-	case Twilio:
+	case IntegrationType_Twilio:
 		_, err := opts.PreviewClient.DeleteTwilioIntegration(&preview_secret_service.DeleteTwilioIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,
@@ -102,13 +102,41 @@ func deleteRun(opts *DeleteOpts) error {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
 		return nil
 
-	case MongoDB:
+	case IntegrationType_MONGODB_ATLAS:
 		_, err := opts.PreviewClient.DeleteMongoDBAtlasIntegration(&preview_secret_service.DeleteMongoDBAtlasIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,
 			OrganizationID:  opts.Profile.OrganizationID,
 			IntegrationName: opts.IntegrationName,
 			Name:            &opts.IntegrationName,
+		}, nil)
+		if err != nil {
+			return fmt.Errorf("failed to delete integration: %w", err)
+		}
+
+		fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
+		return nil
+
+	case IntegrationType_AWS:
+		_, err := opts.PreviewClient.DeleteAwsIntegration(&preview_secret_service.DeleteAwsIntegrationParams{
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Name:           opts.IntegrationName,
+		}, nil)
+		if err != nil {
+			return fmt.Errorf("failed to delete integration: %w", err)
+		}
+
+		fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
+		return nil
+
+	case IntegrationType_GCP:
+		_, err := opts.PreviewClient.DeleteGcpIntegration(&preview_secret_service.DeleteGcpIntegrationParams{
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Name:           opts.IntegrationName,
 		}, nil)
 		if err != nil {
 			return fmt.Errorf("failed to delete integration: %w", err)

--- a/internal/commands/vaultsecrets/integrations/delete.go
+++ b/internal/commands/vaultsecrets/integrations/delete.go
@@ -24,7 +24,7 @@ type DeleteOpts struct {
 	IO      iostreams.IOStreams
 
 	IntegrationName string
-	Type            string
+	Type            IntegrationType
 	Client          secret_service.ClientService
 	PreviewClient   preview_secret_service.ClientService
 }
@@ -93,6 +93,7 @@ func deleteRun(opts *DeleteOpts) error {
 			ProjectID:       opts.Profile.ProjectID,
 			OrganizationID:  opts.Profile.OrganizationID,
 			IntegrationName: opts.IntegrationName,
+			Name:            &opts.IntegrationName,
 		}, nil)
 		if err != nil {
 			return fmt.Errorf("failed to delete integration: %w", err)
@@ -107,6 +108,7 @@ func deleteRun(opts *DeleteOpts) error {
 			ProjectID:       opts.Profile.ProjectID,
 			OrganizationID:  opts.Profile.OrganizationID,
 			IntegrationName: opts.IntegrationName,
+			Name:            &opts.IntegrationName,
 		}, nil)
 		if err != nil {
 			return fmt.Errorf("failed to delete integration: %w", err)

--- a/internal/commands/vaultsecrets/integrations/delete.go
+++ b/internal/commands/vaultsecrets/integrations/delete.go
@@ -87,7 +87,7 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 
 func deleteRun(opts *DeleteOpts) error {
 	switch opts.Type {
-	case IntegrationType_Twilio:
+	case Twilio:
 		_, err := opts.PreviewClient.DeleteTwilioIntegration(&preview_secret_service.DeleteTwilioIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,
@@ -102,7 +102,7 @@ func deleteRun(opts *DeleteOpts) error {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
 		return nil
 
-	case IntegrationType_MONGODB_ATLAS:
+	case MongoDBAtlas:
 		_, err := opts.PreviewClient.DeleteMongoDBAtlasIntegration(&preview_secret_service.DeleteMongoDBAtlasIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,
@@ -117,7 +117,7 @@ func deleteRun(opts *DeleteOpts) error {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
 		return nil
 
-	case IntegrationType_AWS:
+	case AWS:
 		_, err := opts.PreviewClient.DeleteAwsIntegration(&preview_secret_service.DeleteAwsIntegrationParams{
 			Context:        opts.Ctx,
 			ProjectID:      opts.Profile.ProjectID,
@@ -131,7 +131,7 @@ func deleteRun(opts *DeleteOpts) error {
 		fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
 		return nil
 
-	case IntegrationType_GCP:
+	case GCP:
 		_, err := opts.PreviewClient.DeleteGcpIntegration(&preview_secret_service.DeleteGcpIntegrationParams{
 			Context:        opts.Ctx,
 			ProjectID:      opts.Profile.ProjectID,

--- a/internal/commands/vaultsecrets/integrations/delete.go
+++ b/internal/commands/vaultsecrets/integrations/delete.go
@@ -1,0 +1,121 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package integrations
+
+import (
+	"context"
+	"fmt"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+type DeleteOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	Output  *format.Outputter
+	IO      iostreams.IOStreams
+
+	IntegrationName string
+	Type            string
+	Client          secret_service.ClientService
+	PreviewClient   preview_secret_service.ClientService
+}
+
+func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
+	opts := &DeleteOpts{
+		Ctx:           ctx.ShutdownCtx,
+		Profile:       ctx.Profile,
+		Output:        ctx.Output,
+		IO:            ctx.IO,
+		Client:        secret_service.New(ctx.HCP, nil),
+		PreviewClient: preview_secret_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "delete",
+		ShortHelp: "Delete a Vault Secrets integration.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+      The {{ template "mdCodeOrBold" "hcp vault-secrets integrations delete" }} command deletes a Vault Secrets integration.
+      `),
+		Examples: []cmd.Example{
+			{
+				Preamble: `Delete an integration:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+            $ hcp vault-secrets integrations delete sample-integration --type twilio
+            `),
+			},
+		},
+		Args: cmd.PositionalArguments{
+			Args: []cmd.PositionalArgument{
+				{
+					Name:          "NAME",
+					Documentation: "The name of the integration to delete.",
+				},
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "type",
+					DisplayValue: "TYPE",
+					Description:  "The type of the integration to delete.",
+					Value:        flagvalue.Simple("", &opts.Type),
+					Required:     true,
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			opts.IntegrationName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return deleteRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+func deleteRun(opts *DeleteOpts) error {
+	switch opts.Type {
+	case "twilio":
+		_, err := opts.PreviewClient.DeleteTwilioIntegration(&preview_secret_service.DeleteTwilioIntegrationParams{
+			Context:         opts.Ctx,
+			ProjectID:       opts.Profile.ProjectID,
+			OrganizationID:  opts.Profile.OrganizationID,
+			IntegrationName: opts.IntegrationName,
+		}, nil)
+		if err != nil {
+			return fmt.Errorf("failed to delete integration: %w", err)
+		}
+
+		fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
+		return nil
+
+	case "mongodb":
+		_, err := opts.PreviewClient.DeleteMongoDBAtlasIntegration(&preview_secret_service.DeleteMongoDBAtlasIntegrationParams{
+			Context:         opts.Ctx,
+			ProjectID:       opts.Profile.ProjectID,
+			OrganizationID:  opts.Profile.OrganizationID,
+			IntegrationName: opts.IntegrationName,
+		}, nil)
+		if err != nil {
+			return fmt.Errorf("failed to delete integration: %w", err)
+		}
+
+		fmt.Fprintf(opts.IO.Err(), "%s Successfully deleted integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
+		return nil
+
+	default:
+		return fmt.Errorf("not a valid integration type")
+	}
+}

--- a/internal/commands/vaultsecrets/integrations/delete_test.go
+++ b/internal/commands/vaultsecrets/integrations/delete_test.go
@@ -96,17 +96,17 @@ func TestDeleteRun(t *testing.T) {
 		Name            string
 		ErrMsg          string
 		IntegrationName string
-		Type            string
+		Type            IntegrationType
 	}{
 		{
 			Name:   "Failed: Integration not found",
 			ErrMsg: "[DELETE /secrets/2023-11-28/organizations/{organization_id}/projects/{project_id}/integrations/twilio/config/{integration_name}][404] DeleteTwilioIntegration",
-			Type:   "twilio",
+			Type:   Twilio,
 		},
 		{
 			Name:            "Success: Delete integration",
 			IntegrationName: "sample-integration",
-			Type:            "twilio",
+			Type:            Twilio,
 		},
 	}
 
@@ -136,6 +136,7 @@ func TestDeleteRun(t *testing.T) {
 					OrganizationID:  "123",
 					ProjectID:       "abc",
 					IntegrationName: opts.IntegrationName,
+					Name:            &opts.IntegrationName,
 					Context:         opts.Ctx,
 				}, nil).Return(&preview_secret_service.DeleteTwilioIntegrationOK{}, nil).Once()
 			}

--- a/internal/commands/vaultsecrets/integrations/delete_test.go
+++ b/internal/commands/vaultsecrets/integrations/delete_test.go
@@ -148,7 +148,7 @@ func TestDeleteRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Contains(io.Error.String(), fmt.Sprintf("✓ Successfully deleted integration with name \"sample-integration\"\n"))
+			r.Contains(io.Error.String(), fmt.Sprintf("✓ Successfully deleted integration with name \"%s\"\n", c.IntegrationName))
 		})
 	}
 }

--- a/internal/commands/vaultsecrets/integrations/displayer.go
+++ b/internal/commands/vaultsecrets/integrations/displayer.go
@@ -100,7 +100,7 @@ func (m *mongodbDisplayer) FieldTemplates() []format.Field {
 		},
 		{
 			Name:        "API Public Key",
-			ValueFormat: "{{ .APIPublicKey }}",
+			ValueFormat: "{{ .MongodbAPIPublicKey }}",
 		},
 	}
 }

--- a/internal/commands/vaultsecrets/integrations/integrations.go
+++ b/internal/commands/vaultsecrets/integrations/integrations.go
@@ -22,5 +22,6 @@ func NewCmdIntegrations(ctx *cmd.Context) *cmd.Command {
 	}
 
 	cmd.AddChild(NewCmdRead(ctx, nil))
+	cmd.AddChild(NewCmdDelete(ctx, nil))
 	return cmd
 }

--- a/internal/commands/vaultsecrets/integrations/integrations.go
+++ b/internal/commands/vaultsecrets/integrations/integrations.go
@@ -11,8 +11,10 @@ import (
 type IntegrationType string
 
 const (
-	Twilio  IntegrationType = "twilio"
-	MongoDB IntegrationType = "mongodb-atlas"
+	IntegrationType_Twilio        IntegrationType = "twilio"
+	IntegrationType_MONGODB_ATLAS IntegrationType = "mongodb-atlas"
+	IntegrationType_AWS           IntegrationType = "aws"
+	IntegrationType_GCP           IntegrationType = "gcp"
 )
 
 func NewCmdIntegrations(ctx *cmd.Context) *cmd.Command {

--- a/internal/commands/vaultsecrets/integrations/integrations.go
+++ b/internal/commands/vaultsecrets/integrations/integrations.go
@@ -8,6 +8,13 @@ import (
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 )
 
+type IntegrationType string
+
+const (
+	Twilio  IntegrationType = "twilio"
+	MongoDB IntegrationType = "mongodb-atlas"
+)
+
 func NewCmdIntegrations(ctx *cmd.Context) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "integrations",

--- a/internal/commands/vaultsecrets/integrations/integrations.go
+++ b/internal/commands/vaultsecrets/integrations/integrations.go
@@ -11,10 +11,10 @@ import (
 type IntegrationType string
 
 const (
-	IntegrationType_Twilio        IntegrationType = "twilio"
-	IntegrationType_MONGODB_ATLAS IntegrationType = "mongodb-atlas"
-	IntegrationType_AWS           IntegrationType = "aws"
-	IntegrationType_GCP           IntegrationType = "gcp"
+	Twilio       IntegrationType = "twilio"
+	MongoDBAtlas IntegrationType = "mongodb-atlas"
+	AWS          IntegrationType = "aws"
+	GCP          IntegrationType = "gcp"
 )
 
 func NewCmdIntegrations(ctx *cmd.Context) *cmd.Command {

--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -87,7 +87,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 
 func readRun(opts *ReadOpts) error {
 	switch opts.Type {
-	case IntegrationType_Twilio:
+	case Twilio:
 		resp, err := opts.PreviewClient.GetTwilioIntegration(&preview_secret_service.GetTwilioIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,
@@ -100,7 +100,7 @@ func readRun(opts *ReadOpts) error {
 
 		return opts.Output.Display(newTwilioDisplayer(true, resp.Payload.Integration))
 
-	case IntegrationType_MONGODB_ATLAS:
+	case MongoDBAtlas:
 		resp, err := opts.PreviewClient.GetMongoDBAtlasIntegration(&preview_secret_service.GetMongoDBAtlasIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,

--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -87,7 +87,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 
 func readRun(opts *ReadOpts) error {
 	switch opts.Type {
-	case Twilio:
+	case IntegrationType_Twilio:
 		resp, err := opts.PreviewClient.GetTwilioIntegration(&preview_secret_service.GetTwilioIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,
@@ -100,7 +100,7 @@ func readRun(opts *ReadOpts) error {
 
 		return opts.Output.Display(newTwilioDisplayer(true, resp.Payload.Integration))
 
-	case MongoDB:
+	case IntegrationType_MONGODB_ATLAS:
 		resp, err := opts.PreviewClient.GetMongoDBAtlasIntegration(&preview_secret_service.GetMongoDBAtlasIntegrationParams{
 			Context:         opts.Ctx,
 			ProjectID:       opts.Profile.ProjectID,

--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -24,15 +24,10 @@ type ReadOpts struct {
 	IO      iostreams.IOStreams
 
 	IntegrationName string
-	Type            string
+	Type            IntegrationType
 	Client          secret_service.ClientService
 	PreviewClient   preview_secret_service.ClientService
 }
-
-const (
-	Twilio  = "twilio"
-	MongoDB = "mongo"
-)
 
 func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 	opts := &ReadOpts{

--- a/internal/commands/vaultsecrets/integrations/read_test.go
+++ b/internal/commands/vaultsecrets/integrations/read_test.go
@@ -98,17 +98,17 @@ func TestReadRun(t *testing.T) {
 		Name            string
 		ErrMsg          string
 		IntegrationName string
-		Type            string
+		Type            IntegrationType
 	}{
 		{
 			Name:   "Failed: Integration not found",
 			ErrMsg: "[GET /secrets/2023-11-28/organizations/{organization_id}/projects/{project_id}/integrations/twilio/config/{integration_name}][404] GetTwilioIntegration",
-			Type:   "twilio",
+			Type:   Twilio,
 		},
 		{
 			Name:            "Success: Read integration",
 			IntegrationName: "sample-integration",
-			Type:            "twilio",
+			Type:            Twilio,
 		},
 	}
 


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds the delete command for hvs integrations for ticket https://hashicorp.atlassian.net/browse/VAULT-29014

### How I've tested this PR:
Ran make go/build to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Delete an integration `./bin/hcp vault-secrets integrations delete {YOUR_INTEGRATION_NAME} --type {YOUR_INTEGRATION_TYPE}

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
<img width="1059" alt="Screenshot 2024-07-24 at 10 02 31 AM" src="https://github.com/user-attachments/assets/87671bb3-6de6-4219-a231-202173576b78">

### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
