### PR TITLE
Replace RotationIntegratioName => IntegratioName in Create..Secret calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.19.1
-	github.com/hashicorp/hcp-sdk-go v0.108.0
+	github.com/hashicorp/hcp-sdk-go v0.110.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.108.0 h1:MgP7vGTx5A34l9HpktvQSY4nNfwCBpIXRJhJCHCxcyQ=
-github.com/hashicorp/hcp-sdk-go v0.108.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.110.0 h1:eaDO6XoEb0H+g00Ka3C+ZbRibhwWyA2YNmv48xFCL2w=
+github.com/hashicorp/hcp-sdk-go v0.110.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -144,10 +144,8 @@ type MongoDBScope struct {
 	Type string `mapstructure:"name"`
 }
 
-var (
-	// There are no Twilio-specific keys
-	MongoDBAtlasRequiredKeys = []string{"mongodb_group_id", "mongodb_roles"}
-)
+// There are no Twilio-specific keys
+var MongoDBAtlasRequiredKeys = []string{"mongodb_group_id", "mongodb_roles"}
 
 var rotationPolicies = map[string]string{
 	"30": "built-in:30-days-2-active",
@@ -156,7 +154,6 @@ var rotationPolicies = map[string]string{
 }
 
 func createRun(opts *CreateOpts) error {
-
 	switch opts.Type {
 	case Static, "":
 		if err := readPlainTextSecret(opts); err != nil {
@@ -207,9 +204,9 @@ func createRun(opts *CreateOpts) error {
 			req.ProjectID = opts.Profile.ProjectID
 			req.AppName = opts.AppName
 			req.Body = &preview_models.SecretServiceCreateTwilioRotatingSecretBody{
-				RotationIntegrationName: sc.IntegrationName,
-				RotationPolicyName:      rotationPolicies[sc.PolicyName],
-				SecretName:              opts.SecretName,
+				IntegrationName:    sc.IntegrationName,
+				RotationPolicyName: rotationPolicies[sc.PolicyName],
+				SecretName:         opts.SecretName,
 			}
 
 			resp, err := opts.PreviewClient.CreateTwilioRotatingSecret(req, nil)
@@ -271,9 +268,9 @@ func createRun(opts *CreateOpts) error {
 					MongodbRoles:   reqRoles,
 					MongodbScopes:  reqScopes,
 				},
-				RotationIntegrationName: sc.IntegrationName,
-				RotationPolicyName:      rotationPolicies[sc.Details[MongoDBAtlasRequiredKeys[0]].(string)],
-				SecretName:              opts.SecretName,
+				IntegrationName:    sc.IntegrationName,
+				RotationPolicyName: rotationPolicies[sc.Details[MongoDBAtlasRequiredKeys[0]].(string)],
+				SecretName:         opts.SecretName,
 			}
 			resp, err := opts.PreviewClient.CreateMongoDBAtlasRotatingSecret(req, nil)
 			if err != nil {

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -128,7 +128,7 @@ type CreateOpts struct {
 type RotatingSecretConfig struct {
 	Version         string
 	Type            integrations.IntegrationType
-	IntegrationName string `yaml:"rotation_integration_name"`
+	IntegrationName string `yaml:"integration_name"`
 	PolicyName      string `yaml:"rotation_policy_name"`
 	Details         map[string]any
 }
@@ -342,7 +342,7 @@ func validateRotatingSecretConfig(sc RotatingSecretConfig) []string {
 	}
 
 	if sc.IntegrationName == "" {
-		missingKeys = append(missingKeys, "rotation_integration_name")
+		missingKeys = append(missingKeys, "integration_name")
 	}
 
 	if sc.PolicyName == "" {

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -287,19 +287,19 @@ details:
 							ProjectID:      testProfile(t).ProjectID,
 							AppName:        testProfile(t).VaultSecrets.AppName,
 							Body: &preview_models.SecretServiceCreateTwilioRotatingSecretBody{
-								SecretName:              opts.SecretName,
-								RotationIntegrationName: "Twil-Int-11",
-								RotationPolicyName:      "built-in:60-days-2-active",
+								SecretName:         opts.SecretName,
+								IntegrationName:    "Twil-Int-11",
+								RotationPolicyName: "built-in:60-days-2-active",
 							},
 							Context: opts.Ctx,
 						}, mock.Anything).Return(&preview_secret_service.CreateTwilioRotatingSecretOK{
 							Payload: &preview_models.Secrets20231128CreateTwilioRotatingSecretResponse{
 								Config: &preview_models.Secrets20231128RotatingSecretConfig{
-									AppName:                 opts.AppName,
-									CreatedAt:               dt,
-									RotationIntegrationName: "Twil-Int-11",
-									RotationPolicyName:      "built-in:60-days-2-active",
-									SecretName:              opts.SecretName,
+									AppName:            opts.AppName,
+									CreatedAt:          dt,
+									IntegrationName:    "Twil-Int-11",
+									RotationPolicyName: "built-in:60-days-2-active",
+									SecretName:         opts.SecretName,
 								},
 							},
 						}, nil).Once()

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -185,7 +185,7 @@ func TestCreateRun(t *testing.T) {
 			MockCalled: true,
 			Input: []byte(`version: 1.0.0
 type: "twilio"
-rotation_integration_name: "Twil-Int-11"
+integration_name: "Twil-Int-11"
 rotation_policy_name: "60"`),
 		},
 		{
@@ -196,7 +196,7 @@ rotation_policy_name: "60"`),
 			},
 			Input: []byte(`version: 1.0.0
 type: "twilio"
-rotation_integration_name: "Twil-Int-11"
+integration_name: "Twil-Int-11"
 details:
   none: "none"`),
 			ErrMsg: "missing required field(s) in the config file: [rotation_policy_name]",

--- a/internal/commands/vaultsecrets/secrets/displayer.go
+++ b/internal/commands/vaultsecrets/secrets/displayer.go
@@ -273,8 +273,8 @@ func (r *rotatingSecretsDisplayer) FieldTemplates() []format.Field {
 			ValueFormat: "{{ .SecretName }}",
 		},
 		{
-			Name:        " Rotation Integration",
-			ValueFormat: "{{ .RotationIntegrationName }}",
+			Name:        " Integration Name",
+			ValueFormat: "{{ .IntegrationName }}",
 		},
 		{
 			Name:        " Rotation Policy",


### PR DESCRIPTION
### Changes proposed in this PR:

We've recently renamed `RotationIntegrationName` to `IntegrationName` in our Create...Secret API endpoints (https://github.com/hashicorp/cloud-vault-secrets/pull/1944). Switching to the latest field here.

### How I've tested this PR:

### How I expect reviewers to test this PR:

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
