### PR TITLE
CVE - Vim (CVE-2024-43790 / CVE-2024-43802)

### DIFF
--- a/.changelog/152.txt
+++ b/.changelog/152.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+security: address vulnerability for docker image CVE-2024-43790 / CVE-2024-43802 (vim)
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,11 @@ RUN apk --no-cache upgrade && apk --no-cache add \
 
 ## No patch for vulnerabilities in alpine, downloading fixed versions from edge
 RUN apk --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --no-cache add \
-  vim=9.1.0678-r0 \
   curl=8.9.1-r1
+  # Vim temporarily removed as there is no available patch on edge yet, although it is fixed in version > 9.1.0697
+  # https://pkgs.alpinelinux.org/packages?name=vim&branch=edge&repo=&arch=&maintainer=
+  # https://security.alpinelinux.org/vuln/CVE-2024-43802
+  # https://security.alpinelinux.org/vuln/CVE-2024-43790
 
 RUN touch ~/.bashrc
 


### PR DESCRIPTION
### Changes proposed in this PR:
* Security scanner picked up 2 additional Vim CVE's:
  * [CVE-2024-43790](https://security.alpinelinux.org/vuln/CVE-2024-43790) 
  * [CVE-2024-43802](https://security.alpinelinux.org/vuln/CVE-2024-43802) 
* vim [9.1.0698](https://github.com/vim/vim/releases/tag/v9.1.0698) fixes both vulnerabilities, however there is currently [no available newer version](https://pkgs.alpinelinux.org/packages?name=vim&branch=edge&repo=&arch=&maintainer=) available for install.
* Removed the package from the build temporarily.

### How I've tested this PR:
`make docker/dev`

### How I expect reviewers to test this PR:


<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
