### PR TITLE
VAULT-30012 - Update a rotating secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.22.0
-	github.com/hashicorp/hcp-sdk-go v0.110.0
+	github.com/hashicorp/hcp-sdk-go v0.112.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,6 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.22.0 h1:hkZ3nCtqeJsDhPRFz5EA9iwcG1hNWGePOTw6oyul12M=
 github.com/hashicorp/hcl/v2 v2.22.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/hcp-sdk-go v0.110.0 h1:eaDO6XoEb0H+g00Ka3C+ZbRibhwWyA2YNmv48xFCL2w=
-github.com/hashicorp/hcp-sdk-go v0.110.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/hcp-sdk-go v0.112.0 h1:gKzxaPhzJj4NobFw7Sc1rGf3nMSqUKBgTtsbZ6bzd14=
 github.com/hashicorp/hcp-sdk-go v0.112.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/hashicorp/hcl/v2 v2.22.0 h1:hkZ3nCtqeJsDhPRFz5EA9iwcG1hNWGePOTw6oyul1
 github.com/hashicorp/hcl/v2 v2.22.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/hcp-sdk-go v0.110.0 h1:eaDO6XoEb0H+g00Ka3C+ZbRibhwWyA2YNmv48xFCL2w=
 github.com/hashicorp/hcp-sdk-go v0.110.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.112.0 h1:gKzxaPhzJj4NobFw7Sc1rGf3nMSqUKBgTtsbZ6bzd14=
+github.com/hashicorp/hcp-sdk-go v0.112.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/commands/vaultsecrets/secrets/secrets.go
+++ b/internal/commands/vaultsecrets/secrets/secrets.go
@@ -49,6 +49,7 @@ func NewCmdSecrets(ctx *cmd.Context) *cmd.Command {
 	cmd.AddChild(NewCmdList(ctx, nil))
 	cmd.AddChild(NewCmdOpen(ctx, nil))
 	cmd.AddChild(NewCmdRotate(ctx, nil))
+	cmd.AddChild(NewCmdUpdate(ctx, nil))
 
 	cmd.AddChild(versions.NewCmdVersions(ctx))
 	return cmd

--- a/internal/commands/vaultsecrets/secrets/update.go
+++ b/internal/commands/vaultsecrets/secrets/update.go
@@ -238,29 +238,29 @@ func updateRun(opts *UpdateOpts) error {
 	return nil
 }
 
-func readUpdateConfigFile(filePath string) (SecretUpdateConfig, DetailsInternal, error) {
+func readUpdateConfigFile(filePath string) (SecretUpdateConfig, secretConfigInternal, error) {
 	var (
-		sc SecretUpdateConfig
-		di DetailsInternal
+		secretConfig   SecretUpdateConfig
+		internalConfig secretConfigInternal
 	)
 
-	if err := hclsimple.DecodeFile(filePath, nil, &sc); err != nil {
-		return sc, di, fmt.Errorf("failed to decode config file: %w", err)
+	if err := hclsimple.DecodeFile(filePath, nil, &secretConfig); err != nil {
+		return secretConfig, internalConfig, fmt.Errorf("failed to decode config file: %w", err)
 	}
 
-	detailsMap, err := ctyValueToMap(sc.Details)
+	detailsMap, err := ctyValueToMap(secretConfig.Details)
 	if err != nil {
-		return sc, di, err
+		return secretConfig, internalConfig, err
 	}
-	di.Details = detailsMap
+	internalConfig.Details = detailsMap
 
-	return sc, di, nil
+	return secretConfig, internalConfig, nil
 }
 
-func validateSecretUpdateConfig(sc SecretUpdateConfig) []string {
+func validateSecretUpdateConfig(secretConfig SecretUpdateConfig) []string {
 	var missingKeys []string
 
-	if sc.Type == "" {
+	if secretConfig.Type == "" {
 		missingKeys = append(missingKeys, "type")
 	}
 

--- a/internal/commands/vaultsecrets/secrets/update.go
+++ b/internal/commands/vaultsecrets/secrets/update.go
@@ -112,18 +112,18 @@ type SecretUpdateConfig struct {
 func updateRun(opts *UpdateOpts) error {
 	switch opts.Type {
 	case secretTypeRotating:
-		sc, di, err := readUpdateConfigFile(opts.SecretFilePath)
+		secretConfig, internalConfig, err := readUpdateConfigFile(opts.SecretFilePath)
 		if err != nil {
 			return fmt.Errorf("failed to process config file: %w", err)
 		}
 
-		missingFields := validateSecretUpdateConfig(sc)
+		missingFields := validateSecretUpdateConfig(secretConfig)
 
 		if len(missingFields) > 0 {
 			return fmt.Errorf("missing required field(s) in the config file: %s", missingFields)
 		}
 
-		switch sc.Type {
+		switch secretConfig.Type {
 		case integrations.Twilio:
 			req := preview_secret_service.NewUpdateTwilioRotatingSecretParamsWithContext(opts.Ctx)
 			req.OrganizationID = opts.Profile.OrganizationID
@@ -132,7 +132,7 @@ func updateRun(opts *UpdateOpts) error {
 			req.SecretName = opts.SecretName
 
 			var twilioBody preview_models.SecretServiceUpdateTwilioRotatingSecretBody
-			detailBytes, err := json.Marshal(di.Details)
+			detailBytes, err := json.Marshal(internalConfig.Details)
 			if err != nil {
 				return fmt.Errorf("error marshaling details config: %w", err)
 			}
@@ -160,7 +160,7 @@ func updateRun(opts *UpdateOpts) error {
 			req.SecretName = opts.SecretName
 
 			var mongoDBBody preview_models.SecretServiceUpdateMongoDBAtlasRotatingSecretBody
-			detailBytes, err := json.Marshal(di.Details)
+			detailBytes, err := json.Marshal(internalConfig.Details)
 			if err != nil {
 				return fmt.Errorf("error marshaling details config: %w", err)
 			}
@@ -187,7 +187,7 @@ func updateRun(opts *UpdateOpts) error {
 			req.AppName = opts.AppName
 
 			var awsBody preview_models.SecretServiceUpdateAwsIAMUserAccessKeyRotatingSecretBody
-			detailBytes, err := json.Marshal(di.Details)
+			detailBytes, err := json.Marshal(internalConfig.Details)
 			if err != nil {
 				return fmt.Errorf("error marshaling details config: %w", err)
 			}
@@ -211,7 +211,7 @@ func updateRun(opts *UpdateOpts) error {
 			req.AppName = opts.AppName
 
 			var gcpBody preview_models.SecretServiceUpdateGcpServiceAccountKeyRotatingSecretBody
-			detailBytes, err := json.Marshal(di.Details)
+			detailBytes, err := json.Marshal(internalConfig.Details)
 			if err != nil {
 				return fmt.Errorf("error marshaling details config: %w", err)
 			}

--- a/internal/commands/vaultsecrets/secrets/update.go
+++ b/internal/commands/vaultsecrets/secrets/update.go
@@ -1,0 +1,268 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/posener/complete"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/hcl/v2/hclsimple"
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/integrations"
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/secrets/appname"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+type UpdateOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	IO      iostreams.IOStreams
+	Output  *format.Outputter
+
+	AppName              string
+	SecretName           string
+	SecretValuePlaintext string
+	SecretFilePath       string
+	Type                 string
+	PreviewClient        preview_secret_service.ClientService
+	Client               secret_service.ClientService
+}
+
+func NewCmdUpdate(ctx *cmd.Context, runF func(*UpdateOpts) error) *cmd.Command {
+	opts := &UpdateOpts{
+		Ctx:           ctx.ShutdownCtx,
+		Profile:       ctx.Profile,
+		IO:            ctx.IO,
+		Output:        ctx.Output,
+		PreviewClient: preview_secret_service.New(ctx.HCP, nil),
+		Client:        secret_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "update",
+		ShortHelp: "Update an existing secret.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+      The {{ template "mdCodeOrBold" "hcp vault-secrets secrets update" }} command updates an existing rotating or dynamic secret under a Vault Secrets application.
+      `),
+		Examples: []cmd.Example{
+			{
+				Preamble: `Update a rotating secret in the Vault Secrets application on your active profile:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+            $ hcp vault-secrets secrets update secret_1 --secret-type=rotating --data-file=tmp/secrets1.txt
+            `),
+			},
+		},
+		Args: cmd.PositionalArguments{
+			Args: []cmd.PositionalArgument{
+				{
+					Name:          "NAME",
+					Documentation: "The name of the secret to update.",
+				},
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "data-file",
+					DisplayValue: "DATA_FILE_PATH",
+					Description:  "File path to read secret data from. Set this to '-' to read the secret data from stdin.",
+					Value:        flagvalue.Simple("", &opts.SecretFilePath),
+					Required:     true,
+					Autocomplete: complete.PredictOr(
+						complete.PredictFiles("*"),
+						complete.PredictSet("-"),
+					),
+				},
+				{
+					Name:         "secret-type",
+					DisplayValue: "SECRET_TYPE",
+					Description:  "The type of secret to update: rotating or dynamic.",
+					Value:        flagvalue.Simple("", &opts.Type),
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			opts.AppName = appname.Get()
+			opts.SecretName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return updateRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+type SecretUpdateConfig struct {
+	Type    integrations.IntegrationType `hcl:"type"`
+	Details cty.Value                    `hcl:"details"`
+}
+
+func updateRun(opts *UpdateOpts) error {
+	switch opts.Type {
+	case secretTypeRotating:
+		sc, di, err := readUpdateConfigFile(opts.SecretFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to process config file: %w", err)
+		}
+
+		missingFields := validateSecretUpdateConfig(sc)
+
+		if len(missingFields) > 0 {
+			return fmt.Errorf("missing required field(s) in the config file: %s", missingFields)
+		}
+
+		switch sc.Type {
+		case integrations.Twilio:
+			req := preview_secret_service.NewUpdateTwilioRotatingSecretParamsWithContext(opts.Ctx)
+			req.OrganizationID = opts.Profile.OrganizationID
+			req.ProjectID = opts.Profile.ProjectID
+			req.AppName = opts.AppName
+			req.SecretName = opts.SecretName
+
+			var twilioBody preview_models.SecretServiceUpdateTwilioRotatingSecretBody
+			detailBytes, err := json.Marshal(di.Details)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			err = twilioBody.UnmarshalBinary(detailBytes)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+			req.Body = &twilioBody
+
+			resp, err := opts.PreviewClient.UpdateTwilioRotatingSecret(req, nil)
+			if err != nil {
+				return fmt.Errorf("failed to update secret with name %q: %w", opts.SecretName, err)
+			}
+
+			if err := opts.Output.Display(newRotatingSecretsDisplayer(true).PreviewRotatingSecrets(resp.Payload.Config)); err != nil {
+				return err
+			}
+
+		case integrations.MongoDBAtlas:
+			req := preview_secret_service.NewUpdateMongoDBAtlasRotatingSecretParamsWithContext(opts.Ctx)
+			req.OrganizationID = opts.Profile.OrganizationID
+			req.ProjectID = opts.Profile.ProjectID
+			req.AppName = opts.AppName
+			req.SecretName = opts.SecretName
+
+			var mongoDBBody preview_models.SecretServiceUpdateMongoDBAtlasRotatingSecretBody
+			detailBytes, err := json.Marshal(di.Details)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			err = mongoDBBody.UnmarshalBinary(detailBytes)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+			req.Body = &mongoDBBody
+
+			resp, err := opts.PreviewClient.UpdateMongoDBAtlasRotatingSecret(req, nil)
+			if err != nil {
+				return fmt.Errorf("failed to update secret with name %q: %w", opts.SecretName, err)
+			}
+
+			if err := opts.Output.Display(newRotatingSecretsDisplayer(true).PreviewRotatingSecrets(resp.Payload.Config)); err != nil {
+				return err
+			}
+
+		case integrations.AWS:
+			req := preview_secret_service.NewUpdateAwsIAMUserAccessKeyRotatingSecretParamsWithContext(opts.Ctx)
+			req.OrganizationID = opts.Profile.OrganizationID
+			req.ProjectID = opts.Profile.ProjectID
+			req.AppName = opts.AppName
+
+			var awsBody preview_models.SecretServiceUpdateAwsIAMUserAccessKeyRotatingSecretBody
+			detailBytes, err := json.Marshal(di.Details)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			err = awsBody.UnmarshalBinary(detailBytes)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			req.Body = &awsBody
+
+			_, err = opts.PreviewClient.UpdateAwsIAMUserAccessKeyRotatingSecret(req, nil)
+			if err != nil {
+				return fmt.Errorf("failed to update secret with name %q: %w", opts.SecretName, err)
+			}
+
+		case integrations.GCP:
+			req := preview_secret_service.NewUpdateGcpServiceAccountKeyRotatingSecretParamsWithContext(opts.Ctx)
+			req.OrganizationID = opts.Profile.OrganizationID
+			req.ProjectID = opts.Profile.ProjectID
+			req.AppName = opts.AppName
+
+			var gcpBody preview_models.SecretServiceUpdateGcpServiceAccountKeyRotatingSecretBody
+			detailBytes, err := json.Marshal(di.Details)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			err = gcpBody.UnmarshalBinary(detailBytes)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			req.Body = &gcpBody
+
+			_, err = opts.PreviewClient.UpdateGcpServiceAccountKeyRotatingSecret(req, nil)
+			if err != nil {
+				return fmt.Errorf("failed to update secret with name %q: %w", opts.SecretName, err)
+			}
+		}
+
+	default:
+		return fmt.Errorf("%q is an unsupported secret type; \"rotating\" and \"dynamic\" are available types", opts.Type)
+	}
+
+	fmt.Fprintf(opts.IO.Err(), "%s Successfully updated secret with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.SecretName)
+
+	return nil
+}
+
+func readUpdateConfigFile(filePath string) (SecretUpdateConfig, DetailsInternal, error) {
+	var (
+		sc SecretUpdateConfig
+		di DetailsInternal
+	)
+
+	if err := hclsimple.DecodeFile(filePath, nil, &sc); err != nil {
+		return sc, di, fmt.Errorf("failed to decode config file: %w", err)
+	}
+
+	detailsMap, err := ctyValueToMap(sc.Details)
+	if err != nil {
+		return sc, di, err
+	}
+	di.Details = detailsMap
+
+	return sc, di, nil
+}
+
+func validateSecretUpdateConfig(sc SecretUpdateConfig) []string {
+	var missingKeys []string
+
+	if sc.Type == "" {
+		missingKeys = append(missingKeys, "type")
+	}
+
+	return missingKeys
+}

--- a/internal/commands/vaultsecrets/secrets/update_test.go
+++ b/internal/commands/vaultsecrets/secrets/update_test.go
@@ -150,7 +150,7 @@ func TestUpdateRun(t *testing.T) {
 			Input: []byte(`type = "mongodb-atlas"
 details = {
   rotate_on_update = true
-  rotation_policy_name = "60"
+  rotation_policy_name = "built-in:60-days-2-active"
   secret_details = {
     mongodb_group_id = "mbdgi"
     mongodb_roles = [{

--- a/internal/commands/vaultsecrets/secrets/update_test.go
+++ b/internal/commands/vaultsecrets/secrets/update_test.go
@@ -1,0 +1,278 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	mock_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+func TestNewCmdUpdate(t *testing.T) {
+	t.Parallel()
+
+	testProfile := func(t *testing.T) *profile.Profile {
+		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+		tp.VaultSecrets = &profile.VaultSecretsConf{
+			AppName: "test-app",
+		}
+		return tp
+	}
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *UpdateOpts
+	}{
+		{
+			Name:    "Failed: No secret name arg specified",
+			Profile: testProfile,
+			Args:    []string{},
+			Error:   "ERROR: missing required flag: --data-file=DATA_FILE_PATH",
+		},
+		{
+			Name:    "Good: Secret name arg specified",
+			Profile: testProfile,
+			Args:    []string{"test", "--data-file=DATA_FILE_PATH"},
+			Expect: &UpdateOpts{
+				AppName:    testProfile(t).VaultSecrets.AppName,
+				SecretName: "test",
+			},
+		},
+		{
+			Name:    "Good: Rotating secret",
+			Profile: testProfile,
+			Args:    []string{"test", "--secret-type=rotating", "--data-file=DATA_FILE_PATH"},
+			Expect: &UpdateOpts{
+				AppName:    testProfile(t).VaultSecrets.AppName,
+				SecretName: "test",
+			},
+		},
+		{
+			Name:    "Good: Dynamic secret",
+			Profile: testProfile,
+			Args:    []string{"test", "--secret-type=dynamic", "--data-file=DATA_FILE_PATH"},
+			Expect: &UpdateOpts{
+				AppName:    testProfile(t).VaultSecrets.AppName,
+				SecretName: "test",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			// Create a context.
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts *UpdateOpts
+			updateCmd := NewCmdUpdate(ctx, func(o *UpdateOpts) error {
+				gotOpts = o
+				gotOpts.AppName = "test-app"
+				return nil
+			})
+			updateCmd.SetIO(io)
+
+			code := updateCmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+			r.Equal(c.Expect.AppName, gotOpts.AppName)
+			r.Equal(c.Expect.SecretName, gotOpts.SecretName)
+		})
+	}
+}
+
+func TestUpdateRun(t *testing.T) {
+	t.Parallel()
+
+	testProfile := func(t *testing.T) *profile.Profile {
+		tp := profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+		tp.VaultSecrets = &profile.VaultSecretsConf{
+			AppName: "test-app",
+		}
+		return tp
+	}
+
+	cases := []struct {
+		Name             string
+		RespErr          bool
+		ReadViaStdin     bool
+		EmptySecretValue bool
+		ErrMsg           string
+		MockCalled       bool
+		AugmentOpts      func(opts *UpdateOpts)
+		Input            []byte
+	}{
+		{
+			Name:    "Success: Update a MongoDB rotating secret",
+			RespErr: false,
+			AugmentOpts: func(o *UpdateOpts) {
+				o.Type = secretTypeRotating
+			},
+			MockCalled: true,
+			Input: []byte(`type = "mongodb-atlas"
+details = {
+  rotate_on_update = true
+  rotation_policy_name = "60"
+  secret_details = {
+    mongodb_group_id = "mbdgi"
+    mongodb_roles = [{
+      "role_name" = "rn1"
+      "database_name" = "dn1"
+      "collection_name" = "cn1"
+    },
+	{
+	  "role_name" = "rn2"
+	  "database_name" = "dn2"
+	  "collection_name" = "cn2"
+	}]
+  }
+}`),
+		},
+		{
+			Name:    "Failed: Unsupported secret type",
+			RespErr: true,
+			AugmentOpts: func(o *UpdateOpts) {
+				o.Type = "random"
+			},
+			Input:  []byte{},
+			ErrMsg: "\"random\" is an unsupported secret type; \"rotating\" and \"dynamic\" are available types",
+		},
+		{
+			Name:    "Failed: Unsupported static secret type",
+			RespErr: true,
+			AugmentOpts: func(o *UpdateOpts) {
+				o.Type = secretTypeKV
+			},
+			Input:  []byte{},
+			ErrMsg: "\"kv\" is an unsupported secret type; \"rotating\" and \"dynamic\" are available types",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+
+			vs := mock_secret_service.NewMockClientService(t)
+			pvs := mock_preview_secret_service.NewMockClientService(t)
+
+			opts := &UpdateOpts{
+				Ctx:           context.Background(),
+				IO:            io,
+				Profile:       testProfile(t),
+				Output:        format.New(io),
+				Client:        vs,
+				PreviewClient: pvs,
+				AppName:       testProfile(t).VaultSecrets.AppName,
+				SecretName:    "test_secret",
+			}
+
+			if c.AugmentOpts != nil {
+				c.AugmentOpts(opts)
+			}
+
+			tempDir := t.TempDir()
+			f, err := os.Create(filepath.Join(tempDir, "config.hcl"))
+			r.NoError(err)
+			_, err = f.Write(c.Input)
+			r.NoError(err)
+			opts.SecretFilePath = f.Name()
+
+			dt := strfmt.NewDateTime()
+			if c.MockCalled {
+				if c.RespErr {
+					pvs.EXPECT().UpdateMongoDBAtlasRotatingSecret(mock.Anything, mock.Anything).Return(nil, errors.New(c.ErrMsg)).Once()
+				} else {
+					pvs.EXPECT().UpdateMongoDBAtlasRotatingSecret(&preview_secret_service.UpdateMongoDBAtlasRotatingSecretParams{
+						OrganizationID: testProfile(t).OrganizationID,
+						ProjectID:      testProfile(t).ProjectID,
+						AppName:        testProfile(t).VaultSecrets.AppName,
+						SecretName:     "test_secret",
+						Body: &preview_models.SecretServiceUpdateMongoDBAtlasRotatingSecretBody{
+							RotateOnUpdate:     true,
+							RotationPolicyName: "built-in:60-days-2-active",
+							SecretDetails: &preview_models.Secrets20231128MongoDBAtlasSecretDetails{
+								MongodbGroupID: "mbdgi",
+								MongodbRoles: []*preview_models.Secrets20231128MongoDBRole{
+									{
+										RoleName:       "rn1",
+										DatabaseName:   "dn1",
+										CollectionName: "cn1",
+									},
+									{
+										RoleName:       "rn2",
+										DatabaseName:   "dn2",
+										CollectionName: "cn2",
+									},
+								},
+							},
+						},
+						Context: opts.Ctx,
+					}, mock.Anything).Return(&preview_secret_service.UpdateMongoDBAtlasRotatingSecretOK{
+						Payload: &preview_models.Secrets20231128UpdateMongoDBAtlasRotatingSecretResponse{
+							Config: &preview_models.Secrets20231128RotatingSecretConfig{
+								AppName:            opts.AppName,
+								CreatedAt:          dt,
+								IntegrationName:    "mongo-db-integration",
+								RotationPolicyName: "built-in:60-days-2-active",
+								SecretName:         opts.SecretName,
+							},
+						},
+					}, nil).Once()
+				}
+			}
+
+			// Run the command
+			err = updateRun(opts)
+			if c.ErrMsg != "" {
+				r.Contains(err.Error(), c.ErrMsg)
+				return
+			}
+
+			r.NoError(err)
+			r.Contains(io.Error.String(), fmt.Sprintf("✓ Successfully updated secret with name %q\n", opts.SecretName))
+		})
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds the update command for hvs rotating secrets for ticket https://hashicorp.atlassian.net/browse/VAULT-30012

### How I've tested this PR:
Ran `make go/build` to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Update a HVS rotating secret `./bin/hcp vault-secrets secrets update --secret-type=rotating --data-file=path/to/file/config.hcl

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
HCL Config File:

```
type = "aws"
details = { 
  rotation_policy_name: "60"
  assume_role = {
    "role_arn" = "redacted"
  }
}

```
<img width="1283" alt="Screenshot 2024-09-13 at 4 58 08 PM" src="https://github.com/user-attachments/assets/4186643e-fa40-4fce-bad3-3d4d4cb2778b">

### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
