### PR TITLE
VAULT-29260 - Create rotating secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.19.1
-	github.com/hashicorp/hcp-sdk-go v0.104.0
+	github.com/hashicorp/hcp-sdk-go v0.108.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5R
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/hcp-sdk-go v0.104.0 h1:uKAgAzXdjb+JgLgoT0Ta1/N/NEYTyCBHZUrknhJsBsQ=
 github.com/hashicorp/hcp-sdk-go v0.104.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.108.0 h1:MgP7vGTx5A34l9HpktvQSY4nNfwCBpIXRJhJCHCxcyQ=
+github.com/hashicorp/hcp-sdk-go v0.108.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.104.0 h1:uKAgAzXdjb+JgLgoT0Ta1/N/NEYTyCBHZUrknhJsBsQ=
-github.com/hashicorp/hcp-sdk-go v0.104.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/hcp-sdk-go v0.108.0 h1:MgP7vGTx5A34l9HpktvQSY4nNfwCBpIXRJhJCHCxcyQ=
 github.com/hashicorp/hcp-sdk-go v0.108.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -127,10 +127,12 @@ func createRun(opts *CreateOpts) error {
 		}
 
 		body := &preview_models.SecretServiceCreateTwilioIntegrationBody{
-			Name:               opts.IntegrationName,
-			TwilioAccountSid:   i.Details[TwilioKeys[0]],
-			TwilioAPIKeySecret: i.Details[TwilioKeys[1]],
-			TwilioAPIKeySid:    i.Details[TwilioKeys[2]],
+			Name: opts.IntegrationName,
+			StaticCredentialDetails: &preview_models.Secrets20231128TwilioStaticCredentialsRequest{
+				AccountSid:   i.Details[TwilioKeys[0]],
+				APIKeySecret: i.Details[TwilioKeys[1]],
+				APIKeySid:    i.Details[TwilioKeys[2]],
+			},
 		}
 
 		_, err := opts.PreviewClient.CreateTwilioIntegration(&preview_secret_service.CreateTwilioIntegrationParams{
@@ -152,9 +154,11 @@ func createRun(opts *CreateOpts) error {
 		}
 
 		body := &preview_models.SecretServiceCreateMongoDBAtlasIntegrationBody{
-			Name:                 opts.IntegrationName,
-			MongodbAPIPrivateKey: i.Details[MongoKeys[0]],
-			MongodbAPIPublicKey:  i.Details[MongoKeys[1]],
+			Name: opts.IntegrationName,
+			StaticCredentialDetails: &preview_models.Secrets20231128MongoDBAtlasStaticCredentialsRequest{
+				APIPrivateKey: i.Details[MongoKeys[0]],
+				APIPublicKey:  i.Details[MongoKeys[1]],
+			},
 		}
 
 		_, err := opts.PreviewClient.CreateMongoDBAtlasIntegration(&preview_secret_service.CreateMongoDBAtlasIntegrationParams{

--- a/internal/commands/vaultsecrets/integrations/delete.go
+++ b/internal/commands/vaultsecrets/integrations/delete.go
@@ -89,11 +89,10 @@ func deleteRun(opts *DeleteOpts) error {
 	switch opts.Type {
 	case Twilio:
 		_, err := opts.PreviewClient.DeleteTwilioIntegration(&preview_secret_service.DeleteTwilioIntegrationParams{
-			Context:         opts.Ctx,
-			ProjectID:       opts.Profile.ProjectID,
-			OrganizationID:  opts.Profile.OrganizationID,
-			IntegrationName: opts.IntegrationName,
-			Name:            &opts.IntegrationName,
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Name:           opts.IntegrationName,
 		}, nil)
 		if err != nil {
 			return fmt.Errorf("failed to delete integration: %w", err)
@@ -104,11 +103,10 @@ func deleteRun(opts *DeleteOpts) error {
 
 	case MongoDBAtlas:
 		_, err := opts.PreviewClient.DeleteMongoDBAtlasIntegration(&preview_secret_service.DeleteMongoDBAtlasIntegrationParams{
-			Context:         opts.Ctx,
-			ProjectID:       opts.Profile.ProjectID,
-			OrganizationID:  opts.Profile.OrganizationID,
-			IntegrationName: opts.IntegrationName,
-			Name:            &opts.IntegrationName,
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Name:           opts.IntegrationName,
 		}, nil)
 		if err != nil {
 			return fmt.Errorf("failed to delete integration: %w", err)

--- a/internal/commands/vaultsecrets/integrations/delete_test.go
+++ b/internal/commands/vaultsecrets/integrations/delete_test.go
@@ -133,11 +133,10 @@ func TestDeleteRun(t *testing.T) {
 				vs.EXPECT().DeleteTwilioIntegration(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
 			} else {
 				vs.EXPECT().DeleteTwilioIntegration(&preview_secret_service.DeleteTwilioIntegrationParams{
-					OrganizationID:  "123",
-					ProjectID:       "abc",
-					IntegrationName: opts.IntegrationName,
-					Name:            &opts.IntegrationName,
-					Context:         opts.Ctx,
+					OrganizationID: "123",
+					ProjectID:      "abc",
+					Name:           opts.IntegrationName,
+					Context:        opts.Ctx,
 				}, nil).Return(&preview_secret_service.DeleteTwilioIntegrationOK{}, nil).Once()
 			}
 

--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -89,10 +89,10 @@ func readRun(opts *ReadOpts) error {
 	switch opts.Type {
 	case Twilio:
 		resp, err := opts.PreviewClient.GetTwilioIntegration(&preview_secret_service.GetTwilioIntegrationParams{
-			Context:         opts.Ctx,
-			ProjectID:       opts.Profile.ProjectID,
-			OrganizationID:  opts.Profile.OrganizationID,
-			IntegrationName: opts.IntegrationName,
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Name:           opts.IntegrationName,
 		}, nil)
 		if err != nil {
 			return fmt.Errorf("failed to read integration: %w", err)
@@ -102,10 +102,10 @@ func readRun(opts *ReadOpts) error {
 
 	case MongoDBAtlas:
 		resp, err := opts.PreviewClient.GetMongoDBAtlasIntegration(&preview_secret_service.GetMongoDBAtlasIntegrationParams{
-			Context:         opts.Ctx,
-			ProjectID:       opts.Profile.ProjectID,
-			OrganizationID:  opts.Profile.OrganizationID,
-			IntegrationName: opts.IntegrationName,
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Name:           opts.IntegrationName,
 		}, nil)
 		if err != nil {
 			return fmt.Errorf("failed to read integration: %w", err)

--- a/internal/commands/vaultsecrets/integrations/read_test.go
+++ b/internal/commands/vaultsecrets/integrations/read_test.go
@@ -135,15 +135,14 @@ func TestReadRun(t *testing.T) {
 				vs.EXPECT().GetTwilioIntegration(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
 			} else {
 				vs.EXPECT().GetTwilioIntegration(&preview_secret_service.GetTwilioIntegrationParams{
-					OrganizationID:  "123",
-					ProjectID:       "abc",
-					IntegrationName: opts.IntegrationName,
-					Context:         opts.Ctx,
+					OrganizationID: "123",
+					ProjectID:      "abc",
+					Name:           opts.IntegrationName,
+					Context:        opts.Ctx,
 				}, nil).Return(&preview_secret_service.GetTwilioIntegrationOK{
 					Payload: &preview_models.Secrets20231128GetTwilioIntegrationResponse{
 						Integration: &preview_models.Secrets20231128TwilioIntegration{
-							IntegrationName: opts.IntegrationName,
-							Name:            opts.IntegrationName,
+							Name: opts.IntegrationName,
 							StaticCredentialDetails: &preview_models.Secrets20231128TwilioStaticCredentialsResponse{
 								AccountSid: "account_sid",
 								APIKeySid:  "api_key_sid",

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -7,15 +7,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/integrations"
-	"github.com/mitchellh/mapstructure"
-	"gopkg.in/yaml.v3"
 	"io"
 	"os"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/posener/complete"
+	"gopkg.in/yaml.v3"
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/integrations"
 	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
@@ -23,7 +25,6 @@ import (
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
 	"github.com/hashicorp/hcp/internal/pkg/profile"
-	"github.com/posener/complete"
 )
 
 type SecretType string

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -261,7 +261,7 @@ func createRun(opts *CreateOpts) error {
 				var scope MongoDBScope
 				decoder, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{WeaklyTypedInput: true, Result: &scope})
 				if err := decoder.Decode(r); err != nil {
-					return fmt.Errorf("unable to decode to a mongodb role")
+					return fmt.Errorf("unable to decode to a mongodb scope")
 				}
 
 				reqScope := &preview_models.Secrets20231128MongoDBScope{
@@ -272,9 +272,11 @@ func createRun(opts *CreateOpts) error {
 			}
 
 			req.Body = &preview_models.SecretServiceCreateMongoDBAtlasRotatingSecretBody{
-				MongodbGroupID:          sc.Details[MongoKeys[1]].(string),
-				MongodbRoles:            reqRoles,
-				MongodbScopes:           reqScopes,
+				SecretDetails: &preview_models.Secrets20231128MongoDBAtlasSecretDetails{
+					MongodbGroupID: sc.Details[MongoKeys[1]].(string),
+					MongodbRoles:   reqRoles,
+					MongodbScopes:  reqScopes,
+				},
 				RotationIntegrationName: sc.IntegrationName,
 				RotationPolicyName:      rotationPolicies[sc.Details[MongoKeys[0]].(string)],
 				SecretName:              opts.SecretName,

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -80,6 +80,7 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 					DisplayValue: "DATA_FILE_PATH",
 					Description:  "File path to read secret data from. Set this to '-' to read the secret data from stdin.",
 					Value:        flagvalue.Simple("", &opts.SecretFilePath),
+					Required:     true,
 					Autocomplete: complete.PredictOr(
 						complete.PredictFiles("*"),
 						complete.PredictSet("-"),

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/exp/maps"
 	"io"
 	"os"
 	"slices"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/posener/complete"
+	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -146,7 +146,7 @@ type MongoDBScope struct {
 
 var (
 	// There are no Twilio-specific keys
-	MongoKeys = []string{"mongodb_group_id", "mongodb_roles"}
+	MongoDBAtlasRequiredKeys = []string{"mongodb_group_id", "mongodb_roles"}
 )
 
 var rotationPolicies = map[string]string{
@@ -222,7 +222,7 @@ func createRun(opts *CreateOpts) error {
 			}
 
 		case integrations.MongoDBAtlas:
-			missingDetails := validateDetails(sc.Details, MongoKeys)
+			missingDetails := validateDetails(sc.Details, MongoDBAtlasRequiredKeys)
 
 			if len(missingDetails) > 0 {
 				return fmt.Errorf("missing required detail(s) in the config file: %s", missingDetails)
@@ -267,12 +267,12 @@ func createRun(opts *CreateOpts) error {
 
 			req.Body = &preview_models.SecretServiceCreateMongoDBAtlasRotatingSecretBody{
 				SecretDetails: &preview_models.Secrets20231128MongoDBAtlasSecretDetails{
-					MongodbGroupID: sc.Details[MongoKeys[1]].(string),
+					MongodbGroupID: sc.Details[MongoDBAtlasRequiredKeys[1]].(string),
 					MongodbRoles:   reqRoles,
 					MongodbScopes:  reqScopes,
 				},
 				RotationIntegrationName: sc.IntegrationName,
-				RotationPolicyName:      rotationPolicies[sc.Details[MongoKeys[0]].(string)],
+				RotationPolicyName:      rotationPolicies[sc.Details[MongoDBAtlasRequiredKeys[0]].(string)],
 				SecretName:              opts.SecretName,
 			}
 			resp, err := opts.PreviewClient.CreateMongoDBAtlasRotatingSecret(req, nil)

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -126,10 +126,10 @@ type CreateOpts struct {
 }
 
 type SecretConfig struct {
-	Version                 string
-	Type                    integrations.IntegrationType
-	RotationIntegrationName string `yaml:"rotation_integration_name"`
-	Details                 map[string]any
+	Version         string
+	Type            integrations.IntegrationType
+	IntegrationName string `yaml:"rotation_integration_name"`
+	Details         map[string]any
 }
 
 type MongoDBRole struct {
@@ -192,6 +192,14 @@ func createRun(opts *CreateOpts) error {
 			return fmt.Errorf("failed to unmarshal config file: %w", err)
 		}
 
+		if sc.Type == "" || sc.IntegrationName == "" {
+			return fmt.Errorf("missing required field in the config file: type")
+		}
+
+		if sc.IntegrationName == "" {
+			return fmt.Errorf("missing required field in the config file: rotation_integration_name")
+		}
+
 		switch sc.Type {
 		case integrations.Twilio:
 			missingField := validateDetails(sc.Details, TwilioKeys)
@@ -205,7 +213,7 @@ func createRun(opts *CreateOpts) error {
 			req.ProjectID = opts.Profile.ProjectID
 			req.AppName = opts.AppName
 			req.Body = &preview_models.SecretServiceCreateTwilioRotatingSecretBody{
-				RotationIntegrationName: sc.RotationIntegrationName,
+				RotationIntegrationName: sc.IntegrationName,
 				RotationPolicyName:      rotationPolicies[sc.Details["rotation_policy_name"].(string)],
 				SecretName:              opts.SecretName,
 			}
@@ -267,7 +275,7 @@ func createRun(opts *CreateOpts) error {
 				MongodbGroupID:          sc.Details["mongodb_group_id"].(string),
 				MongodbRoles:            reqRoles,
 				MongodbScopes:           reqScopes,
-				RotationIntegrationName: sc.RotationIntegrationName,
+				RotationIntegrationName: sc.IntegrationName,
 				RotationPolicyName:      rotationPolicies[sc.Details["rotation_policy_name"].(string)],
 				SecretName:              opts.SecretName,
 			}

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -56,6 +56,15 @@ func TestNewCmdCreate(t *testing.T) {
 				SecretName: "test",
 			},
 		},
+		{
+			Name:    "Good: Rotating secret",
+			Profile: testProfile,
+			Args:    []string{"test", "--secret-type=rotating"},
+			Expect: &CreateOpts{
+				AppName:    testProfile(t).VaultSecrets.AppName,
+				SecretName: "test",
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -7,25 +7,25 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
-	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
-	models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/models"
-	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/models"
+	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
 	"github.com/hashicorp/hcp/internal/pkg/profile"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewCmdCreate(t *testing.T) {

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -45,12 +45,12 @@ func TestNewCmdCreate(t *testing.T) {
 			Name:    "Failed: No secret name arg specified",
 			Profile: testProfile,
 			Args:    []string{},
-			Error:   "ERROR: accepts 1 arg(s), received 0",
+			Error:   "ERROR: missing required flag: --data-file=DATA_FILE_PATH",
 		},
 		{
 			Name:    "Good: Secret name arg specified",
 			Profile: testProfile,
-			Args:    []string{"test"},
+			Args:    []string{"test", "--data-file=DATA_FILE_PATH"},
 			Expect: &CreateOpts{
 				AppName:    testProfile(t).VaultSecrets.AppName,
 				SecretName: "test",
@@ -59,7 +59,7 @@ func TestNewCmdCreate(t *testing.T) {
 		{
 			Name:    "Good: Rotating secret",
 			Profile: testProfile,
-			Args:    []string{"test", "--secret-type=rotating"},
+			Args:    []string{"test", "--secret-type=rotating", "--data-file=DATA_FILE_PATH"},
 			Expect: &CreateOpts{
 				AppName:    testProfile(t).VaultSecrets.AppName,
 				SecretName: "test",

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -200,7 +200,7 @@ type: "twilio"
 rotation_integration_name: "Twil-Int-11"
 details:
   none: "none"`),
-			ErrMsg: "missing required field in the config file: rotation_policy_name",
+			ErrMsg: "missing required field(s) in the config file: [rotation_policy_name]",
 		},
 	}
 

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -186,8 +186,7 @@ func TestCreateRun(t *testing.T) {
 			Input: []byte(`version: 1.0.0
 type: "twilio"
 rotation_integration_name: "Twil-Int-11"
-details:
-  rotation_policy_name: "60"`),
+rotation_policy_name: "60"`),
 		},
 		{
 			Name:    "Failed: Missing required rotating secret field",

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -232,3 +232,53 @@ func (d *displayer) openAppSecretsPayload() any {
 	}
 	return d.openAppSecrets
 }
+
+type rotatingSecretsDisplayer struct {
+	previewRotatingSecrets []*preview_models.Secrets20231128RotatingSecretConfig
+	single                 bool
+
+	format format.Format
+}
+
+func newRotatingSecretsDisplayer(single bool) *rotatingSecretsDisplayer {
+	return &rotatingSecretsDisplayer{
+		single: single,
+		format: format.Table,
+	}
+}
+
+func (r *rotatingSecretsDisplayer) PreviewRotatingSecrets(secrets ...*preview_models.Secrets20231128RotatingSecretConfig) *rotatingSecretsDisplayer {
+	r.previewRotatingSecrets = secrets
+	return r
+}
+
+func (r *rotatingSecretsDisplayer) DefaultFormat() format.Format {
+	return r.format
+}
+
+func (r *rotatingSecretsDisplayer) Payload() any {
+	if r.single {
+		if len(r.previewRotatingSecrets) != 1 {
+			return nil
+		}
+		return r.previewRotatingSecrets[0]
+	}
+	return r.previewRotatingSecrets
+}
+
+func (r *rotatingSecretsDisplayer) FieldTemplates() []format.Field {
+	return []format.Field{
+		{
+			Name:        "Secret Name",
+			ValueFormat: "{{ .SecretName }}",
+		},
+		{
+			Name:        " Rotation Integration",
+			ValueFormat: "{{ . RotationIntegrationName }}",
+		},
+		{
+			Name:        " Rotation Policy",
+			ValueFormat: "{{ . RotationPolicyName }}",
+		},
+	}
+}

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -274,11 +274,11 @@ func (r *rotatingSecretsDisplayer) FieldTemplates() []format.Field {
 		},
 		{
 			Name:        " Rotation Integration",
-			ValueFormat: "{{ . RotationIntegrationName }}",
+			ValueFormat: "{{ .RotationIntegrationName }}",
 		},
 		{
 			Name:        " Rotation Policy",
-			ValueFormat: "{{ . RotationPolicyName }}",
+			ValueFormat: "{{ .RotationPolicyName }}",
 		},
 	}
 }

--- a/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service/mock_ClientService.go
+++ b/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service/mock_ClientService.go
@@ -466,6 +466,80 @@ func (_c *MockClientService_CreateAwsDynamicSecret_Call) RunAndReturn(run func(*
 	return _c
 }
 
+// CreateAwsIAMUserAccessKeyRotatingSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) CreateAwsIAMUserAccessKeyRotatingSecret(params *secret_service.CreateAwsIAMUserAccessKeyRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateAwsIAMUserAccessKeyRotatingSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAwsIAMUserAccessKeyRotatingSecret")
+	}
+
+	var r0 *secret_service.CreateAwsIAMUserAccessKeyRotatingSecretOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateAwsIAMUserAccessKeyRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateAwsIAMUserAccessKeyRotatingSecretOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateAwsIAMUserAccessKeyRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.CreateAwsIAMUserAccessKeyRotatingSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.CreateAwsIAMUserAccessKeyRotatingSecretOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.CreateAwsIAMUserAccessKeyRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_CreateAwsIAMUserAccessKeyRotatingSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAwsIAMUserAccessKeyRotatingSecret'
+type MockClientService_CreateAwsIAMUserAccessKeyRotatingSecret_Call struct {
+	*mock.Call
+}
+
+// CreateAwsIAMUserAccessKeyRotatingSecret is a helper method to define mock.On call
+//   - params *secret_service.CreateAwsIAMUserAccessKeyRotatingSecretParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) CreateAwsIAMUserAccessKeyRotatingSecret(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_CreateAwsIAMUserAccessKeyRotatingSecret_Call {
+	return &MockClientService_CreateAwsIAMUserAccessKeyRotatingSecret_Call{Call: _e.mock.On("CreateAwsIAMUserAccessKeyRotatingSecret",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_CreateAwsIAMUserAccessKeyRotatingSecret_Call) Run(run func(params *secret_service.CreateAwsIAMUserAccessKeyRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_CreateAwsIAMUserAccessKeyRotatingSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.CreateAwsIAMUserAccessKeyRotatingSecretParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_CreateAwsIAMUserAccessKeyRotatingSecret_Call) Return(_a0 *secret_service.CreateAwsIAMUserAccessKeyRotatingSecretOK, _a1 error) *MockClientService_CreateAwsIAMUserAccessKeyRotatingSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_CreateAwsIAMUserAccessKeyRotatingSecret_Call) RunAndReturn(run func(*secret_service.CreateAwsIAMUserAccessKeyRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateAwsIAMUserAccessKeyRotatingSecretOK, error)) *MockClientService_CreateAwsIAMUserAccessKeyRotatingSecret_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateAwsIntegration provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) CreateAwsIntegration(params *secret_service.CreateAwsIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateAwsIntegrationOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -906,6 +980,80 @@ func (_c *MockClientService_CreateGcpIntegration_Call) Return(_a0 *secret_servic
 }
 
 func (_c *MockClientService_CreateGcpIntegration_Call) RunAndReturn(run func(*secret_service.CreateGcpIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateGcpIntegrationOK, error)) *MockClientService_CreateGcpIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateGcpServiceAccountKeyRotatingSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) CreateGcpServiceAccountKeyRotatingSecret(params *secret_service.CreateGcpServiceAccountKeyRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateGcpServiceAccountKeyRotatingSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateGcpServiceAccountKeyRotatingSecret")
+	}
+
+	var r0 *secret_service.CreateGcpServiceAccountKeyRotatingSecretOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateGcpServiceAccountKeyRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateGcpServiceAccountKeyRotatingSecretOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateGcpServiceAccountKeyRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.CreateGcpServiceAccountKeyRotatingSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.CreateGcpServiceAccountKeyRotatingSecretOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.CreateGcpServiceAccountKeyRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_CreateGcpServiceAccountKeyRotatingSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateGcpServiceAccountKeyRotatingSecret'
+type MockClientService_CreateGcpServiceAccountKeyRotatingSecret_Call struct {
+	*mock.Call
+}
+
+// CreateGcpServiceAccountKeyRotatingSecret is a helper method to define mock.On call
+//   - params *secret_service.CreateGcpServiceAccountKeyRotatingSecretParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) CreateGcpServiceAccountKeyRotatingSecret(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_CreateGcpServiceAccountKeyRotatingSecret_Call {
+	return &MockClientService_CreateGcpServiceAccountKeyRotatingSecret_Call{Call: _e.mock.On("CreateGcpServiceAccountKeyRotatingSecret",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_CreateGcpServiceAccountKeyRotatingSecret_Call) Run(run func(params *secret_service.CreateGcpServiceAccountKeyRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_CreateGcpServiceAccountKeyRotatingSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.CreateGcpServiceAccountKeyRotatingSecretParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_CreateGcpServiceAccountKeyRotatingSecret_Call) Return(_a0 *secret_service.CreateGcpServiceAccountKeyRotatingSecretOK, _a1 error) *MockClientService_CreateGcpServiceAccountKeyRotatingSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_CreateGcpServiceAccountKeyRotatingSecret_Call) RunAndReturn(run func(*secret_service.CreateGcpServiceAccountKeyRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateGcpServiceAccountKeyRotatingSecretOK, error)) *MockClientService_CreateGcpServiceAccountKeyRotatingSecret_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2908,6 +3056,80 @@ func (_c *MockClientService_GetAwsDynamicSecret_Call) RunAndReturn(run func(*sec
 	return _c
 }
 
+// GetAwsIAMUserAccessKeyRotatingSecretConfig provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetAwsIAMUserAccessKeyRotatingSecretConfig(params *secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAwsIAMUserAccessKeyRotatingSecretConfig")
+	}
+
+	var r0 *secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_GetAwsIAMUserAccessKeyRotatingSecretConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAwsIAMUserAccessKeyRotatingSecretConfig'
+type MockClientService_GetAwsIAMUserAccessKeyRotatingSecretConfig_Call struct {
+	*mock.Call
+}
+
+// GetAwsIAMUserAccessKeyRotatingSecretConfig is a helper method to define mock.On call
+//   - params *secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) GetAwsIAMUserAccessKeyRotatingSecretConfig(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_GetAwsIAMUserAccessKeyRotatingSecretConfig_Call {
+	return &MockClientService_GetAwsIAMUserAccessKeyRotatingSecretConfig_Call{Call: _e.mock.On("GetAwsIAMUserAccessKeyRotatingSecretConfig",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_GetAwsIAMUserAccessKeyRotatingSecretConfig_Call) Run(run func(params *secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_GetAwsIAMUserAccessKeyRotatingSecretConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_GetAwsIAMUserAccessKeyRotatingSecretConfig_Call) Return(_a0 *secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigOK, _a1 error) *MockClientService_GetAwsIAMUserAccessKeyRotatingSecretConfig_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_GetAwsIAMUserAccessKeyRotatingSecretConfig_Call) RunAndReturn(run func(*secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetAwsIAMUserAccessKeyRotatingSecretConfigOK, error)) *MockClientService_GetAwsIAMUserAccessKeyRotatingSecretConfig_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAwsIntegration provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) GetAwsIntegration(params *secret_service.GetAwsIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetAwsIntegrationOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -3056,6 +3278,80 @@ func (_c *MockClientService_GetGatewayPool_Call) RunAndReturn(run func(*secret_s
 	return _c
 }
 
+// GetGatewayPoolCertificate provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetGatewayPoolCertificate(params *secret_service.GetGatewayPoolCertificateParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetGatewayPoolCertificateOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGatewayPoolCertificate")
+	}
+
+	var r0 *secret_service.GetGatewayPoolCertificateOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.GetGatewayPoolCertificateParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetGatewayPoolCertificateOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.GetGatewayPoolCertificateParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.GetGatewayPoolCertificateOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.GetGatewayPoolCertificateOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.GetGatewayPoolCertificateParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_GetGatewayPoolCertificate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGatewayPoolCertificate'
+type MockClientService_GetGatewayPoolCertificate_Call struct {
+	*mock.Call
+}
+
+// GetGatewayPoolCertificate is a helper method to define mock.On call
+//   - params *secret_service.GetGatewayPoolCertificateParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) GetGatewayPoolCertificate(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_GetGatewayPoolCertificate_Call {
+	return &MockClientService_GetGatewayPoolCertificate_Call{Call: _e.mock.On("GetGatewayPoolCertificate",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_GetGatewayPoolCertificate_Call) Run(run func(params *secret_service.GetGatewayPoolCertificateParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_GetGatewayPoolCertificate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.GetGatewayPoolCertificateParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_GetGatewayPoolCertificate_Call) Return(_a0 *secret_service.GetGatewayPoolCertificateOK, _a1 error) *MockClientService_GetGatewayPoolCertificate_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_GetGatewayPoolCertificate_Call) RunAndReturn(run func(*secret_service.GetGatewayPoolCertificateParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetGatewayPoolCertificateOK, error)) *MockClientService_GetGatewayPoolCertificate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGcpDynamicSecret provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) GetGcpDynamicSecret(params *secret_service.GetGcpDynamicSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetGcpDynamicSecretOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -3200,6 +3496,80 @@ func (_c *MockClientService_GetGcpIntegration_Call) Return(_a0 *secret_service.G
 }
 
 func (_c *MockClientService_GetGcpIntegration_Call) RunAndReturn(run func(*secret_service.GetGcpIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetGcpIntegrationOK, error)) *MockClientService_GetGcpIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetGcpServiceAccountKeyRotatingSecretConfig provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetGcpServiceAccountKeyRotatingSecretConfig(params *secret_service.GetGcpServiceAccountKeyRotatingSecretConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetGcpServiceAccountKeyRotatingSecretConfigOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGcpServiceAccountKeyRotatingSecretConfig")
+	}
+
+	var r0 *secret_service.GetGcpServiceAccountKeyRotatingSecretConfigOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.GetGcpServiceAccountKeyRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetGcpServiceAccountKeyRotatingSecretConfigOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.GetGcpServiceAccountKeyRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.GetGcpServiceAccountKeyRotatingSecretConfigOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.GetGcpServiceAccountKeyRotatingSecretConfigOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.GetGcpServiceAccountKeyRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_GetGcpServiceAccountKeyRotatingSecretConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGcpServiceAccountKeyRotatingSecretConfig'
+type MockClientService_GetGcpServiceAccountKeyRotatingSecretConfig_Call struct {
+	*mock.Call
+}
+
+// GetGcpServiceAccountKeyRotatingSecretConfig is a helper method to define mock.On call
+//   - params *secret_service.GetGcpServiceAccountKeyRotatingSecretConfigParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) GetGcpServiceAccountKeyRotatingSecretConfig(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_GetGcpServiceAccountKeyRotatingSecretConfig_Call {
+	return &MockClientService_GetGcpServiceAccountKeyRotatingSecretConfig_Call{Call: _e.mock.On("GetGcpServiceAccountKeyRotatingSecretConfig",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_GetGcpServiceAccountKeyRotatingSecretConfig_Call) Run(run func(params *secret_service.GetGcpServiceAccountKeyRotatingSecretConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_GetGcpServiceAccountKeyRotatingSecretConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.GetGcpServiceAccountKeyRotatingSecretConfigParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_GetGcpServiceAccountKeyRotatingSecretConfig_Call) Return(_a0 *secret_service.GetGcpServiceAccountKeyRotatingSecretConfigOK, _a1 error) *MockClientService_GetGcpServiceAccountKeyRotatingSecretConfig_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_GetGcpServiceAccountKeyRotatingSecretConfig_Call) RunAndReturn(run func(*secret_service.GetGcpServiceAccountKeyRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetGcpServiceAccountKeyRotatingSecretConfigOK, error)) *MockClientService_GetGcpServiceAccountKeyRotatingSecretConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5975,6 +6345,80 @@ func (_c *MockClientService_UpdateApp_Call) RunAndReturn(run func(*secret_servic
 	return _c
 }
 
+// UpdateAwsIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdateAwsIntegration(params *secret_service.UpdateAwsIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateAwsIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateAwsIntegration")
+	}
+
+	var r0 *secret_service.UpdateAwsIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateAwsIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateAwsIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateAwsIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateAwsIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdateAwsIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdateAwsIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdateAwsIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateAwsIntegration'
+type MockClientService_UpdateAwsIntegration_Call struct {
+	*mock.Call
+}
+
+// UpdateAwsIntegration is a helper method to define mock.On call
+//   - params *secret_service.UpdateAwsIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdateAwsIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateAwsIntegration_Call {
+	return &MockClientService_UpdateAwsIntegration_Call{Call: _e.mock.On("UpdateAwsIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdateAwsIntegration_Call) Run(run func(params *secret_service.UpdateAwsIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateAwsIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdateAwsIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdateAwsIntegration_Call) Return(_a0 *secret_service.UpdateAwsIntegrationOK, _a1 error) *MockClientService_UpdateAwsIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdateAwsIntegration_Call) RunAndReturn(run func(*secret_service.UpdateAwsIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateAwsIntegrationOK, error)) *MockClientService_UpdateAwsIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateGatewayPool provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) UpdateGatewayPool(params *secret_service.UpdateGatewayPoolParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateGatewayPoolOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -6049,6 +6493,228 @@ func (_c *MockClientService_UpdateGatewayPool_Call) RunAndReturn(run func(*secre
 	return _c
 }
 
+// UpdateGcpIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdateGcpIntegration(params *secret_service.UpdateGcpIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateGcpIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateGcpIntegration")
+	}
+
+	var r0 *secret_service.UpdateGcpIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateGcpIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateGcpIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateGcpIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateGcpIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdateGcpIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdateGcpIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdateGcpIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateGcpIntegration'
+type MockClientService_UpdateGcpIntegration_Call struct {
+	*mock.Call
+}
+
+// UpdateGcpIntegration is a helper method to define mock.On call
+//   - params *secret_service.UpdateGcpIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdateGcpIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateGcpIntegration_Call {
+	return &MockClientService_UpdateGcpIntegration_Call{Call: _e.mock.On("UpdateGcpIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdateGcpIntegration_Call) Run(run func(params *secret_service.UpdateGcpIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateGcpIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdateGcpIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdateGcpIntegration_Call) Return(_a0 *secret_service.UpdateGcpIntegrationOK, _a1 error) *MockClientService_UpdateGcpIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdateGcpIntegration_Call) RunAndReturn(run func(*secret_service.UpdateGcpIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateGcpIntegrationOK, error)) *MockClientService_UpdateGcpIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateMongoDBAtlasIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdateMongoDBAtlasIntegration(params *secret_service.UpdateMongoDBAtlasIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateMongoDBAtlasIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateMongoDBAtlasIntegration")
+	}
+
+	var r0 *secret_service.UpdateMongoDBAtlasIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateMongoDBAtlasIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateMongoDBAtlasIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateMongoDBAtlasIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateMongoDBAtlasIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdateMongoDBAtlasIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdateMongoDBAtlasIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdateMongoDBAtlasIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateMongoDBAtlasIntegration'
+type MockClientService_UpdateMongoDBAtlasIntegration_Call struct {
+	*mock.Call
+}
+
+// UpdateMongoDBAtlasIntegration is a helper method to define mock.On call
+//   - params *secret_service.UpdateMongoDBAtlasIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdateMongoDBAtlasIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateMongoDBAtlasIntegration_Call {
+	return &MockClientService_UpdateMongoDBAtlasIntegration_Call{Call: _e.mock.On("UpdateMongoDBAtlasIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdateMongoDBAtlasIntegration_Call) Run(run func(params *secret_service.UpdateMongoDBAtlasIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateMongoDBAtlasIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdateMongoDBAtlasIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdateMongoDBAtlasIntegration_Call) Return(_a0 *secret_service.UpdateMongoDBAtlasIntegrationOK, _a1 error) *MockClientService_UpdateMongoDBAtlasIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdateMongoDBAtlasIntegration_Call) RunAndReturn(run func(*secret_service.UpdateMongoDBAtlasIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateMongoDBAtlasIntegrationOK, error)) *MockClientService_UpdateMongoDBAtlasIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateMongoDBAtlasRotatingSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdateMongoDBAtlasRotatingSecret(params *secret_service.UpdateMongoDBAtlasRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateMongoDBAtlasRotatingSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateMongoDBAtlasRotatingSecret")
+	}
+
+	var r0 *secret_service.UpdateMongoDBAtlasRotatingSecretOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateMongoDBAtlasRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateMongoDBAtlasRotatingSecretOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateMongoDBAtlasRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateMongoDBAtlasRotatingSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdateMongoDBAtlasRotatingSecretOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdateMongoDBAtlasRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdateMongoDBAtlasRotatingSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateMongoDBAtlasRotatingSecret'
+type MockClientService_UpdateMongoDBAtlasRotatingSecret_Call struct {
+	*mock.Call
+}
+
+// UpdateMongoDBAtlasRotatingSecret is a helper method to define mock.On call
+//   - params *secret_service.UpdateMongoDBAtlasRotatingSecretParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdateMongoDBAtlasRotatingSecret(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call {
+	return &MockClientService_UpdateMongoDBAtlasRotatingSecret_Call{Call: _e.mock.On("UpdateMongoDBAtlasRotatingSecret",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call) Run(run func(params *secret_service.UpdateMongoDBAtlasRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdateMongoDBAtlasRotatingSecretParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call) Return(_a0 *secret_service.UpdateMongoDBAtlasRotatingSecretOK, _a1 error) *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call) RunAndReturn(run func(*secret_service.UpdateMongoDBAtlasRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateMongoDBAtlasRotatingSecretOK, error)) *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateSyncInstallation provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) UpdateSyncInstallation(params *secret_service.UpdateSyncInstallationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateSyncInstallationOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -6119,6 +6785,154 @@ func (_c *MockClientService_UpdateSyncInstallation_Call) Return(_a0 *secret_serv
 }
 
 func (_c *MockClientService_UpdateSyncInstallation_Call) RunAndReturn(run func(*secret_service.UpdateSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateSyncInstallationOK, error)) *MockClientService_UpdateSyncInstallation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateTwilioIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdateTwilioIntegration(params *secret_service.UpdateTwilioIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateTwilioIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateTwilioIntegration")
+	}
+
+	var r0 *secret_service.UpdateTwilioIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateTwilioIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateTwilioIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateTwilioIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateTwilioIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdateTwilioIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdateTwilioIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdateTwilioIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateTwilioIntegration'
+type MockClientService_UpdateTwilioIntegration_Call struct {
+	*mock.Call
+}
+
+// UpdateTwilioIntegration is a helper method to define mock.On call
+//   - params *secret_service.UpdateTwilioIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdateTwilioIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateTwilioIntegration_Call {
+	return &MockClientService_UpdateTwilioIntegration_Call{Call: _e.mock.On("UpdateTwilioIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdateTwilioIntegration_Call) Run(run func(params *secret_service.UpdateTwilioIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateTwilioIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdateTwilioIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdateTwilioIntegration_Call) Return(_a0 *secret_service.UpdateTwilioIntegrationOK, _a1 error) *MockClientService_UpdateTwilioIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdateTwilioIntegration_Call) RunAndReturn(run func(*secret_service.UpdateTwilioIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateTwilioIntegrationOK, error)) *MockClientService_UpdateTwilioIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateTwilioRotatingSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdateTwilioRotatingSecret(params *secret_service.UpdateTwilioRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateTwilioRotatingSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateTwilioRotatingSecret")
+	}
+
+	var r0 *secret_service.UpdateTwilioRotatingSecretOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateTwilioRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateTwilioRotatingSecretOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateTwilioRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateTwilioRotatingSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdateTwilioRotatingSecretOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdateTwilioRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdateTwilioRotatingSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateTwilioRotatingSecret'
+type MockClientService_UpdateTwilioRotatingSecret_Call struct {
+	*mock.Call
+}
+
+// UpdateTwilioRotatingSecret is a helper method to define mock.On call
+//   - params *secret_service.UpdateTwilioRotatingSecretParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdateTwilioRotatingSecret(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateTwilioRotatingSecret_Call {
+	return &MockClientService_UpdateTwilioRotatingSecret_Call{Call: _e.mock.On("UpdateTwilioRotatingSecret",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdateTwilioRotatingSecret_Call) Run(run func(params *secret_service.UpdateTwilioRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateTwilioRotatingSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdateTwilioRotatingSecretParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdateTwilioRotatingSecret_Call) Return(_a0 *secret_service.UpdateTwilioRotatingSecretOK, _a1 error) *MockClientService_UpdateTwilioRotatingSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdateTwilioRotatingSecret_Call) RunAndReturn(run func(*secret_service.UpdateTwilioRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateTwilioRotatingSecretOK, error)) *MockClientService_UpdateTwilioRotatingSecret_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service/mock_ClientService.go
+++ b/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service/mock_ClientService.go
@@ -170,6 +170,80 @@ func (_c *MockClientService_CompleteVercelInstallation_Call) RunAndReturn(run fu
 	return _c
 }
 
+// ConnectGitHubInstallation provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) ConnectGitHubInstallation(params *secret_service.ConnectGitHubInstallationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.ConnectGitHubInstallationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConnectGitHubInstallation")
+	}
+
+	var r0 *secret_service.ConnectGitHubInstallationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.ConnectGitHubInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.ConnectGitHubInstallationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.ConnectGitHubInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.ConnectGitHubInstallationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.ConnectGitHubInstallationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.ConnectGitHubInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_ConnectGitHubInstallation_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConnectGitHubInstallation'
+type MockClientService_ConnectGitHubInstallation_Call struct {
+	*mock.Call
+}
+
+// ConnectGitHubInstallation is a helper method to define mock.On call
+//   - params *secret_service.ConnectGitHubInstallationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) ConnectGitHubInstallation(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_ConnectGitHubInstallation_Call {
+	return &MockClientService_ConnectGitHubInstallation_Call{Call: _e.mock.On("ConnectGitHubInstallation",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_ConnectGitHubInstallation_Call) Run(run func(params *secret_service.ConnectGitHubInstallationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_ConnectGitHubInstallation_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.ConnectGitHubInstallationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_ConnectGitHubInstallation_Call) Return(_a0 *secret_service.ConnectGitHubInstallationOK, _a1 error) *MockClientService_ConnectGitHubInstallation_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_ConnectGitHubInstallation_Call) RunAndReturn(run func(*secret_service.ConnectGitHubInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.ConnectGitHubInstallationOK, error)) *MockClientService_ConnectGitHubInstallation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateApp provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) CreateApp(params *secret_service.CreateAppParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateAppOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -392,6 +466,228 @@ func (_c *MockClientService_CreateAwsSmSyncIntegration_Call) RunAndReturn(run fu
 	return _c
 }
 
+// CreateAzureKvSyncIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) CreateAzureKvSyncIntegration(params *secret_service.CreateAzureKvSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateAzureKvSyncIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAzureKvSyncIntegration")
+	}
+
+	var r0 *secret_service.CreateAzureKvSyncIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateAzureKvSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateAzureKvSyncIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateAzureKvSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.CreateAzureKvSyncIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.CreateAzureKvSyncIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.CreateAzureKvSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_CreateAzureKvSyncIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAzureKvSyncIntegration'
+type MockClientService_CreateAzureKvSyncIntegration_Call struct {
+	*mock.Call
+}
+
+// CreateAzureKvSyncIntegration is a helper method to define mock.On call
+//   - params *secret_service.CreateAzureKvSyncIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) CreateAzureKvSyncIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_CreateAzureKvSyncIntegration_Call {
+	return &MockClientService_CreateAzureKvSyncIntegration_Call{Call: _e.mock.On("CreateAzureKvSyncIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_CreateAzureKvSyncIntegration_Call) Run(run func(params *secret_service.CreateAzureKvSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_CreateAzureKvSyncIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.CreateAzureKvSyncIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_CreateAzureKvSyncIntegration_Call) Return(_a0 *secret_service.CreateAzureKvSyncIntegrationOK, _a1 error) *MockClientService_CreateAzureKvSyncIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_CreateAzureKvSyncIntegration_Call) RunAndReturn(run func(*secret_service.CreateAzureKvSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateAzureKvSyncIntegrationOK, error)) *MockClientService_CreateAzureKvSyncIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateGcpSmSyncIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) CreateGcpSmSyncIntegration(params *secret_service.CreateGcpSmSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateGcpSmSyncIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateGcpSmSyncIntegration")
+	}
+
+	var r0 *secret_service.CreateGcpSmSyncIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateGcpSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateGcpSmSyncIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateGcpSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.CreateGcpSmSyncIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.CreateGcpSmSyncIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.CreateGcpSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_CreateGcpSmSyncIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateGcpSmSyncIntegration'
+type MockClientService_CreateGcpSmSyncIntegration_Call struct {
+	*mock.Call
+}
+
+// CreateGcpSmSyncIntegration is a helper method to define mock.On call
+//   - params *secret_service.CreateGcpSmSyncIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) CreateGcpSmSyncIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_CreateGcpSmSyncIntegration_Call {
+	return &MockClientService_CreateGcpSmSyncIntegration_Call{Call: _e.mock.On("CreateGcpSmSyncIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_CreateGcpSmSyncIntegration_Call) Run(run func(params *secret_service.CreateGcpSmSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_CreateGcpSmSyncIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.CreateGcpSmSyncIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_CreateGcpSmSyncIntegration_Call) Return(_a0 *secret_service.CreateGcpSmSyncIntegrationOK, _a1 error) *MockClientService_CreateGcpSmSyncIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_CreateGcpSmSyncIntegration_Call) RunAndReturn(run func(*secret_service.CreateGcpSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateGcpSmSyncIntegrationOK, error)) *MockClientService_CreateGcpSmSyncIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateGhOrgSyncIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) CreateGhOrgSyncIntegration(params *secret_service.CreateGhOrgSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateGhOrgSyncIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateGhOrgSyncIntegration")
+	}
+
+	var r0 *secret_service.CreateGhOrgSyncIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateGhOrgSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateGhOrgSyncIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateGhOrgSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.CreateGhOrgSyncIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.CreateGhOrgSyncIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.CreateGhOrgSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_CreateGhOrgSyncIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateGhOrgSyncIntegration'
+type MockClientService_CreateGhOrgSyncIntegration_Call struct {
+	*mock.Call
+}
+
+// CreateGhOrgSyncIntegration is a helper method to define mock.On call
+//   - params *secret_service.CreateGhOrgSyncIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) CreateGhOrgSyncIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_CreateGhOrgSyncIntegration_Call {
+	return &MockClientService_CreateGhOrgSyncIntegration_Call{Call: _e.mock.On("CreateGhOrgSyncIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_CreateGhOrgSyncIntegration_Call) Run(run func(params *secret_service.CreateGhOrgSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_CreateGhOrgSyncIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.CreateGhOrgSyncIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_CreateGhOrgSyncIntegration_Call) Return(_a0 *secret_service.CreateGhOrgSyncIntegrationOK, _a1 error) *MockClientService_CreateGhOrgSyncIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_CreateGhOrgSyncIntegration_Call) RunAndReturn(run func(*secret_service.CreateGhOrgSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateGhOrgSyncIntegrationOK, error)) *MockClientService_CreateGhOrgSyncIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateGhRepoSyncIntegration provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) CreateGhRepoSyncIntegration(params *secret_service.CreateGhRepoSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateGhRepoSyncIntegrationOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -462,6 +758,154 @@ func (_c *MockClientService_CreateGhRepoSyncIntegration_Call) Return(_a0 *secret
 }
 
 func (_c *MockClientService_CreateGhRepoSyncIntegration_Call) RunAndReturn(run func(*secret_service.CreateGhRepoSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateGhRepoSyncIntegrationOK, error)) *MockClientService_CreateGhRepoSyncIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateHcpTerraformSyncInstallation provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) CreateHcpTerraformSyncInstallation(params *secret_service.CreateHcpTerraformSyncInstallationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateHcpTerraformSyncInstallationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateHcpTerraformSyncInstallation")
+	}
+
+	var r0 *secret_service.CreateHcpTerraformSyncInstallationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateHcpTerraformSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateHcpTerraformSyncInstallationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateHcpTerraformSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.CreateHcpTerraformSyncInstallationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.CreateHcpTerraformSyncInstallationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.CreateHcpTerraformSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_CreateHcpTerraformSyncInstallation_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateHcpTerraformSyncInstallation'
+type MockClientService_CreateHcpTerraformSyncInstallation_Call struct {
+	*mock.Call
+}
+
+// CreateHcpTerraformSyncInstallation is a helper method to define mock.On call
+//   - params *secret_service.CreateHcpTerraformSyncInstallationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) CreateHcpTerraformSyncInstallation(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_CreateHcpTerraformSyncInstallation_Call {
+	return &MockClientService_CreateHcpTerraformSyncInstallation_Call{Call: _e.mock.On("CreateHcpTerraformSyncInstallation",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_CreateHcpTerraformSyncInstallation_Call) Run(run func(params *secret_service.CreateHcpTerraformSyncInstallationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_CreateHcpTerraformSyncInstallation_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.CreateHcpTerraformSyncInstallationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_CreateHcpTerraformSyncInstallation_Call) Return(_a0 *secret_service.CreateHcpTerraformSyncInstallationOK, _a1 error) *MockClientService_CreateHcpTerraformSyncInstallation_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_CreateHcpTerraformSyncInstallation_Call) RunAndReturn(run func(*secret_service.CreateHcpTerraformSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateHcpTerraformSyncInstallationOK, error)) *MockClientService_CreateHcpTerraformSyncInstallation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateHcpTerraformSyncIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) CreateHcpTerraformSyncIntegration(params *secret_service.CreateHcpTerraformSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateHcpTerraformSyncIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateHcpTerraformSyncIntegration")
+	}
+
+	var r0 *secret_service.CreateHcpTerraformSyncIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateHcpTerraformSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateHcpTerraformSyncIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateHcpTerraformSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.CreateHcpTerraformSyncIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.CreateHcpTerraformSyncIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.CreateHcpTerraformSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_CreateHcpTerraformSyncIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateHcpTerraformSyncIntegration'
+type MockClientService_CreateHcpTerraformSyncIntegration_Call struct {
+	*mock.Call
+}
+
+// CreateHcpTerraformSyncIntegration is a helper method to define mock.On call
+//   - params *secret_service.CreateHcpTerraformSyncIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) CreateHcpTerraformSyncIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_CreateHcpTerraformSyncIntegration_Call {
+	return &MockClientService_CreateHcpTerraformSyncIntegration_Call{Call: _e.mock.On("CreateHcpTerraformSyncIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_CreateHcpTerraformSyncIntegration_Call) Run(run func(params *secret_service.CreateHcpTerraformSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_CreateHcpTerraformSyncIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.CreateHcpTerraformSyncIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_CreateHcpTerraformSyncIntegration_Call) Return(_a0 *secret_service.CreateHcpTerraformSyncIntegrationOK, _a1 error) *MockClientService_CreateHcpTerraformSyncIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_CreateHcpTerraformSyncIntegration_Call) RunAndReturn(run func(*secret_service.CreateHcpTerraformSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateHcpTerraformSyncIntegrationOK, error)) *MockClientService_CreateHcpTerraformSyncIntegration_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1206,6 +1650,80 @@ func (_c *MockClientService_GetAppSecretVersion_Call) RunAndReturn(run func(*sec
 	return _c
 }
 
+// GetGitHubEnvironments provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetGitHubEnvironments(params *secret_service.GetGitHubEnvironmentsParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetGitHubEnvironmentsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGitHubEnvironments")
+	}
+
+	var r0 *secret_service.GetGitHubEnvironmentsOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.GetGitHubEnvironmentsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetGitHubEnvironmentsOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.GetGitHubEnvironmentsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.GetGitHubEnvironmentsOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.GetGitHubEnvironmentsOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.GetGitHubEnvironmentsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_GetGitHubEnvironments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubEnvironments'
+type MockClientService_GetGitHubEnvironments_Call struct {
+	*mock.Call
+}
+
+// GetGitHubEnvironments is a helper method to define mock.On call
+//   - params *secret_service.GetGitHubEnvironmentsParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) GetGitHubEnvironments(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_GetGitHubEnvironments_Call {
+	return &MockClientService_GetGitHubEnvironments_Call{Call: _e.mock.On("GetGitHubEnvironments",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_GetGitHubEnvironments_Call) Run(run func(params *secret_service.GetGitHubEnvironmentsParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_GetGitHubEnvironments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.GetGitHubEnvironmentsParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_GetGitHubEnvironments_Call) Return(_a0 *secret_service.GetGitHubEnvironmentsOK, _a1 error) *MockClientService_GetGitHubEnvironments_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_GetGitHubEnvironments_Call) RunAndReturn(run func(*secret_service.GetGitHubEnvironmentsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetGitHubEnvironmentsOK, error)) *MockClientService_GetGitHubEnvironments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGitHubInstallLinks provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) GetGitHubInstallLinks(params *secret_service.GetGitHubInstallLinksParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetGitHubInstallLinksOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -1276,6 +1794,80 @@ func (_c *MockClientService_GetGitHubInstallLinks_Call) Return(_a0 *secret_servi
 }
 
 func (_c *MockClientService_GetGitHubInstallLinks_Call) RunAndReturn(run func(*secret_service.GetGitHubInstallLinksParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetGitHubInstallLinksOK, error)) *MockClientService_GetGitHubInstallLinks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetGitHubRepositories provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetGitHubRepositories(params *secret_service.GetGitHubRepositoriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetGitHubRepositoriesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGitHubRepositories")
+	}
+
+	var r0 *secret_service.GetGitHubRepositoriesOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.GetGitHubRepositoriesParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetGitHubRepositoriesOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.GetGitHubRepositoriesParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.GetGitHubRepositoriesOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.GetGitHubRepositoriesOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.GetGitHubRepositoriesParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_GetGitHubRepositories_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubRepositories'
+type MockClientService_GetGitHubRepositories_Call struct {
+	*mock.Call
+}
+
+// GetGitHubRepositories is a helper method to define mock.On call
+//   - params *secret_service.GetGitHubRepositoriesParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) GetGitHubRepositories(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_GetGitHubRepositories_Call {
+	return &MockClientService_GetGitHubRepositories_Call{Call: _e.mock.On("GetGitHubRepositories",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_GetGitHubRepositories_Call) Run(run func(params *secret_service.GetGitHubRepositoriesParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_GetGitHubRepositories_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.GetGitHubRepositoriesParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_GetGitHubRepositories_Call) Return(_a0 *secret_service.GetGitHubRepositoriesOK, _a1 error) *MockClientService_GetGitHubRepositories_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_GetGitHubRepositories_Call) RunAndReturn(run func(*secret_service.GetGitHubRepositoriesParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetGitHubRepositoriesOK, error)) *MockClientService_GetGitHubRepositories_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1872,6 +2464,80 @@ func (_c *MockClientService_ListApps_Call) RunAndReturn(run func(*secret_service
 	return _c
 }
 
+// ListGitHubInstallations provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) ListGitHubInstallations(params *secret_service.ListGitHubInstallationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.ListGitHubInstallationsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListGitHubInstallations")
+	}
+
+	var r0 *secret_service.ListGitHubInstallationsOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.ListGitHubInstallationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.ListGitHubInstallationsOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.ListGitHubInstallationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.ListGitHubInstallationsOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.ListGitHubInstallationsOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.ListGitHubInstallationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_ListGitHubInstallations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListGitHubInstallations'
+type MockClientService_ListGitHubInstallations_Call struct {
+	*mock.Call
+}
+
+// ListGitHubInstallations is a helper method to define mock.On call
+//   - params *secret_service.ListGitHubInstallationsParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) ListGitHubInstallations(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_ListGitHubInstallations_Call {
+	return &MockClientService_ListGitHubInstallations_Call{Call: _e.mock.On("ListGitHubInstallations",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_ListGitHubInstallations_Call) Run(run func(params *secret_service.ListGitHubInstallationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_ListGitHubInstallations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.ListGitHubInstallationsParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_ListGitHubInstallations_Call) Return(_a0 *secret_service.ListGitHubInstallationsOK, _a1 error) *MockClientService_ListGitHubInstallations_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_ListGitHubInstallations_Call) RunAndReturn(run func(*secret_service.ListGitHubInstallationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.ListGitHubInstallationsOK, error)) *MockClientService_ListGitHubInstallations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListOpenAppSecretVersions provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) ListOpenAppSecretVersions(params *secret_service.ListOpenAppSecretVersionsParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.ListOpenAppSecretVersionsOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -1942,6 +2608,80 @@ func (_c *MockClientService_ListOpenAppSecretVersions_Call) Return(_a0 *secret_s
 }
 
 func (_c *MockClientService_ListOpenAppSecretVersions_Call) RunAndReturn(run func(*secret_service.ListOpenAppSecretVersionsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.ListOpenAppSecretVersionsOK, error)) *MockClientService_ListOpenAppSecretVersions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListSyncInstallations provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) ListSyncInstallations(params *secret_service.ListSyncInstallationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.ListSyncInstallationsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListSyncInstallations")
+	}
+
+	var r0 *secret_service.ListSyncInstallationsOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.ListSyncInstallationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.ListSyncInstallationsOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.ListSyncInstallationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.ListSyncInstallationsOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.ListSyncInstallationsOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.ListSyncInstallationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_ListSyncInstallations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSyncInstallations'
+type MockClientService_ListSyncInstallations_Call struct {
+	*mock.Call
+}
+
+// ListSyncInstallations is a helper method to define mock.On call
+//   - params *secret_service.ListSyncInstallationsParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) ListSyncInstallations(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_ListSyncInstallations_Call {
+	return &MockClientService_ListSyncInstallations_Call{Call: _e.mock.On("ListSyncInstallations",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_ListSyncInstallations_Call) Run(run func(params *secret_service.ListSyncInstallationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_ListSyncInstallations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.ListSyncInstallationsParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_ListSyncInstallations_Call) Return(_a0 *secret_service.ListSyncInstallationsOK, _a1 error) *MockClientService_ListSyncInstallations_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_ListSyncInstallations_Call) RunAndReturn(run func(*secret_service.ListSyncInstallationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.ListSyncInstallationsOK, error)) *MockClientService_ListSyncInstallations_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2423,8 +3163,8 @@ func (_c *MockClientService_UpdateApp_Call) RunAndReturn(run func(*secret_servic
 	return _c
 }
 
-// UpdateAwsSmSyncIntegration provides a mock function with given fields: params, authInfo, opts
-func (_m *MockClientService) UpdateAwsSmSyncIntegration(params *secret_service.UpdateAwsSmSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateAwsSmSyncIntegrationOK, error) {
+// UpdateSyncInstallation provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdateSyncInstallation(params *secret_service.UpdateSyncInstallationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateSyncInstallationOK, error) {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
@@ -2435,23 +3175,23 @@ func (_m *MockClientService) UpdateAwsSmSyncIntegration(params *secret_service.U
 	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
-		panic("no return value specified for UpdateAwsSmSyncIntegration")
+		panic("no return value specified for UpdateSyncInstallation")
 	}
 
-	var r0 *secret_service.UpdateAwsSmSyncIntegrationOK
+	var r0 *secret_service.UpdateSyncInstallationOK
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*secret_service.UpdateAwsSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateAwsSmSyncIntegrationOK, error)); ok {
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateSyncInstallationOK, error)); ok {
 		return rf(params, authInfo, opts...)
 	}
-	if rf, ok := ret.Get(0).(func(*secret_service.UpdateAwsSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateAwsSmSyncIntegrationOK); ok {
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateSyncInstallationOK); ok {
 		r0 = rf(params, authInfo, opts...)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*secret_service.UpdateAwsSmSyncIntegrationOK)
+			r0 = ret.Get(0).(*secret_service.UpdateSyncInstallationOK)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*secret_service.UpdateAwsSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdateSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
 		r1 = rf(params, authInfo, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -2460,21 +3200,21 @@ func (_m *MockClientService) UpdateAwsSmSyncIntegration(params *secret_service.U
 	return r0, r1
 }
 
-// MockClientService_UpdateAwsSmSyncIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateAwsSmSyncIntegration'
-type MockClientService_UpdateAwsSmSyncIntegration_Call struct {
+// MockClientService_UpdateSyncInstallation_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateSyncInstallation'
+type MockClientService_UpdateSyncInstallation_Call struct {
 	*mock.Call
 }
 
-// UpdateAwsSmSyncIntegration is a helper method to define mock.On call
-//   - params *secret_service.UpdateAwsSmSyncIntegrationParams
+// UpdateSyncInstallation is a helper method to define mock.On call
+//   - params *secret_service.UpdateSyncInstallationParams
 //   - authInfo runtime.ClientAuthInfoWriter
 //   - opts ...secret_service.ClientOption
-func (_e *MockClientService_Expecter) UpdateAwsSmSyncIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateAwsSmSyncIntegration_Call {
-	return &MockClientService_UpdateAwsSmSyncIntegration_Call{Call: _e.mock.On("UpdateAwsSmSyncIntegration",
+func (_e *MockClientService_Expecter) UpdateSyncInstallation(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateSyncInstallation_Call {
+	return &MockClientService_UpdateSyncInstallation_Call{Call: _e.mock.On("UpdateSyncInstallation",
 		append([]interface{}{params, authInfo}, opts...)...)}
 }
 
-func (_c *MockClientService_UpdateAwsSmSyncIntegration_Call) Run(run func(params *secret_service.UpdateAwsSmSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateAwsSmSyncIntegration_Call {
+func (_c *MockClientService_UpdateSyncInstallation_Call) Run(run func(params *secret_service.UpdateSyncInstallationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateSyncInstallation_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
 		for i, a := range args[2:] {
@@ -2482,461 +3222,17 @@ func (_c *MockClientService_UpdateAwsSmSyncIntegration_Call) Run(run func(params
 				variadicArgs[i] = a.(secret_service.ClientOption)
 			}
 		}
-		run(args[0].(*secret_service.UpdateAwsSmSyncIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+		run(args[0].(*secret_service.UpdateSyncInstallationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
 	})
 	return _c
 }
 
-func (_c *MockClientService_UpdateAwsSmSyncIntegration_Call) Return(_a0 *secret_service.UpdateAwsSmSyncIntegrationOK, _a1 error) *MockClientService_UpdateAwsSmSyncIntegration_Call {
+func (_c *MockClientService_UpdateSyncInstallation_Call) Return(_a0 *secret_service.UpdateSyncInstallationOK, _a1 error) *MockClientService_UpdateSyncInstallation_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockClientService_UpdateAwsSmSyncIntegration_Call) RunAndReturn(run func(*secret_service.UpdateAwsSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateAwsSmSyncIntegrationOK, error)) *MockClientService_UpdateAwsSmSyncIntegration_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateGhRepoSyncIntegration provides a mock function with given fields: params, authInfo, opts
-func (_m *MockClientService) UpdateGhRepoSyncIntegration(params *secret_service.UpdateGhRepoSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateGhRepoSyncIntegrationOK, error) {
-	_va := make([]interface{}, len(opts))
-	for _i := range opts {
-		_va[_i] = opts[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, params, authInfo)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateGhRepoSyncIntegration")
-	}
-
-	var r0 *secret_service.UpdateGhRepoSyncIntegrationOK
-	var r1 error
-	if rf, ok := ret.Get(0).(func(*secret_service.UpdateGhRepoSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateGhRepoSyncIntegrationOK, error)); ok {
-		return rf(params, authInfo, opts...)
-	}
-	if rf, ok := ret.Get(0).(func(*secret_service.UpdateGhRepoSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateGhRepoSyncIntegrationOK); ok {
-		r0 = rf(params, authInfo, opts...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*secret_service.UpdateGhRepoSyncIntegrationOK)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(*secret_service.UpdateGhRepoSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
-		r1 = rf(params, authInfo, opts...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockClientService_UpdateGhRepoSyncIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateGhRepoSyncIntegration'
-type MockClientService_UpdateGhRepoSyncIntegration_Call struct {
-	*mock.Call
-}
-
-// UpdateGhRepoSyncIntegration is a helper method to define mock.On call
-//   - params *secret_service.UpdateGhRepoSyncIntegrationParams
-//   - authInfo runtime.ClientAuthInfoWriter
-//   - opts ...secret_service.ClientOption
-func (_e *MockClientService_Expecter) UpdateGhRepoSyncIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateGhRepoSyncIntegration_Call {
-	return &MockClientService_UpdateGhRepoSyncIntegration_Call{Call: _e.mock.On("UpdateGhRepoSyncIntegration",
-		append([]interface{}{params, authInfo}, opts...)...)}
-}
-
-func (_c *MockClientService_UpdateGhRepoSyncIntegration_Call) Run(run func(params *secret_service.UpdateGhRepoSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateGhRepoSyncIntegration_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
-		for i, a := range args[2:] {
-			if a != nil {
-				variadicArgs[i] = a.(secret_service.ClientOption)
-			}
-		}
-		run(args[0].(*secret_service.UpdateGhRepoSyncIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
-	})
-	return _c
-}
-
-func (_c *MockClientService_UpdateGhRepoSyncIntegration_Call) Return(_a0 *secret_service.UpdateGhRepoSyncIntegrationOK, _a1 error) *MockClientService_UpdateGhRepoSyncIntegration_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockClientService_UpdateGhRepoSyncIntegration_Call) RunAndReturn(run func(*secret_service.UpdateGhRepoSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateGhRepoSyncIntegrationOK, error)) *MockClientService_UpdateGhRepoSyncIntegration_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateVercelProjectSyncIntegration provides a mock function with given fields: params, authInfo, opts
-func (_m *MockClientService) UpdateVercelProjectSyncIntegration(params *secret_service.UpdateVercelProjectSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateVercelProjectSyncIntegrationOK, error) {
-	_va := make([]interface{}, len(opts))
-	for _i := range opts {
-		_va[_i] = opts[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, params, authInfo)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateVercelProjectSyncIntegration")
-	}
-
-	var r0 *secret_service.UpdateVercelProjectSyncIntegrationOK
-	var r1 error
-	if rf, ok := ret.Get(0).(func(*secret_service.UpdateVercelProjectSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateVercelProjectSyncIntegrationOK, error)); ok {
-		return rf(params, authInfo, opts...)
-	}
-	if rf, ok := ret.Get(0).(func(*secret_service.UpdateVercelProjectSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateVercelProjectSyncIntegrationOK); ok {
-		r0 = rf(params, authInfo, opts...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*secret_service.UpdateVercelProjectSyncIntegrationOK)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(*secret_service.UpdateVercelProjectSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
-		r1 = rf(params, authInfo, opts...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockClientService_UpdateVercelProjectSyncIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateVercelProjectSyncIntegration'
-type MockClientService_UpdateVercelProjectSyncIntegration_Call struct {
-	*mock.Call
-}
-
-// UpdateVercelProjectSyncIntegration is a helper method to define mock.On call
-//   - params *secret_service.UpdateVercelProjectSyncIntegrationParams
-//   - authInfo runtime.ClientAuthInfoWriter
-//   - opts ...secret_service.ClientOption
-func (_e *MockClientService_Expecter) UpdateVercelProjectSyncIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateVercelProjectSyncIntegration_Call {
-	return &MockClientService_UpdateVercelProjectSyncIntegration_Call{Call: _e.mock.On("UpdateVercelProjectSyncIntegration",
-		append([]interface{}{params, authInfo}, opts...)...)}
-}
-
-func (_c *MockClientService_UpdateVercelProjectSyncIntegration_Call) Run(run func(params *secret_service.UpdateVercelProjectSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateVercelProjectSyncIntegration_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
-		for i, a := range args[2:] {
-			if a != nil {
-				variadicArgs[i] = a.(secret_service.ClientOption)
-			}
-		}
-		run(args[0].(*secret_service.UpdateVercelProjectSyncIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
-	})
-	return _c
-}
-
-func (_c *MockClientService_UpdateVercelProjectSyncIntegration_Call) Return(_a0 *secret_service.UpdateVercelProjectSyncIntegrationOK, _a1 error) *MockClientService_UpdateVercelProjectSyncIntegration_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockClientService_UpdateVercelProjectSyncIntegration_Call) RunAndReturn(run func(*secret_service.UpdateVercelProjectSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateVercelProjectSyncIntegrationOK, error)) *MockClientService_UpdateVercelProjectSyncIntegration_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpsertAwsSmSyncIntegration provides a mock function with given fields: params, authInfo, opts
-func (_m *MockClientService) UpsertAwsSmSyncIntegration(params *secret_service.UpsertAwsSmSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpsertAwsSmSyncIntegrationOK, error) {
-	_va := make([]interface{}, len(opts))
-	for _i := range opts {
-		_va[_i] = opts[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, params, authInfo)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpsertAwsSmSyncIntegration")
-	}
-
-	var r0 *secret_service.UpsertAwsSmSyncIntegrationOK
-	var r1 error
-	if rf, ok := ret.Get(0).(func(*secret_service.UpsertAwsSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpsertAwsSmSyncIntegrationOK, error)); ok {
-		return rf(params, authInfo, opts...)
-	}
-	if rf, ok := ret.Get(0).(func(*secret_service.UpsertAwsSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpsertAwsSmSyncIntegrationOK); ok {
-		r0 = rf(params, authInfo, opts...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*secret_service.UpsertAwsSmSyncIntegrationOK)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(*secret_service.UpsertAwsSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
-		r1 = rf(params, authInfo, opts...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockClientService_UpsertAwsSmSyncIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertAwsSmSyncIntegration'
-type MockClientService_UpsertAwsSmSyncIntegration_Call struct {
-	*mock.Call
-}
-
-// UpsertAwsSmSyncIntegration is a helper method to define mock.On call
-//   - params *secret_service.UpsertAwsSmSyncIntegrationParams
-//   - authInfo runtime.ClientAuthInfoWriter
-//   - opts ...secret_service.ClientOption
-func (_e *MockClientService_Expecter) UpsertAwsSmSyncIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpsertAwsSmSyncIntegration_Call {
-	return &MockClientService_UpsertAwsSmSyncIntegration_Call{Call: _e.mock.On("UpsertAwsSmSyncIntegration",
-		append([]interface{}{params, authInfo}, opts...)...)}
-}
-
-func (_c *MockClientService_UpsertAwsSmSyncIntegration_Call) Run(run func(params *secret_service.UpsertAwsSmSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpsertAwsSmSyncIntegration_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
-		for i, a := range args[2:] {
-			if a != nil {
-				variadicArgs[i] = a.(secret_service.ClientOption)
-			}
-		}
-		run(args[0].(*secret_service.UpsertAwsSmSyncIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
-	})
-	return _c
-}
-
-func (_c *MockClientService_UpsertAwsSmSyncIntegration_Call) Return(_a0 *secret_service.UpsertAwsSmSyncIntegrationOK, _a1 error) *MockClientService_UpsertAwsSmSyncIntegration_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockClientService_UpsertAwsSmSyncIntegration_Call) RunAndReturn(run func(*secret_service.UpsertAwsSmSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpsertAwsSmSyncIntegrationOK, error)) *MockClientService_UpsertAwsSmSyncIntegration_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpsertGhRepoSyncIntegration provides a mock function with given fields: params, authInfo, opts
-func (_m *MockClientService) UpsertGhRepoSyncIntegration(params *secret_service.UpsertGhRepoSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpsertGhRepoSyncIntegrationOK, error) {
-	_va := make([]interface{}, len(opts))
-	for _i := range opts {
-		_va[_i] = opts[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, params, authInfo)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpsertGhRepoSyncIntegration")
-	}
-
-	var r0 *secret_service.UpsertGhRepoSyncIntegrationOK
-	var r1 error
-	if rf, ok := ret.Get(0).(func(*secret_service.UpsertGhRepoSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpsertGhRepoSyncIntegrationOK, error)); ok {
-		return rf(params, authInfo, opts...)
-	}
-	if rf, ok := ret.Get(0).(func(*secret_service.UpsertGhRepoSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpsertGhRepoSyncIntegrationOK); ok {
-		r0 = rf(params, authInfo, opts...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*secret_service.UpsertGhRepoSyncIntegrationOK)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(*secret_service.UpsertGhRepoSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
-		r1 = rf(params, authInfo, opts...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockClientService_UpsertGhRepoSyncIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertGhRepoSyncIntegration'
-type MockClientService_UpsertGhRepoSyncIntegration_Call struct {
-	*mock.Call
-}
-
-// UpsertGhRepoSyncIntegration is a helper method to define mock.On call
-//   - params *secret_service.UpsertGhRepoSyncIntegrationParams
-//   - authInfo runtime.ClientAuthInfoWriter
-//   - opts ...secret_service.ClientOption
-func (_e *MockClientService_Expecter) UpsertGhRepoSyncIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpsertGhRepoSyncIntegration_Call {
-	return &MockClientService_UpsertGhRepoSyncIntegration_Call{Call: _e.mock.On("UpsertGhRepoSyncIntegration",
-		append([]interface{}{params, authInfo}, opts...)...)}
-}
-
-func (_c *MockClientService_UpsertGhRepoSyncIntegration_Call) Run(run func(params *secret_service.UpsertGhRepoSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpsertGhRepoSyncIntegration_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
-		for i, a := range args[2:] {
-			if a != nil {
-				variadicArgs[i] = a.(secret_service.ClientOption)
-			}
-		}
-		run(args[0].(*secret_service.UpsertGhRepoSyncIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
-	})
-	return _c
-}
-
-func (_c *MockClientService_UpsertGhRepoSyncIntegration_Call) Return(_a0 *secret_service.UpsertGhRepoSyncIntegrationOK, _a1 error) *MockClientService_UpsertGhRepoSyncIntegration_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockClientService_UpsertGhRepoSyncIntegration_Call) RunAndReturn(run func(*secret_service.UpsertGhRepoSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpsertGhRepoSyncIntegrationOK, error)) *MockClientService_UpsertGhRepoSyncIntegration_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpsertSyncInstallation provides a mock function with given fields: params, authInfo, opts
-func (_m *MockClientService) UpsertSyncInstallation(params *secret_service.UpsertSyncInstallationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpsertSyncInstallationOK, error) {
-	_va := make([]interface{}, len(opts))
-	for _i := range opts {
-		_va[_i] = opts[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, params, authInfo)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpsertSyncInstallation")
-	}
-
-	var r0 *secret_service.UpsertSyncInstallationOK
-	var r1 error
-	if rf, ok := ret.Get(0).(func(*secret_service.UpsertSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpsertSyncInstallationOK, error)); ok {
-		return rf(params, authInfo, opts...)
-	}
-	if rf, ok := ret.Get(0).(func(*secret_service.UpsertSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpsertSyncInstallationOK); ok {
-		r0 = rf(params, authInfo, opts...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*secret_service.UpsertSyncInstallationOK)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(*secret_service.UpsertSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
-		r1 = rf(params, authInfo, opts...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockClientService_UpsertSyncInstallation_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertSyncInstallation'
-type MockClientService_UpsertSyncInstallation_Call struct {
-	*mock.Call
-}
-
-// UpsertSyncInstallation is a helper method to define mock.On call
-//   - params *secret_service.UpsertSyncInstallationParams
-//   - authInfo runtime.ClientAuthInfoWriter
-//   - opts ...secret_service.ClientOption
-func (_e *MockClientService_Expecter) UpsertSyncInstallation(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpsertSyncInstallation_Call {
-	return &MockClientService_UpsertSyncInstallation_Call{Call: _e.mock.On("UpsertSyncInstallation",
-		append([]interface{}{params, authInfo}, opts...)...)}
-}
-
-func (_c *MockClientService_UpsertSyncInstallation_Call) Run(run func(params *secret_service.UpsertSyncInstallationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpsertSyncInstallation_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
-		for i, a := range args[2:] {
-			if a != nil {
-				variadicArgs[i] = a.(secret_service.ClientOption)
-			}
-		}
-		run(args[0].(*secret_service.UpsertSyncInstallationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
-	})
-	return _c
-}
-
-func (_c *MockClientService_UpsertSyncInstallation_Call) Return(_a0 *secret_service.UpsertSyncInstallationOK, _a1 error) *MockClientService_UpsertSyncInstallation_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockClientService_UpsertSyncInstallation_Call) RunAndReturn(run func(*secret_service.UpsertSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpsertSyncInstallationOK, error)) *MockClientService_UpsertSyncInstallation_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpsertVercelProjectSyncIntegration provides a mock function with given fields: params, authInfo, opts
-func (_m *MockClientService) UpsertVercelProjectSyncIntegration(params *secret_service.UpsertVercelProjectSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpsertVercelProjectSyncIntegrationOK, error) {
-	_va := make([]interface{}, len(opts))
-	for _i := range opts {
-		_va[_i] = opts[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, params, authInfo)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpsertVercelProjectSyncIntegration")
-	}
-
-	var r0 *secret_service.UpsertVercelProjectSyncIntegrationOK
-	var r1 error
-	if rf, ok := ret.Get(0).(func(*secret_service.UpsertVercelProjectSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpsertVercelProjectSyncIntegrationOK, error)); ok {
-		return rf(params, authInfo, opts...)
-	}
-	if rf, ok := ret.Get(0).(func(*secret_service.UpsertVercelProjectSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpsertVercelProjectSyncIntegrationOK); ok {
-		r0 = rf(params, authInfo, opts...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*secret_service.UpsertVercelProjectSyncIntegrationOK)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(*secret_service.UpsertVercelProjectSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
-		r1 = rf(params, authInfo, opts...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockClientService_UpsertVercelProjectSyncIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertVercelProjectSyncIntegration'
-type MockClientService_UpsertVercelProjectSyncIntegration_Call struct {
-	*mock.Call
-}
-
-// UpsertVercelProjectSyncIntegration is a helper method to define mock.On call
-//   - params *secret_service.UpsertVercelProjectSyncIntegrationParams
-//   - authInfo runtime.ClientAuthInfoWriter
-//   - opts ...secret_service.ClientOption
-func (_e *MockClientService_Expecter) UpsertVercelProjectSyncIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpsertVercelProjectSyncIntegration_Call {
-	return &MockClientService_UpsertVercelProjectSyncIntegration_Call{Call: _e.mock.On("UpsertVercelProjectSyncIntegration",
-		append([]interface{}{params, authInfo}, opts...)...)}
-}
-
-func (_c *MockClientService_UpsertVercelProjectSyncIntegration_Call) Run(run func(params *secret_service.UpsertVercelProjectSyncIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpsertVercelProjectSyncIntegration_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
-		for i, a := range args[2:] {
-			if a != nil {
-				variadicArgs[i] = a.(secret_service.ClientOption)
-			}
-		}
-		run(args[0].(*secret_service.UpsertVercelProjectSyncIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
-	})
-	return _c
-}
-
-func (_c *MockClientService_UpsertVercelProjectSyncIntegration_Call) Return(_a0 *secret_service.UpsertVercelProjectSyncIntegrationOK, _a1 error) *MockClientService_UpsertVercelProjectSyncIntegration_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockClientService_UpsertVercelProjectSyncIntegration_Call) RunAndReturn(run func(*secret_service.UpsertVercelProjectSyncIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpsertVercelProjectSyncIntegrationOK, error)) *MockClientService_UpsertVercelProjectSyncIntegration_Call {
+func (_c *MockClientService_UpdateSyncInstallation_Call) RunAndReturn(run func(*secret_service.UpdateSyncInstallationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateSyncInstallationOK, error)) *MockClientService_UpdateSyncInstallation_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Changes proposed in this PR:
This PR edits the secrets create command for hvs rotating secrets for ticket https://hashicorp.atlassian.net/browse/VAULT-29260

### How I've tested this PR:
Ran `make go/build` to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Create a rotating secret `./bin/hcp vault-secrets secrets create {SECRET_NAME} --secret-type rotating --data-file "/path/to/file/config.yaml"`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
Example config file:
```
type: "twilio"
rotation_integration_name: "Twil-Int-4"
details:
  rotation_policy_name: "60"
```

<img width="1133" alt="Screenshot 2024-08-16 at 3 11 26 PM" src="https://github.com/user-attachments/assets/808959e5-3a80-4534-a6ee-3b91ce133afc">

### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
