### PR TITLE
CVE Updates

### DIFF
--- a/.changelog/151.txt
+++ b/.changelog/151.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-Address vulnerabilities for docker image: CVE-2024-7264 (curl) and CVE-2024-43374 (vim)
+security: address vulnerabilities for docker image CVE-2024-7264 (curl) and CVE-2024-43374 (vim)
 ```

--- a/.changelog/151.txt
+++ b/.changelog/151.txt
@@ -1,0 +1,6 @@
+```release-note:security
+Address vulnerabilities for docker image
+- CVE-2024-7264 curl
+- CVE-2024-43374 vim
+Removed both dependencies from image build
+```

--- a/.changelog/151.txt
+++ b/.changelog/151.txt
@@ -1,3 +1,3 @@
-```release-note:security
+```release-note:bug
 security: address vulnerabilities for docker image CVE-2024-7264 (curl) and CVE-2024-43374 (vim)
 ```

--- a/.changelog/151.txt
+++ b/.changelog/151.txt
@@ -1,6 +1,3 @@
 ```release-note:security
-Address vulnerabilities for docker image
-- CVE-2024-7264 curl
-- CVE-2024-43374 vim
-Removed both dependencies from image build
+Address vulnerabilities for docker image: CVE-2024-7264 (curl) and CVE-2024-43374 (vim)
 ```

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -5,16 +5,6 @@ container {
 	dependencies = true
 	alpine_secdb = true
 	secrets      = true
-
-  triage {
-    suppress {
-      vulnerabilities = [
-        // curl is used in "Print access token" command as an example and added
-        // for convinience in the Docker image to support this example.
-        "CVE-2024-7264", // curl@8.9.0-r0; no new image with fix; RE: https://security.alpinelinux.org/vuln/CVE-2024-7264
-      ]
-    }
-  }
 }
 
 binary {

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -5,6 +5,16 @@ container {
 	dependencies = true
 	alpine_secdb = true
 	secrets      = true
+
+  triage {
+    suppress {
+      vulnerabilities = [
+        // curl is used in "Print access token" command as an example and added
+        // for convinience in the Docker image to support this example.
+        "CVE-2024-7264", // curl@8.9.0-r0; no new image with fix; RE: https://security.alpinelinux.org/vuln/CVE-2024-7264
+      ]
+    }
+  }
 }
 
 binary {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-## Dev DOCKERFILE ##
-FROM alpine:3.20 as dev
-
-COPY bin/hcp /bin/hcp
+## Common Base Layer
+FROM alpine:3.20 as base
 
 RUN apk --no-cache upgrade && apk --no-cache add \
 	bash \
@@ -16,12 +14,18 @@ RUN apk --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --no-cache 
   vim=9.1.0678-r0 \
   curl=8.9.1-r1
 
-RUN touch ~/.bashrc && hcp --autocomplete-install
+RUN touch ~/.bashrc
+
+## Dev DOCKERFILE ##
+FROM base as dev
+
+COPY bin/hcp /bin/hcp
+RUN hcp --autocomplete-install
 
 CMD ["/bin/bash"]
 
 ## DOCKERHUB DOCKERFILE ##
-FROM dev as release
+FROM base as release
 
 ARG BIN_NAME
 ARG NAME=hcp
@@ -40,5 +44,6 @@ LABEL name="HCP CLI" \
       description="The hcp CLI allows interaction with the HashiCorp Cloud Platform using the command-line."
 
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+RUN hcp --autocomplete-install
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,8 @@ FROM alpine:3.20 as dev
 COPY bin/hcp /bin/hcp
 RUN apk --no-cache upgrade && apk --no-cache add \
 	bash \
-	curl \
 	jq \
-	nano \
-	vim=9.1.0678-r0 # https://security.alpinelinux.org/vuln/CVE-2024-43374
+	nano
 RUN touch ~/.bashrc && hcp --autocomplete-install
 CMD ["/bin/bash"]
 
@@ -35,10 +33,8 @@ LABEL name="HCP CLI" \
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
 RUN apk --no-cache upgrade && apk --no-cache add \
 	bash \
-	curl \
 	jq \
-	nano \
-	vim=9.1.0678-r0 # https://security.alpinelinux.org/vuln/CVE-2024-43374
+	nano
 RUN touch ~/.bashrc
 RUN hcp --autocomplete-install
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache upgrade && apk --no-cache add \
 	curl \
 	jq \
 	nano \
-	vim
+	vim=9.1.0678-r0 # https://security.alpinelinux.org/vuln/CVE-2024-43374
 RUN touch ~/.bashrc && hcp --autocomplete-install
 CMD ["/bin/bash"]
 
@@ -38,7 +38,7 @@ RUN apk --no-cache upgrade && apk --no-cache add \
 	curl \
 	jq \
 	nano \
-	vim
+	vim=9.1.0678-r0 # https://security.alpinelinux.org/vuln/CVE-2024-43374
 RUN touch ~/.bashrc
 RUN hcp --autocomplete-install
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,25 @@
 
 ## Dev DOCKERFILE ##
 FROM alpine:3.20 as dev
+
 COPY bin/hcp /bin/hcp
+
 RUN apk --no-cache upgrade && apk --no-cache add \
 	bash \
 	jq \
 	nano
+
+## No patch for vulnerabilities in alpine, downloading fixed versions from edge
+RUN apk --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --no-cache add \
+  vim=9.1.0678-r0 \
+  curl=8.9.1-r1
+
 RUN touch ~/.bashrc && hcp --autocomplete-install
+
 CMD ["/bin/bash"]
 
 ## DOCKERHUB DOCKERFILE ##
-FROM alpine:3.20 as release
+FROM dev as release
 
 ARG BIN_NAME
 ARG NAME=hcp
@@ -31,10 +40,5 @@ LABEL name="HCP CLI" \
       description="The hcp CLI allows interaction with the HashiCorp Cloud Platform using the command-line."
 
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
-RUN apk --no-cache upgrade && apk --no-cache add \
-	bash \
-	jq \
-	nano
-RUN touch ~/.bashrc
-RUN hcp --autocomplete-install
+
 CMD ["/bin/bash"]

--- a/internal/commands/auth/print_access_token.go
+++ b/internal/commands/auth/print_access_token.go
@@ -17,7 +17,7 @@ func NewCmdPrintAccessToken(ctx *cmd.Context) *cmd.Command {
 		Name:      "print-access-token",
 		ShortHelp: "Print the access token for the authenticated account.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp auth print-access-token" }} command 
+		The {{ template "mdCodeOrBold" "hcp auth print-access-token" }} command
 		prints an access token for the currently authenticated account.
 
 		The output of this command can be used to set the {{ template "mdCodeOrBold"
@@ -27,13 +27,6 @@ func NewCmdPrintAccessToken(ctx *cmd.Context) *cmd.Command {
 			{
 				Preamble: "To print the access token:",
 				Command:  "$ hcp auth print-access-token",
-			},
-			{
-				Preamble: "To use the access token when curling an API:",
-				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
-				$ curl https://api.cloud.hashicorp.com/iam/2019-12-10/caller-identity \
-				  --header "Authorization: Bearer $(hcp auth print-access-token)"
-				  `),
 			},
 		},
 		RunF: func(c *cmd.Command, args []string) error {

--- a/internal/commands/auth/print_access_token.go
+++ b/internal/commands/auth/print_access_token.go
@@ -28,6 +28,13 @@ func NewCmdPrintAccessToken(ctx *cmd.Context) *cmd.Command {
 				Preamble: "To print the access token:",
 				Command:  "$ hcp auth print-access-token",
 			},
+			{
+				Preamble: "To use the access token when curling an API:",
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ curl https://api.cloud.hashicorp.com/iam/2019-12-10/caller-identity \
+				  --header "Authorization: Bearer $(hcp auth print-access-token)"
+				  `),
+			},
 		},
 		RunF: func(c *cmd.Command, args []string) error {
 			hcpCfg, err := auth.GetHCPConfig(hcpconf.WithoutBrowserLogin())


### PR DESCRIPTION
### Changes proposed in this PR:
* 2 CVE's from alpine linux 3.20 have caused the docker image artifacts to fail security scans.
* Example: https://github.com/hashicorp/crt-workflows-common/actions/runs/10564866097/job/29268528445

1. [CVE-2024-7264](https://security.alpinelinux.org/vuln/CVE-2024-7264) (curl 8.9.0-r0)
2. [CVE-2024-43374](https://security.alpinelinux.org/vuln/CVE-2024-43374) (vim 9.1.0414-r0)

* Both have patched versions on alpine edge (not yet in a patched version).
  * Manually pinned the edge versions in build.
* Updated the build to base the production image on the dev build stage since it already shared the same foundational build steps.

### How I've tested this PR:
```
make docker/dev

docker buildx build \
                --load \
                --platform linux/arm64 \
                --tag docker.io/hashicorp/hcp:latest-195e341 \
                --target=base \
                .

docker buildx build \
		--load \
		--platform linux/arm64 \
		--tag docker.io/hashicorp/hcp:latest-195e341 \
		--target=dev \
		.
```

### How I expect reviewers to test this PR:


<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
