### PR TITLE
VAULT-29633 - Create integrations using HCL config files

### DIFF
--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"slices"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/hashicorp/hcl/v2/hclsimple"
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
@@ -18,7 +20,6 @@ import (
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
 	"github.com/hashicorp/hcp/internal/pkg/profile"
-	"golang.org/x/exp/maps"
 )
 
 type CreateOpts struct {

--- a/internal/commands/vaultsecrets/integrations/create_test.go
+++ b/internal/commands/vaultsecrets/integrations/create_test.go
@@ -110,28 +110,28 @@ func TestCreateRun(t *testing.T) {
 		{
 			Name:            "Good",
 			IntegrationName: "sample-integration",
-			Input: []byte(`version: 1.0.0
-type: "aws"
-details:
-  audience: abc
-  role_arn: def`),
+			Input: []byte(`type = "aws"
+details = {
+  "audience" = "abc",
+  "role_arn" = "def"
+}`),
 		},
 		{
 			Name:            "Missing a single required field",
 			IntegrationName: "sample-integration",
-			Input: []byte(`version: 1.0.0
-type: "mongodb-atlas"
-details:
-  public_key: abc`),
+			Input: []byte(`type = "mongodb-atlas"
+details = {
+  "public_key" = "abc"
+}`),
 			Error: "missing required field(s) in the config file: [private_key]",
 		},
 		{
 			Name:            "Missing multiple required fields",
 			IntegrationName: "sample-integration",
-			Input: []byte(`version: 1.0.0
-type: "twilio"
-details:
-  api_key_sid: ghi`),
+			Input: []byte(`type = "twilio"
+details = {
+  "api_key_sid" = "ghi"
+}`),
 			Error: "missing required field(s) in the config file: [account_sid api_key_secret]",
 		},
 	}
@@ -144,7 +144,7 @@ details:
 			r := require.New(t)
 
 			tempDir := t.TempDir()
-			f, err := os.Create(filepath.Join(tempDir, "config.yaml"))
+			f, err := os.Create(filepath.Join(tempDir, "config.hcl"))
 			r.NoError(err)
 			_, err = f.Write(c.Input)
 			r.NoError(err)
@@ -173,6 +173,9 @@ details:
 							Audience: "abc",
 							RoleArn:  "def",
 						},
+						Capabilities: []*preview_models.Secrets20231128Capability{
+							preview_models.Secrets20231128CapabilityDYNAMIC.Pointer(),
+						},
 					},
 				}, nil).Return(&preview_secret_service.CreateAwsIntegrationOK{
 					Payload: &preview_models.Secrets20231128CreateAwsIntegrationResponse{
@@ -181,6 +184,9 @@ details:
 							FederatedWorkloadIdentity: &preview_models.Secrets20231128AwsFederatedWorkloadIdentityResponse{
 								Audience: "abc",
 								RoleArn:  "def",
+							},
+							Capabilities: []*preview_models.Secrets20231128Capability{
+								preview_models.Secrets20231128CapabilityDYNAMIC.Pointer(),
 							},
 						},
 					},


### PR DESCRIPTION
### Changes proposed in this PR:
On ticket https://hashicorp.atlassian.net/browse/VAULT-29633, we want to adhere to Hashicorp standards and ensure that users are creating integrations from `hcl` files instead of `yaml`.

### How I've tested this PR:
Updated unit tests and ran `make go/build` to test manually

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Create an integration from a `hcl` config file: `./bin/hcp vs integrations create hcl-integration --config-file=/path/to/file/config.hcl`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

Config file at `/Users/mercedeshall/Documents/integrations.hcl`
```
type = "twilio"
details = {
  "account_sid" = "redacted"
  "api_key_secret" = "redacted"
  "api_key_sid" = "redacted"
}
```
<img width="902" alt="Screenshot 2024-09-04 at 2 01 58 PM" src="https://github.com/user-attachments/assets/cbc93d2d-82dc-4dc8-8e64-10eb27744de2">

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
