### PR TITLE
license: add LICENSE file to release zip and docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,13 @@ jobs:
           instructions: |
             make crt-build
 
+      - name: Copy license file
+        env:
+          LICENSE_DIR: ".release/linux/package/usr/share/doc/${{ env.PKG_NAME }}"
+        run: |
+          mkdir -p "$LICENSE_DIR"
+          cp LICENSE "$LICENSE_DIR/LICENSE.txt"
+
       - name: Package
         if: ${{ matrix.goos == 'linux' }}
         uses: hashicorp/actions-packaging-linux@v1
@@ -118,6 +125,7 @@ jobs:
           rpm_depends: "openssl"
           postinstall: .release/linux/postinst
           preremove: .release/linux/prerm
+          config_dir: ".release/linux/package/"
 
       - name: Set Package Names
         if: ${{ matrix.goos == 'linux' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,10 @@ LABEL name="HCP CLI" \
       release=${PRODUCT_REVISION} \
       revision=${PRODUCT_REVISION} \
       summary="The hcp CLI allows interaction with the HashiCorp Cloud Platform." \
-      description="The hcp CLI allows interaction with the HashiCorp Cloud Platform using the command-line."
+      description="The hcp CLI allows interaction with the HashiCorp Cloud Platform using the command-line." \
+	  org.opencontainers.image.licenses="MPL-2.0"
 
+COPY LICENSE /usr/share/doc/$NAME/LICENSE.txt
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
 RUN hcp --autocomplete-install
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ MOCKERY_OUTPUT_DIRS=internal/pkg/api/mocks internal/commands/auth/mocks internal
 MOCKERY_OUTPUT_FILES=internal/pkg/api/iampolicy/mock_setter.go \
 					 internal/pkg/api/iampolicy/mock_resource_updater.go
 
+# TARGET_DIR is set by actions-go-build (https://github.com/hashicorp/actions-go-build?tab=readme-ov-file#environment-variables)
+# if the build target is being invoked outside of the build.yml, we need to set this to something sensible
+TARGET_DIR?=/usr/share/doc/hcp
+
 default: help
 
 .PHONY: docs/gen
@@ -118,6 +122,7 @@ docker/dev: go/build
 crt-build:
 	CGO_ENABLED=0 go build -o ${BIN_PATH} -trimpath -buildvcs=false \
     	-ldflags "-X github.com/hashicorp/hcp/version.GitCommit=${PRODUCT_REVISION}"
+	@cp $(CURDIR)/LICENSE $(TARGET_DIR)/LICENSE.txt
 
 HELP_FORMAT="    \033[36m%-25s\033[0m %s\n"
 .PHONY: help


### PR DESCRIPTION
### Changes proposed in this PR:

Adding LICENSE file to release zip/docker image

### How I've tested this PR:
Build the binaries and download the zips / docker image and verified: https://github.com/hashicorp/hcp/actions/runs/10797537783

### How I expect reviewers to test this PR:

Compare against suggestions:
https://hermes.hashicorp.services/document/1axPAhaN2xk70-GwyqRznWx6Voxetc_FLVa-zM8Kza1w
https://github.com/hashicorp/crt-core-helloworld/pull/172/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R43

### Checklist:
- [X] Tests added if applicable
- [X] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
