### PR TITLE
VAULT-29012 - Create HVS integrations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,5 +94,5 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -110,8 +110,8 @@ func createRun(opts *CreateOpts) error {
 	case Twilio:
 
 		accountSid := i.Details["account_sid"].(string)
-		apiKeySecret := i.Details["twilio_api_key_secret"].(string)
-		apiKeySid := i.Details["twilio_api_key_sid"].(string)
+		apiKeySecret := i.Details["api_key_secret"].(string)
+		apiKeySid := i.Details["api_key_sid"].(string)
 
 		body := &models.SecretServiceCreateTwilioIntegrationBody{
 			IntegrationName:    opts.IntegrationName,
@@ -128,7 +128,7 @@ func createRun(opts *CreateOpts) error {
 		}, nil)
 
 		if err != nil {
-			return fmt.Errorf("failed to create MongoDB integration: %w", err)
+			return fmt.Errorf("failed to create Twilio integration: %w", err)
 		}
 
 		fmt.Fprintln(opts.IO.Err())

--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -120,20 +120,20 @@ func createRun(opts *CreateOpts) error {
 
 	switch i.Type {
 	case Twilio:
-		missingField := validateDetails(i.Details, TwilioKeys)
+		missingFields := validateDetails(i.Details, TwilioKeys)
 
-		if missingField != "" {
-			return fmt.Errorf("missing required field in the config file: %s", missingField)
+		if len(missingFields) > 0 {
+			return fmt.Errorf("missing required field(s) in the config file: %s", missingFields)
 		}
 
 		body := &preview_models.SecretServiceCreateTwilioIntegrationBody{
 			Name:               opts.IntegrationName,
-			TwilioAccountSid:   i.Details["account_sid"],
-			TwilioAPIKeySecret: i.Details["api_key_secret"],
-			TwilioAPIKeySid:    i.Details["api_key_sid"],
+			TwilioAccountSid:   i.Details[TwilioKeys[0]],
+			TwilioAPIKeySecret: i.Details[TwilioKeys[1]],
+			TwilioAPIKeySid:    i.Details[TwilioKeys[2]],
 		}
 
-		resp, err := opts.PreviewClient.CreateTwilioIntegration(&preview_secret_service.CreateTwilioIntegrationParams{
+		_, err := opts.PreviewClient.CreateTwilioIntegration(&preview_secret_service.CreateTwilioIntegrationParams{
 			Context:        opts.Ctx,
 			ProjectID:      opts.Profile.ProjectID,
 			OrganizationID: opts.Profile.OrganizationID,
@@ -144,23 +144,20 @@ func createRun(opts *CreateOpts) error {
 			return fmt.Errorf("failed to create Twilio integration: %w", err)
 		}
 
-		fmt.Fprintln(opts.IO.Err())
-		fmt.Fprintf(opts.IO.Err(), "%s Successfully created integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), resp.Payload.Integration.Name)
-
 	case MongoDBAtlas:
-		missingField := validateDetails(i.Details, MongoKeys)
+		missingFields := validateDetails(i.Details, MongoKeys)
 
-		if missingField != "" {
-			return fmt.Errorf("missing required field in the config file: %s", missingField)
+		if len(missingFields) > 0 {
+			return fmt.Errorf("missing required field(s) in the config file: %s", missingFields)
 		}
 
 		body := &preview_models.SecretServiceCreateMongoDBAtlasIntegrationBody{
 			Name:                 opts.IntegrationName,
-			MongodbAPIPrivateKey: i.Details["private_key"],
-			MongodbAPIPublicKey:  i.Details["public_key"],
+			MongodbAPIPrivateKey: i.Details[MongoKeys[0]],
+			MongodbAPIPublicKey:  i.Details[MongoKeys[1]],
 		}
 
-		resp, err := opts.PreviewClient.CreateMongoDBAtlasIntegration(&preview_secret_service.CreateMongoDBAtlasIntegrationParams{
+		_, err := opts.PreviewClient.CreateMongoDBAtlasIntegration(&preview_secret_service.CreateMongoDBAtlasIntegrationParams{
 			Context:        opts.Ctx,
 			ProjectID:      opts.Profile.ProjectID,
 			OrganizationID: opts.Profile.OrganizationID,
@@ -171,25 +168,22 @@ func createRun(opts *CreateOpts) error {
 			return fmt.Errorf("failed to create MongoDB Atlas integration: %w", err)
 		}
 
-		fmt.Fprintln(opts.IO.Err())
-		fmt.Fprintf(opts.IO.Err(), "%s Successfully created integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), resp.Payload.Integration.Name)
-
 	case AWS:
-		missingField := validateDetails(i.Details, AWSKeys)
+		missingFields := validateDetails(i.Details, AWSKeys)
 
-		if missingField != "" {
-			return fmt.Errorf("missing required field in the config file: %s", missingField)
+		if len(missingFields) > 0 {
+			return fmt.Errorf("missing required field(s) in the config file: %s", missingFields)
 		}
 
 		body := &preview_models.SecretServiceCreateAwsIntegrationBody{
 			Name: opts.IntegrationName,
 			FederatedWorkloadIdentity: &preview_models.Secrets20231128AwsFederatedWorkloadIdentityRequest{
-				Audience: i.Details["audience"],
-				RoleArn:  i.Details["role_arn"],
+				Audience: i.Details[AWSKeys[0]],
+				RoleArn:  i.Details[AWSKeys[1]],
 			},
 		}
 
-		resp, err := opts.PreviewClient.CreateAwsIntegration(&preview_secret_service.CreateAwsIntegrationParams{
+		_, err := opts.PreviewClient.CreateAwsIntegration(&preview_secret_service.CreateAwsIntegrationParams{
 			Context:        opts.Ctx,
 			ProjectID:      opts.Profile.ProjectID,
 			OrganizationID: opts.Profile.OrganizationID,
@@ -200,25 +194,22 @@ func createRun(opts *CreateOpts) error {
 			return fmt.Errorf("failed to create AWS integration: %w", err)
 		}
 
-		fmt.Fprintln(opts.IO.Err())
-		fmt.Fprintf(opts.IO.Err(), "%s Successfully created integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), resp.Payload.Integration.Name)
-
 	case GCP:
-		missingField := validateDetails(i.Details, GCPKeys)
+		missingFields := validateDetails(i.Details, GCPKeys)
 
-		if missingField != "" {
-			return fmt.Errorf("missing required field in the config file: %s", missingField)
+		if len(missingFields) > 0 {
+			return fmt.Errorf("missing required field(s) in the config file: %s", missingFields)
 		}
 
 		body := &preview_models.SecretServiceCreateGcpIntegrationBody{
 			Name: opts.IntegrationName,
 			FederatedWorkloadIdentity: &preview_models.Secrets20231128GcpFederatedWorkloadIdentityRequest{
-				Audience:            i.Details["audience"],
-				ServiceAccountEmail: i.Details["service_account_email"],
+				Audience:            i.Details[GCPKeys[0]],
+				ServiceAccountEmail: i.Details[GCPKeys[1]],
 			},
 		}
 
-		resp, err := opts.PreviewClient.CreateGcpIntegration(&preview_secret_service.CreateGcpIntegrationParams{
+		_, err := opts.PreviewClient.CreateGcpIntegration(&preview_secret_service.CreateGcpIntegrationParams{
 			Context:        opts.Ctx,
 			ProjectID:      opts.Profile.ProjectID,
 			OrganizationID: opts.Profile.OrganizationID,
@@ -228,21 +219,22 @@ func createRun(opts *CreateOpts) error {
 		if err != nil {
 			return fmt.Errorf("failed to create GCP integration: %w", err)
 		}
-
-		fmt.Fprintln(opts.IO.Err())
-		fmt.Fprintf(opts.IO.Err(), "%s Successfully created integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), resp.Payload.Integration.Name)
 	}
+
+	fmt.Fprintln(opts.IO.Err())
+	fmt.Fprintf(opts.IO.Err(), "%s Successfully created integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
 
 	return nil
 }
 
-func validateDetails(details map[string]string, requiredKeys []string) string {
+func validateDetails(details map[string]string, requiredKeys []string) []string {
 	detailsKeys := maps.Keys(details)
+	var missingKeys []string
 
 	for _, r := range requiredKeys {
 		if !slices.Contains(detailsKeys, r) {
-			return r
+			missingKeys = append(missingKeys, r)
 		}
 	}
-	return ""
+	return missingKeys
 }

--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -1,0 +1,162 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package integrations
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"gopkg.in/yaml.v3"
+	"os"
+)
+
+type CreateOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	IO      iostreams.IOStreams
+	Output  *format.Outputter
+
+	IntegrationName string
+	ConfigFilePath  string
+	PreviewClient   preview_secret_service.ClientService
+	Client          secret_service.ClientService
+}
+
+func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
+	opts := &CreateOpts{
+		Ctx:     ctx.ShutdownCtx,
+		Profile: ctx.Profile,
+		IO:      ctx.IO,
+		Output:  ctx.Output,
+
+		PreviewClient: preview_secret_service.New(ctx.HCP, nil),
+		Client:        secret_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "create",
+		ShortHelp: "Create a new integration.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations create" }} command creates a new Vault Secrets integration.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: `Create a new Vault Secrets integration:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp vault-secrets integrations create sample-integration --config-file=path-to-file/config.yaml
+				`),
+			},
+		},
+		Args: cmd.PositionalArguments{
+			Args: []cmd.PositionalArgument{
+				{
+					Name:          "NAME",
+					Documentation: "The name of the integration to create.",
+				},
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "config-file",
+					DisplayValue: "CONFIG_FILE",
+					Description:  "File path to read integration config data.",
+					Value:        flagvalue.Simple("", &opts.ConfigFilePath),
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			opts.IntegrationName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return createRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+type IntegrationConfig struct {
+	Type    string
+	Details map[string]any
+}
+
+func createRun(opts *CreateOpts) error {
+	// Open the file
+	f, err := os.ReadFile(opts.ConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to open config file: %w", err)
+	}
+
+	var i IntegrationConfig
+	err = yaml.Unmarshal(f, &i)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal config file: %w", err)
+	}
+
+	switch i.Type {
+	case Twilio:
+
+		accountSid := i.Details["account_sid"].(string)
+		apiKeySecret := i.Details["twilio_api_key_secret"].(string)
+		apiKeySid := i.Details["twilio_api_key_sid"].(string)
+
+		body := &models.SecretServiceCreateTwilioIntegrationBody{
+			IntegrationName:    opts.IntegrationName,
+			TwilioAccountSid:   accountSid,
+			TwilioAPIKeySecret: apiKeySecret,
+			TwilioAPIKeySid:    apiKeySid,
+		}
+
+		resp, err := opts.PreviewClient.CreateTwilioIntegration(&preview_secret_service.CreateTwilioIntegrationParams{
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Body:           body,
+		}, nil)
+
+		if err != nil {
+			return fmt.Errorf("failed to create MongoDB integration: %w", err)
+		}
+
+		fmt.Fprintln(opts.IO.Err())
+		fmt.Fprintf(opts.IO.Err(), "%s Successfully created integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), resp.Payload.Integration.IntegrationName)
+
+	case MongoDB:
+		privkey := i.Details["private_key"].(string)
+		pubKey := i.Details["public_key"].(string)
+		body := &models.SecretServiceCreateMongoDBAtlasIntegrationBody{
+			IntegrationName:      opts.IntegrationName,
+			MongodbAPIPrivateKey: privkey,
+			MongodbAPIPublicKey:  pubKey,
+		}
+
+		resp, err := opts.PreviewClient.CreateMongoDBAtlasIntegration(&preview_secret_service.CreateMongoDBAtlasIntegrationParams{
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Body:           body,
+		}, nil)
+
+		if err != nil {
+			return fmt.Errorf("failed to create MongoDB integration: %w", err)
+		}
+
+		fmt.Fprintln(opts.IO.Err())
+		fmt.Fprintf(opts.IO.Err(), "%s Successfully created integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), resp.Payload.Integration.IntegrationName)
+	}
+
+	return nil
+}

--- a/internal/commands/vaultsecrets/integrations/create_test.go
+++ b/internal/commands/vaultsecrets/integrations/create_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package integrations
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/require"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func TestNewCmdCreate(t *testing.T) {
+	t.Parallel()
+
+	testProfile := func(t *testing.T) *profile.Profile {
+		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+		return tp
+	}
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *CreateOpts
+	}{
+		{
+			Name:    "Good",
+			Profile: testProfile,
+			Args:    []string{"sample-integration", "--config-file", "path/to/file"},
+			Expect: &CreateOpts{
+				IntegrationName: "sample-integration",
+				ConfigFilePath:  "path/to/file",
+			},
+		},
+		{
+			Name:    "Failed: No secret name arg specified",
+			Profile: testProfile,
+			Args:    []string{"--config-file", "path/to/file"},
+			Error:   "ERROR: accepts 1 arg(s), received 0",
+		},
+		{
+			Name:    "Failed: No config file flag specified",
+			Profile: testProfile,
+			Args:    []string{"sample-integration"},
+			Error:   "ERROR: missing required flag: --config-file=CONFIG_FILE",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts *CreateOpts
+			createCmd := NewCmdCreate(ctx, func(o *CreateOpts) error {
+				gotOpts = o
+				return nil
+			})
+			createCmd.SetIO(io)
+
+			code := createCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+			r.Equal(c.Expect.IntegrationName, gotOpts.IntegrationName)
+			r.Equal(c.Expect.ConfigFilePath, gotOpts.ConfigFilePath)
+		})
+	}
+}
+
+func TestCreateRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name            string
+		IntegrationName string
+		Input           []byte
+		Error           string
+	}{
+		{
+			Name:            "Good",
+			IntegrationName: "sample-integration",
+			Input: []byte(`version: 1.0.0
+type: "twilio"
+details:
+  account_sid: abc
+  api_key_secret: def
+  api_key_sid: ghi`),
+		},
+		{
+			Name:            "Missing required field",
+			IntegrationName: "sample-integration",
+			Input: []byte(`version: 1.0.0
+type: "twilio"
+details:
+  account_sid: abc
+  api_key_sid: ghi`),
+			Error: "missing required field in the config file: api_key_secret",
+		},
+	}
+
+	for _, c := range cases {
+
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			tempDir := t.TempDir()
+			f, err := os.Create(filepath.Join(tempDir, "config.yaml"))
+			r.NoError(err)
+			_, err = f.Write(c.Input)
+			r.NoError(err)
+
+			io := iostreams.Test()
+			vs := mock_preview_secret_service.NewMockClientService(t)
+
+			opts := &CreateOpts{
+				Ctx:             context.Background(),
+				Profile:         profile.TestProfile(t).SetOrgID("123").SetProjectID("abc"),
+				IO:              io,
+				PreviewClient:   vs,
+				Output:          format.New(io),
+				IntegrationName: c.IntegrationName,
+				ConfigFilePath:  f.Name(),
+			}
+
+			if c.Error == "" {
+				vs.EXPECT().CreateTwilioIntegration(&preview_secret_service.CreateTwilioIntegrationParams{
+					Context:        opts.Ctx,
+					OrganizationID: "123",
+					ProjectID:      "abc",
+					Body: &preview_models.SecretServiceCreateTwilioIntegrationBody{
+						IntegrationName:    opts.IntegrationName,
+						TwilioAccountSid:   "abc",
+						TwilioAPIKeySecret: "def",
+						TwilioAPIKeySid:    "ghi",
+					},
+				}, nil).Return(&preview_secret_service.CreateTwilioIntegrationOK{
+					Payload: &preview_models.Secrets20231128CreateTwilioIntegrationResponse{
+						Integration: &preview_models.Secrets20231128TwilioIntegration{
+							IntegrationName:  opts.IntegrationName,
+							TwilioAccountSid: "abc",
+						},
+					},
+				}, nil).Once()
+			}
+
+			// Run the command
+			err = createRun(opts)
+			if c.Error != "" {
+				r.ErrorContains(err, c.Error)
+				return
+			}
+
+			r.NoError(err)
+			r.Contains(io.Error.String(), fmt.Sprintf("✓ Successfully created integration with name %q\n", opts.IntegrationName))
+		})
+	}
+}

--- a/internal/commands/vaultsecrets/integrations/create_test.go
+++ b/internal/commands/vaultsecrets/integrations/create_test.go
@@ -161,7 +161,7 @@ details:
 					OrganizationID: "123",
 					ProjectID:      "abc",
 					Body: &preview_models.SecretServiceCreateTwilioIntegrationBody{
-						IntegrationName:    opts.IntegrationName,
+						Name:               opts.IntegrationName,
 						TwilioAccountSid:   "abc",
 						TwilioAPIKeySecret: "def",
 						TwilioAPIKeySid:    "ghi",
@@ -169,7 +169,7 @@ details:
 				}, nil).Return(&preview_secret_service.CreateTwilioIntegrationOK{
 					Payload: &preview_models.Secrets20231128CreateTwilioIntegrationResponse{
 						Integration: &preview_models.Secrets20231128TwilioIntegration{
-							IntegrationName:  opts.IntegrationName,
+							Name:             opts.IntegrationName,
 							TwilioAccountSid: "abc",
 						},
 					},

--- a/internal/commands/vaultsecrets/integrations/integrations.go
+++ b/internal/commands/vaultsecrets/integrations/integrations.go
@@ -33,5 +33,6 @@ func NewCmdIntegrations(ctx *cmd.Context) *cmd.Command {
 	cmd.AddChild(NewCmdRead(ctx, nil))
 	cmd.AddChild(NewCmdDelete(ctx, nil))
 	cmd.AddChild(NewCmdList(ctx, nil))
+	cmd.AddChild(NewCmdCreate(ctx, nil))
 	return cmd
 }


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds the create command for hvs apps for ticket https://hashicorp.atlassian.net/browse/VAULT-29012

### How I've tested this PR:
Ran `make go/build` to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Create an integration `./bin/hcp vault-secrets integrations create {INTEGRATION_NAME} --config-file "/path/to/file/config.yaml"`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
Config file `integration-config.yaml`
<img width="414" alt="Screenshot 2024-08-02 at 3 59 45 PM" src="https://github.com/user-attachments/assets/da051c15-f7d6-48eb-8699-133f6ea5dc15">
<img width="1044" alt="Screenshot 2024-08-02 at 3 59 17 PM" src="https://github.com/user-attachments/assets/226e401f-d0fa-4706-b39a-599aa599c9db">

### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
