### PR TITLE
Waypoint Agent: Update execute to parse all waypoint variables

### DIFF
--- a/.changelog/148.txt
+++ b/.changelog/148.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Support loading all variables from Waypoint server in Waypoint agent CLI
+```

--- a/internal/commands/waypoint/agent/run.go
+++ b/internal/commands/waypoint/agent/run.go
@@ -63,6 +63,12 @@ func NewCmdRun(ctx *cmd.Context) *cmd.Command {
 var agentRunDuration = 60 * time.Second
 
 func agentRun(log hclog.Logger, opts *RunOpts) error {
+	// Only set level to info if not in debug mode
+	if !log.IsDebug() {
+		// Give log.Info level feedback to user when they run the agent CLI
+		log.SetLevel(hclog.Info)
+	}
+
 	cfg, err := agent.ParseConfigFile(opts.ConfigPath)
 	if err != nil {
 		return err

--- a/internal/commands/waypoint/agent/run.go
+++ b/internal/commands/waypoint/agent/run.go
@@ -153,14 +153,15 @@ func runOp(
 	exec *agent.Executor,
 	ns string,
 ) {
-
 	var (
 		status     string
 		statusCode int
 	)
 
+	log = log.With("group", ao.Group, "operation", ao.ID, "action-run-id", ao.ActionRunID)
+
 	if ao.ActionRunID != "" {
-		log.Info("reporting action run starting", "action-run-id", ao.ActionRunID)
+		log.Info("reporting action run starting")
 
 		resp, err := opts.WS.WaypointServiceStartingAction(&waypoint_service.WaypointServiceStartingActionParams{
 			NamespaceID: ns,
@@ -175,7 +176,7 @@ func runOp(
 			log.Error("unable to register action as starting", "error", err)
 		} else {
 			defer func() {
-				log.Info("reporting action run ended", "id", resp.Payload.ActionRunID, "status", status, "status-code", statusCode)
+				log.Info("reporting action run ended", "action-run-id", resp.Payload.ActionRunID, "status", status, "status-code", statusCode)
 
 				_, err = opts.WS.WaypointServiceEndingAction(&waypoint_service.WaypointServiceEndingActionParams{
 					NamespaceID: ns,
@@ -199,7 +200,7 @@ func runOp(
 		status = "internal error: " + err.Error()
 		statusCode = 1
 
-		log.Error("error resolving operation", "group", ao.Group, "operation", ao.ID, "error", err)
+		log.Error("error resolving operation", "error", err)
 		return
 	}
 
@@ -207,7 +208,7 @@ func runOp(
 		status = "unknown operation: " + ao.ID
 		statusCode = 127
 
-		log.Error("requested unknown operation", "id", ao.ID)
+		log.Error("requested unknown operation", "status", status, "status-code", statusCode)
 		return
 	}
 
@@ -215,12 +216,12 @@ func runOp(
 	if err != nil {
 		status = "error execution operation: " + err.Error()
 
-		log.Error("error executing operation", "group", ao.Group, "operation", ao.ID, "error", err)
+		log.Error("error executing operation", "error", err)
 		return
 	}
 
 	status = opStat.Status
 	statusCode = opStat.Code
 
-	log.Info("finished operation", "id", ao.ID, "status", status, "status-code", statusCode)
+	log.Info("finished operation")
 }

--- a/internal/commands/waypoint/agent/run.go
+++ b/internal/commands/waypoint/agent/run.go
@@ -176,7 +176,7 @@ func runOp(
 			log.Error("unable to register action as starting", "error", err)
 		} else {
 			defer func() {
-				log.Info("reporting action run ended", "action-run-id", resp.Payload.ActionRunID, "status", status, "status-code", statusCode)
+				log.Info("reporting action run ended", "status", status, "status-code", statusCode)
 
 				_, err = opts.WS.WaypointServiceEndingAction(&waypoint_service.WaypointServiceEndingActionParams{
 					NamespaceID: ns,

--- a/internal/pkg/waypoint/agent/execute_test.go
+++ b/internal/pkg/waypoint/agent/execute_test.go
@@ -115,7 +115,16 @@ func TestExecutor(t *testing.T) {
 		e.Config = cfg
 
 		data, err := json.Marshal(map[string]any{
-			"type": "nerf",
+			"var.type":                              "nerf",
+			"action.name":                           "launch",
+			"application.templateName":              "cool-test-template", // pretend its in an app
+			"application.name":                      "test",
+			"application.outputs.run_id":            "1234",
+			"application.inputs.region":             "us-west-1",
+			"addon.abc123.outputs.database_url":     "http://localhost:5432",
+			"addon.xyz098.outputs.load_balancer_ip": "http://localhost:8080",
+			"var.local_variable":                    "local-value",
+			"var.token":                             "token",
 		})
 		r.NoError(err)
 
@@ -124,7 +133,6 @@ func TestExecutor(t *testing.T) {
 			ID:    "launch",
 			Body:  data,
 		})
-
 		r.NoError(err)
 	})
 


### PR DESCRIPTION
### Changes proposed in this PR:

This commit updates the Waypoint agent CLI to handle all possible
variable values that it could receive from the server. It builds
a simple map of variables and converts them to a structure that
HCL can understand and parse when reading an agent HCL config.

Fixes WAYP-2914

### How I've tested this PR:

I wrote some unit tests to validate variables can be parsed, and
I also tested this against the server live to validate configs
can parse and expand variables.

### How I expect reviewers to test this PR:

Create your own agent action and see that it can use variables.

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
