### PR TITLE
VAULT-29259 -  List HVS integrations

### DIFF
--- a/internal/commands/vaultsecrets/integrations/displayer.go
+++ b/internal/commands/vaultsecrets/integrations/displayer.go
@@ -47,7 +47,7 @@ func (t *twilioDisplayer) FieldTemplates() []format.Field {
 	fields := []format.Field{
 		{
 			Name:        "Integration Name",
-			ValueFormat: "{{ .IntegrationName }}",
+			ValueFormat: "{{ .Name }}",
 		},
 	}
 
@@ -103,7 +103,7 @@ func (m *mongodbDisplayer) FieldTemplates() []format.Field {
 	fields := []format.Field{
 		{
 			Name:        "Integration Name",
-			ValueFormat: "{{ .IntegrationName }}",
+			ValueFormat: "{{ .Name }}",
 		},
 	}
 
@@ -158,7 +158,7 @@ func (g *genericDisplayer) FieldTemplates() []format.Field {
 	return []format.Field{
 		{
 			Name:        "Integration Name",
-			ValueFormat: "{{ .IntegrationName }}",
+			ValueFormat: "{{ .Name }}",
 		},
 	}
 }

--- a/internal/commands/vaultsecrets/integrations/displayer.go
+++ b/internal/commands/vaultsecrets/integrations/displayer.go
@@ -55,7 +55,11 @@ func (t *twilioDisplayer) FieldTemplates() []format.Field {
 		return append(fields, []format.Field{
 			{
 				Name:        "Account SID",
-				ValueFormat: "{{ .TwilioAccountSid }}",
+				ValueFormat: "{{ .StaticCredentialDetails.AccountSid }}",
+			},
+			{
+				Name:        "API Key SID",
+				ValueFormat: "{{ .StaticCredentialDetails.APIKeySid }}",
 			},
 		}...)
 	} else {
@@ -111,7 +115,123 @@ func (m *mongodbDisplayer) FieldTemplates() []format.Field {
 		return append(fields, []format.Field{
 			{
 				Name:        "API Public Key",
-				ValueFormat: "{{ .MongodbAPIPublicKey }}",
+				ValueFormat: "{{ .StaticCredentialDetails.APIPublicKey }}",
+			},
+		}...)
+	} else {
+		return fields
+	}
+}
+
+type awsDisplayer struct {
+	previewAwsIntegrations []*preview_models.Secrets20231128AwsIntegration
+
+	single bool
+}
+
+func newAwsDisplayer(single bool, integrations ...*preview_models.Secrets20231128AwsIntegration) *awsDisplayer {
+	return &awsDisplayer{
+		previewAwsIntegrations: integrations,
+		single:                 single,
+	}
+}
+
+func (a *awsDisplayer) DefaultFormat() format.Format {
+	return format.Table
+}
+
+func (a *awsDisplayer) Payload() any {
+
+	if a.previewAwsIntegrations != nil {
+		return a.previewAwsIntegrationsPayload()
+	}
+
+	return nil
+}
+
+func (a *awsDisplayer) previewAwsIntegrationsPayload() any {
+	if a.single {
+		if len(a.previewAwsIntegrations) != 1 {
+			return nil
+		}
+		return a.previewAwsIntegrations[0]
+	}
+	return a.previewAwsIntegrations
+}
+
+func (a *awsDisplayer) FieldTemplates() []format.Field {
+	fields := []format.Field{
+		{
+			Name:        "Integration Name",
+			ValueFormat: "{{ .Name }}",
+		},
+	}
+
+	if a.single {
+		return append(fields, []format.Field{
+			{
+				Name:        "Audience",
+				ValueFormat: "{{ .FederatedWorkloadIdentity.Audience }}",
+			},
+		}...)
+	} else {
+		return fields
+	}
+}
+
+type gcpDisplayer struct {
+	previewGcpIntegrations []*preview_models.Secrets20231128GcpIntegration
+
+	single bool
+}
+
+func newGcpDisplayer(single bool, integrations ...*preview_models.Secrets20231128GcpIntegration) *gcpDisplayer {
+	return &gcpDisplayer{
+		previewGcpIntegrations: integrations,
+		single:                 single,
+	}
+}
+
+func (g *gcpDisplayer) DefaultFormat() format.Format {
+	return format.Table
+}
+
+func (g *gcpDisplayer) Payload() any {
+
+	if g.previewGcpIntegrations != nil {
+		return g.previewGcpIntegrationsPayload()
+	}
+
+	return nil
+}
+
+func (g *gcpDisplayer) previewGcpIntegrationsPayload() any {
+	if g.single {
+		if len(g.previewGcpIntegrations) != 1 {
+			return nil
+		}
+		return g.previewGcpIntegrations[0]
+	}
+	return g.previewGcpIntegrations
+}
+
+func (g *gcpDisplayer) FieldTemplates() []format.Field {
+	fields := []format.Field{
+		{
+			Name:        "Integration Name",
+			ValueFormat: "{{ .Name }}",
+		},
+	}
+
+	if g.single {
+		return append(fields, []format.Field{
+			{
+				Name:        "Audience",
+				ValueFormat: "{{ .FederatedWorkloadIdentity.Audience }}",
+			},
+			{
+				Name:        "Audience",
+				ValueFormat: "{{ .FederatedWorkloadIdentity.ServiceAccountEmail }}",
 			},
 		}...)
 	} else {

--- a/internal/commands/vaultsecrets/integrations/displayer.go
+++ b/internal/commands/vaultsecrets/integrations/displayer.go
@@ -100,15 +100,22 @@ func (m *mongodbDisplayer) previewMongoDBIntegrationsPayload() any {
 }
 
 func (m *mongodbDisplayer) FieldTemplates() []format.Field {
-	return []format.Field{
+	fields := []format.Field{
 		{
 			Name:        "Integration Name",
 			ValueFormat: "{{ .IntegrationName }}",
 		},
-		{
-			Name:        "API Public Key",
-			ValueFormat: "{{ .MongodbAPIPublicKey }}",
-		},
+	}
+
+	if m.single {
+		return append(fields, []format.Field{
+			{
+				Name:        "API Public Key",
+				ValueFormat: "{{ .MongodbAPIPublicKey }}",
+			},
+		}...)
+	} else {
+		return fields
 	}
 }
 

--- a/internal/commands/vaultsecrets/integrations/displayer.go
+++ b/internal/commands/vaultsecrets/integrations/displayer.go
@@ -173,6 +173,10 @@ func (a *awsDisplayer) FieldTemplates() []format.Field {
 				Name:        "Audience",
 				ValueFormat: "{{ .FederatedWorkloadIdentity.Audience }}",
 			},
+			{
+				Name:        "Role ARN",
+				ValueFormat: "{{ .FederatedWorkloadIdentity.RoleArn }}",
+			},
 		}...)
 	} else {
 		return fields

--- a/internal/commands/vaultsecrets/integrations/displayer.go
+++ b/internal/commands/vaultsecrets/integrations/displayer.go
@@ -44,15 +44,22 @@ func (t *twilioDisplayer) previewTwilioIntegrationsPayload() any {
 }
 
 func (t *twilioDisplayer) FieldTemplates() []format.Field {
-	return []format.Field{
+	fields := []format.Field{
 		{
 			Name:        "Integration Name",
 			ValueFormat: "{{ .IntegrationName }}",
 		},
-		{
-			Name:        "Account SID",
-			ValueFormat: "{{ .TwilioAccountSid }}",
-		},
+	}
+
+	if t.single {
+		return append(fields, []format.Field{
+			{
+				Name:        "Account SID",
+				ValueFormat: "{{ .TwilioAccountSid }}",
+			},
+		}...)
+	} else {
+		return fields
 	}
 }
 
@@ -101,6 +108,50 @@ func (m *mongodbDisplayer) FieldTemplates() []format.Field {
 		{
 			Name:        "API Public Key",
 			ValueFormat: "{{ .MongodbAPIPublicKey }}",
+		},
+	}
+}
+
+type genericDisplayer struct {
+	integrations []*preview_models.Secrets20231128Integration
+
+	single bool
+}
+
+func newGenericDisplayer(single bool, integrations ...*preview_models.Secrets20231128Integration) *genericDisplayer {
+	return &genericDisplayer{
+		integrations: integrations,
+		single:       single,
+	}
+}
+
+func (g *genericDisplayer) DefaultFormat() format.Format {
+	return format.Table
+}
+
+func (g *genericDisplayer) Payload() any {
+	if g.integrations != nil {
+		return g.integrationsPayload()
+	}
+
+	return nil
+}
+
+func (g *genericDisplayer) integrationsPayload() any {
+	if g.single {
+		if len(g.integrations) != 1 {
+			return nil
+		}
+		return g.integrations[0]
+	}
+	return g.integrations
+}
+
+func (g *genericDisplayer) FieldTemplates() []format.Field {
+	return []format.Field{
+		{
+			Name:        "Integration Name",
+			ValueFormat: "{{ .IntegrationName }}",
 		},
 	}
 }

--- a/internal/commands/vaultsecrets/integrations/integrations.go
+++ b/internal/commands/vaultsecrets/integrations/integrations.go
@@ -32,5 +32,6 @@ func NewCmdIntegrations(ctx *cmd.Context) *cmd.Command {
 
 	cmd.AddChild(NewCmdRead(ctx, nil))
 	cmd.AddChild(NewCmdDelete(ctx, nil))
+	cmd.AddChild(NewCmdList(ctx, nil))
 	return cmd
 }

--- a/internal/commands/vaultsecrets/integrations/list.go
+++ b/internal/commands/vaultsecrets/integrations/list.go
@@ -43,8 +43,7 @@ func NewCmdList(ctx *cmd.Context, runF func(*ListOpts) error) *cmd.Command {
 		Name:      "list",
 		ShortHelp: "List Vault Secrets integrations.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations list" }} command lists all Vault Secrets generic integrations
-		of the specified type.
+		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations list" }} command lists Vault Secrets generic integrations.
 		`),
 		Examples: []cmd.Example{
 			{
@@ -53,15 +52,20 @@ func NewCmdList(ctx *cmd.Context, runF func(*ListOpts) error) *cmd.Command {
 				$ hcp vault-secrets integrations list --type "twilio"
 				`),
 			},
+			{
+				Preamble: `List all generic integrations:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp vault-secrets integrations list"
+				`),
+			},
 		},
 		Flags: cmd.Flags{
 			Local: []*cmd.Flag{
 				{
 					Name:         "type",
 					DisplayValue: "TYPE",
-					Description:  "The type of the integration to list.",
+					Description:  "The optional type of integration to list.",
 					Value:        flagvalue.Simple("", &opts.Type),
-					//Required:     true,
 				},
 			},
 		},
@@ -86,7 +90,7 @@ func listRun(opts *ListOpts) error {
 		for {
 			resp, err := opts.PreviewClient.ListIntegrations(params, nil)
 			if err != nil {
-				return fmt.Errorf("failed to list twilio integrations: %w", err)
+				return fmt.Errorf("failed to list integrations: %w", err)
 			}
 
 			integrations = append(integrations, resp.Payload.Integrations...)
@@ -101,9 +105,8 @@ func listRun(opts *ListOpts) error {
 
 	}
 
-	fmt.Println("Type: ", opts.Type)
 	switch opts.Type {
-	case "twilio":
+	case Twilio:
 		var integrations []*models.Secrets20231128TwilioIntegration
 
 		params := &preview_secret_service.ListTwilioIntegrationsParams{
@@ -127,16 +130,9 @@ func listRun(opts *ListOpts) error {
 			params.PaginationNextPageToken = &next
 		}
 
-		//fmt.Println("Integrations: ", integrations)
-		for i, integration := range integrations {
-			fmt.Println(i, integration.IntegrationName)
-			//if integration.StaticCredentialDetails != nil {
-			fmt.Println(i, integration.CreatedAt)
-			//}
-		}
 		return opts.Output.Display(newTwilioDisplayer(false, integrations...))
 
-	case "mongodb":
+	case MongoDB:
 		var integrations []*models.Secrets20231128MongoDBAtlasIntegration
 
 		params := &preview_secret_service.ListMongoDBAtlasIntegrationsParams{
@@ -148,7 +144,7 @@ func listRun(opts *ListOpts) error {
 		for {
 			resp, err := opts.PreviewClient.ListMongoDBAtlasIntegrations(params, nil)
 			if err != nil {
-				return fmt.Errorf("failed to list mongodb integrations: %w", err)
+				return fmt.Errorf("failed to list mongo integrations: %w", err)
 			}
 
 			integrations = append(integrations, resp.Payload.Integrations...)
@@ -159,7 +155,7 @@ func listRun(opts *ListOpts) error {
 			next := resp.Payload.Pagination.NextPageToken
 			params.PaginationNextPageToken = &next
 		}
-		return opts.Output.Display(newMongoDBDisplayer(true, integrations...))
+		return opts.Output.Display(newMongoDBDisplayer(false, integrations...))
 
 	default:
 		return fmt.Errorf("not a valid integration type")

--- a/internal/commands/vaultsecrets/integrations/list.go
+++ b/internal/commands/vaultsecrets/integrations/list.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
@@ -81,7 +81,7 @@ func NewCmdList(ctx *cmd.Context, runF func(*ListOpts) error) *cmd.Command {
 
 func listRun(opts *ListOpts) error {
 	if opts.Type == "" {
-		var integrations []*models.Secrets20231128Integration
+		var integrations []*preview_models.Secrets20231128Integration
 		params := &preview_secret_service.ListIntegrationsParams{
 			Context:        opts.Ctx,
 			ProjectID:      opts.Profile.ProjectID,
@@ -101,13 +101,13 @@ func listRun(opts *ListOpts) error {
 			next := resp.Payload.Pagination.NextPageToken
 			params.PaginationNextPageToken = &next
 		}
-		return opts.Output.Display(newGenericDisplayer(true, integrations...))
+		return opts.Output.Display(newGenericDisplayer(false, integrations...))
 
 	}
 
 	switch opts.Type {
 	case Twilio:
-		var integrations []*models.Secrets20231128TwilioIntegration
+		var integrations []*preview_models.Secrets20231128TwilioIntegration
 
 		params := &preview_secret_service.ListTwilioIntegrationsParams{
 			Context:        opts.Ctx,
@@ -133,7 +133,7 @@ func listRun(opts *ListOpts) error {
 		return opts.Output.Display(newTwilioDisplayer(false, integrations...))
 
 	case MongoDB:
-		var integrations []*models.Secrets20231128MongoDBAtlasIntegration
+		var integrations []*preview_models.Secrets20231128MongoDBAtlasIntegration
 
 		params := &preview_secret_service.ListMongoDBAtlasIntegrationsParams{
 			Context:        opts.Ctx,

--- a/internal/commands/vaultsecrets/integrations/list.go
+++ b/internal/commands/vaultsecrets/integrations/list.go
@@ -6,12 +6,12 @@ package integrations
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
-	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"

--- a/internal/commands/vaultsecrets/integrations/list.go
+++ b/internal/commands/vaultsecrets/integrations/list.go
@@ -1,0 +1,133 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package integrations
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+type ListOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	Output  *format.Outputter
+	IO      iostreams.IOStreams
+
+	Type          string
+	Client        secret_service.ClientService
+	PreviewClient preview_secret_service.ClientService
+}
+
+func NewCmdList(ctx *cmd.Context, runF func(*ListOpts) error) *cmd.Command {
+	opts := &ListOpts{
+		Ctx:           ctx.ShutdownCtx,
+		Profile:       ctx.Profile,
+		IO:            ctx.IO,
+		Output:        ctx.Output,
+		PreviewClient: preview_secret_service.New(ctx.HCP, nil),
+		Client:        secret_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "list",
+		ShortHelp: "List Vault Secrets integrations.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations list" }} command lists all Vault Secrets generic integrations
+		of the specified type.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: `List twilio integrations:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp vault-secrets integrations list --type "twilio"
+				`),
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "type",
+					DisplayValue: "TYPE",
+					Description:  "The type of the integration to list.",
+					Value:        flagvalue.Simple("", &opts.Type),
+					Required:     true,
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			if runF != nil {
+				return runF(opts)
+			}
+			return listRun(opts)
+		},
+	}
+	return cmd
+}
+
+func listRun(opts *ListOpts) error {
+	switch opts.Type {
+	case "twilio":
+		var integrations []*models.Secrets20231128TwilioIntegration
+
+		params := &preview_secret_service.ListTwilioIntegrationsParams{
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+		}
+
+		for {
+			resp, err := opts.PreviewClient.ListTwilioIntegrations(params, nil)
+			if err != nil {
+				return fmt.Errorf("failed to list twilio integrations: %w", err)
+			}
+
+			integrations = append(integrations, resp.Payload.Integrations...)
+			if resp.Payload.Pagination == nil || resp.Payload.Pagination.NextPageToken == "" {
+				break
+			}
+
+			next := resp.Payload.Pagination.NextPageToken
+			params.PaginationNextPageToken = &next
+		}
+		return opts.Output.Display(newTwilioDisplayer(true, integrations...))
+
+	case "mongodb":
+		var integrations []*models.Secrets20231128MongoDBAtlasIntegration
+
+		params := &preview_secret_service.ListMongoDBAtlasIntegrationsParams{
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+		}
+
+		for {
+			resp, err := opts.PreviewClient.ListMongoDBAtlasIntegrations(params, nil)
+			if err != nil {
+				return fmt.Errorf("failed to list mongodb integrations: %w", err)
+			}
+
+			integrations = append(integrations, resp.Payload.Integrations...)
+			if resp.Payload.Pagination == nil || resp.Payload.Pagination.NextPageToken == "" {
+				break
+			}
+
+			next := resp.Payload.Pagination.NextPageToken
+			params.PaginationNextPageToken = &next
+		}
+		return opts.Output.Display(newMongoDBDisplayer(true, integrations...))
+
+	default:
+		return fmt.Errorf("not a valid integration type")
+	}
+}

--- a/internal/commands/vaultsecrets/integrations/list_test.go
+++ b/internal/commands/vaultsecrets/integrations/list_test.go
@@ -48,7 +48,7 @@ func TestNewCmdList(t *testing.T) {
 			Profile: func(t *testing.T) *profile.Profile {
 				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
 			},
-			Error: "ERROR: missing required flag: --type=TYPE,o",
+			Error: "ERROR: missing required flag: --type=TYPE",
 		},
 	}
 

--- a/internal/commands/vaultsecrets/integrations/list_test.go
+++ b/internal/commands/vaultsecrets/integrations/list_test.go
@@ -43,13 +43,6 @@ func TestNewCmdList(t *testing.T) {
 				Type: "twilio",
 			},
 		},
-		{
-			Name: "Missing type flag",
-			Profile: func(t *testing.T) *profile.Profile {
-				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
-			},
-			Error: "ERROR: missing required flag: --type=TYPE",
-		},
 	}
 
 	for _, c := range cases {
@@ -165,8 +158,7 @@ func getIntegrations(start, limit int) []*preview_models.Secrets20231128TwilioIn
 	var secrets []*preview_models.Secrets20231128TwilioIntegration
 	for i := start; i < (start + limit); i++ {
 		secrets = append(secrets, &preview_models.Secrets20231128TwilioIntegration{
-			Name:             fmt.Sprint("test_app_", i),
-			TwilioAccountSid: fmt.Sprint("twilio_account_sid", i),
+			Name: fmt.Sprint("test_app_", i),
 		})
 	}
 	return secrets

--- a/internal/commands/vaultsecrets/integrations/list_test.go
+++ b/internal/commands/vaultsecrets/integrations/list_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package integrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/stretchr/testify/mock"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func TestNewCmdList(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *ListOpts
+	}{
+		{
+			Name: "Good",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Args: []string{"--type=twilio"},
+			Expect: &ListOpts{
+				Type: "twilio",
+			},
+		},
+		{
+			Name: "Missing type flag",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
+			},
+			Error: "ERROR: missing required flag: --type=TYPE,o",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts *ListOpts
+			listCmd := NewCmdList(ctx, func(o *ListOpts) error {
+				gotOpts = o
+				return nil
+			})
+			listCmd.SetIO(io)
+
+			code := listCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+		})
+	}
+}
+
+func TestListRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name   string
+		ErrMsg string
+	}{
+		{
+			Name: "Success: List integrations",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			io.ErrorTTY = true
+			vs := mock_preview_secret_service.NewMockClientService(t)
+
+			opts := &ListOpts{
+				Ctx:           context.Background(),
+				IO:            io,
+				Profile:       profile.TestProfile(t).SetOrgID("123").SetProjectID("abc"),
+				Output:        format.New(io),
+				PreviewClient: vs,
+				Type:          "twilio",
+			}
+
+			if c.ErrMsg != "" {
+				vs.EXPECT().ListTwilioIntegrations(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
+			} else {
+				paginationNextPageToken := "token"
+				vs.EXPECT().ListTwilioIntegrations(&preview_secret_service.ListTwilioIntegrationsParams{
+					OrganizationID: "123",
+					ProjectID:      "abc",
+					Context:        opts.Ctx,
+				}, mock.Anything).Return(&preview_secret_service.ListTwilioIntegrationsOK{
+					Payload: &preview_models.Secrets20231128ListTwilioIntegrationsResponse{
+						Integrations: getIntegrations(0, 10),
+						Pagination: &preview_models.CommonPaginationResponse{
+							NextPageToken: paginationNextPageToken,
+						},
+					},
+				}, nil).Once()
+
+				vs.EXPECT().ListTwilioIntegrations(&preview_secret_service.ListTwilioIntegrationsParams{
+					OrganizationID:          "123",
+					ProjectID:               "abc",
+					Context:                 opts.Ctx,
+					PaginationNextPageToken: &paginationNextPageToken,
+				}, mock.Anything).Return(&preview_secret_service.ListTwilioIntegrationsOK{
+					Payload: &preview_models.Secrets20231128ListTwilioIntegrationsResponse{
+						Integrations: getIntegrations(10, 5),
+					},
+				}, nil).Once()
+			}
+
+			// Run the command
+			err := listRun(opts)
+			if c.ErrMsg != "" {
+				r.Contains(err.Error(), c.ErrMsg)
+				return
+			}
+
+			r.NoError(err)
+			r.NotNil(io.Error.String())
+		})
+	}
+}
+
+func getIntegrations(start, limit int) []*preview_models.Secrets20231128TwilioIntegration {
+	var secrets []*preview_models.Secrets20231128TwilioIntegration
+	for i := start; i < (start + limit); i++ {
+		secrets = append(secrets, &preview_models.Secrets20231128TwilioIntegration{
+			Name:             fmt.Sprint("test_app_", i),
+			TwilioAccountSid: fmt.Sprint("twilio_account_sid", i),
+		})
+	}
+	return secrets
+}

--- a/internal/commands/vaultsecrets/integrations/list_test.go
+++ b/internal/commands/vaultsecrets/integrations/list_test.go
@@ -7,16 +7,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
 	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	"github.com/stretchr/testify/mock"
-	"testing"
-
-	"github.com/go-openapi/runtime/client"
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"

--- a/internal/commands/vaultsecrets/integrations/list_test.go
+++ b/internal/commands/vaultsecrets/integrations/list_test.go
@@ -84,11 +84,17 @@ func TestListRun(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		Name   string
-		ErrMsg string
+		Name    string
+		RespErr bool
+		ErrMsg  string
 	}{
 		{
 			Name: "Success: List integrations",
+		},
+		{
+			Name:    "Failed: Unable to list integrations",
+			RespErr: true,
+			ErrMsg:  "[GET /secrets/2023-11-28/organizations/{organization_id}/projects/{project_id}/integrations][404] ListIntegrations",
 		},
 	}
 
@@ -111,7 +117,7 @@ func TestListRun(t *testing.T) {
 				Type:          "twilio",
 			}
 
-			if c.ErrMsg != "" {
+			if c.RespErr {
 				vs.EXPECT().ListTwilioIntegrations(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
 			} else {
 				paginationNextPageToken := "token"

--- a/internal/commands/vaultsecrets/integrations/read_test.go
+++ b/internal/commands/vaultsecrets/integrations/read_test.go
@@ -143,6 +143,11 @@ func TestReadRun(t *testing.T) {
 					Payload: &preview_models.Secrets20231128GetTwilioIntegrationResponse{
 						Integration: &preview_models.Secrets20231128TwilioIntegration{
 							IntegrationName: opts.IntegrationName,
+							Name:            opts.IntegrationName,
+							StaticCredentialDetails: &preview_models.Secrets20231128TwilioStaticCredentialsResponse{
+								AccountSid: "account_sid",
+								APIKeySid:  "api_key_sid",
+							},
 						},
 					},
 				}, nil).Once()
@@ -156,7 +161,7 @@ func TestReadRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Contains(io.Output.String(), fmt.Sprintf("Integration Name     Account SID\n%s              \n", opts.IntegrationName))
+			r.Contains(io.Output.String(), fmt.Sprintf("Integration Name   Account SID   API Key SID\n                   %s account_sid   api_key_sid\n", opts.IntegrationName))
 		})
 	}
 }

--- a/internal/commands/vaultsecrets/integrations/read_test.go
+++ b/internal/commands/vaultsecrets/integrations/read_test.go
@@ -161,7 +161,7 @@ func TestReadRun(t *testing.T) {
 			}
 
 			r.NoError(err)
-			r.Contains(io.Output.String(), fmt.Sprintf("Integration Name   Account SID   API Key SID\n                   %s account_sid   api_key_sid\n", opts.IntegrationName))
+			r.Contains(io.Output.String(), fmt.Sprintf("Integration Name     Account SID   API Key SID\n%s   account_sid   api_key_sid\n", opts.IntegrationName))
 		})
 	}
 }


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds the `list` command for hvs apps for ticket https://hashicorp.atlassian.net/browse/VAULT-29259

### How I've tested this PR:
Ran `make go/build` to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Read an integration `./bin/hcp vault-secrets integrations list --type {YOUR_INTEGRATION_TYPE}` or `./bin/hcp vault-secrets integrations list`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
<img width="765" alt="Screenshot 2024-07-30 at 4 32 53 PM" src="https://github.com/user-attachments/assets/b8e02d2c-8a7e-4b93-8ad4-d94854d5d2be">

### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
