### PR TITLE
Waypoint Agent: Update execute to parse all waypoint variables

### DIFF
--- a/.changelog/146.txt
+++ b/.changelog/146.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Support loading all variables from Waypoint server in Waypoint agent CLI
+```

--- a/internal/pkg/waypoint/agent/execute_test.go
+++ b/internal/pkg/waypoint/agent/execute_test.go
@@ -115,7 +115,16 @@ func TestExecutor(t *testing.T) {
 		e.Config = cfg
 
 		data, err := json.Marshal(map[string]any{
-			"type": "nerf",
+			"var.type":                              "nerf",
+			"action.name":                           "launch",
+			"application.templateName":              "cool-test-template", // pretend its in an app
+			"application.name":                      "test",
+			"application.outputs.run_id":            "1234",
+			"application.inputs.region":             "us-west-1",
+			"addon.abc123.outputs.database_url":     "http://localhost:5432",
+			"addon.xyz098.outputs.load_balancer_ip": "http://localhost:8080",
+			"var.local_variable":                    "local-value",
+			"var.token":                             "token",
 		})
 		r.NoError(err)
 
@@ -124,7 +133,6 @@ func TestExecutor(t *testing.T) {
 			ID:    "launch",
 			Body:  data,
 		})
-
 		r.NoError(err)
 	})
 


### PR DESCRIPTION
### Changes proposed in this PR:

This commit updates the Waypoint agent CLI to handle all possible variable values that it could receive from the server.

Fixes WAYP-2914

### How I've tested this PR:

Wrote some unit tests.

### How I expect reviewers to test this PR:

Possibly build a local copy and attempt to run agent-typed actions with variables.

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
