### PR TITLE
VAULT-29634 - Create integration from interactive cli

### DIFF
--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -6,10 +6,10 @@ package integrations
 import (
 	"context"
 	"fmt"
-	"github.com/manifoldco/promptui"
 	"io"
 	"slices"
 
+	"github.com/manifoldco/promptui"
 	"golang.org/x/exp/maps"
 
 	"github.com/hashicorp/hcl/v2/hclsimple"
@@ -284,7 +284,7 @@ func promptUserForConfig(opts *CreateOpts) (IntegrationConfig, error) {
 
 		input, err := fieldPrompt.Run()
 		if err != nil {
-			return config, fmt.Errorf("Prompt for field %s failed %v\n", field, err)
+			return config, fmt.Errorf("prompt for field %s failed: %w", field, err)
 		}
 
 		fieldValues[field] = input

--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -113,24 +113,24 @@ var providerToRequiredFields = map[string][]string{
 
 func createRun(opts *CreateOpts) error {
 	var (
-		ic  IntegrationConfig
-		err error
+		config IntegrationConfig
+		err    error
 	)
 
 	if opts.ConfigFilePath == "" {
-		ic, err = promptUserForConfig(opts)
+		config, err = promptUserForConfig(opts)
 		if err != nil {
 			return fmt.Errorf("failed to create integration via cli prompt: %w", err)
 		}
 	} else {
-		if err = hclsimple.DecodeFile(opts.ConfigFilePath, nil, &ic); err != nil {
+		if err = hclsimple.DecodeFile(opts.ConfigFilePath, nil, &config); err != nil {
 			return fmt.Errorf("failed to decode config file: %w", err)
 		}
 	}
 
-	switch ic.Type {
+	switch config.Type {
 	case Twilio:
-		missingFields := validateDetails(ic.Details, TwilioKeys)
+		missingFields := validateDetails(config.Details, TwilioKeys)
 
 		if len(missingFields) > 0 {
 			return fmt.Errorf("missing required field(s) in the config file: %s", missingFields)
@@ -139,9 +139,9 @@ func createRun(opts *CreateOpts) error {
 		body := &preview_models.SecretServiceCreateTwilioIntegrationBody{
 			Name: opts.IntegrationName,
 			StaticCredentialDetails: &preview_models.Secrets20231128TwilioStaticCredentialsRequest{
-				AccountSid:   ic.Details[TwilioKeys[0]],
-				APIKeySecret: ic.Details[TwilioKeys[1]],
-				APIKeySid:    ic.Details[TwilioKeys[2]],
+				AccountSid:   config.Details[TwilioKeys[0]],
+				APIKeySecret: config.Details[TwilioKeys[1]],
+				APIKeySid:    config.Details[TwilioKeys[2]],
 			},
 			Capabilities: []*preview_models.Secrets20231128Capability{
 				preview_models.Secrets20231128CapabilityROTATION.Pointer(),
@@ -160,7 +160,7 @@ func createRun(opts *CreateOpts) error {
 		}
 
 	case MongoDBAtlas:
-		missingFields := validateDetails(ic.Details, MongoKeys)
+		missingFields := validateDetails(config.Details, MongoKeys)
 
 		if len(missingFields) > 0 {
 			return fmt.Errorf("missing required field(s) in the config file: %s", missingFields)
@@ -169,8 +169,8 @@ func createRun(opts *CreateOpts) error {
 		body := &preview_models.SecretServiceCreateMongoDBAtlasIntegrationBody{
 			Name: opts.IntegrationName,
 			StaticCredentialDetails: &preview_models.Secrets20231128MongoDBAtlasStaticCredentialsRequest{
-				APIPrivateKey: ic.Details[MongoKeys[0]],
-				APIPublicKey:  ic.Details[MongoKeys[1]],
+				APIPrivateKey: config.Details[MongoKeys[0]],
+				APIPublicKey:  config.Details[MongoKeys[1]],
 			},
 			Capabilities: []*preview_models.Secrets20231128Capability{
 				preview_models.Secrets20231128CapabilityROTATION.Pointer(),
@@ -189,7 +189,7 @@ func createRun(opts *CreateOpts) error {
 		}
 
 	case AWS:
-		missingFields := validateDetails(ic.Details, AWSKeys)
+		missingFields := validateDetails(config.Details, AWSKeys)
 
 		if len(missingFields) > 0 {
 			return fmt.Errorf("missing required field(s) in the config file: %s", missingFields)
@@ -198,8 +198,8 @@ func createRun(opts *CreateOpts) error {
 		body := &preview_models.SecretServiceCreateAwsIntegrationBody{
 			Name: opts.IntegrationName,
 			FederatedWorkloadIdentity: &preview_models.Secrets20231128AwsFederatedWorkloadIdentityRequest{
-				Audience: ic.Details[AWSKeys[0]],
-				RoleArn:  ic.Details[AWSKeys[1]],
+				Audience: config.Details[AWSKeys[0]],
+				RoleArn:  config.Details[AWSKeys[1]],
 			},
 			Capabilities: []*preview_models.Secrets20231128Capability{
 				preview_models.Secrets20231128CapabilityDYNAMIC.Pointer(),
@@ -218,7 +218,7 @@ func createRun(opts *CreateOpts) error {
 		}
 
 	case GCP:
-		missingFields := validateDetails(ic.Details, GCPKeys)
+		missingFields := validateDetails(config.Details, GCPKeys)
 
 		if len(missingFields) > 0 {
 			return fmt.Errorf("missing required field(s) in the config file: %s", missingFields)
@@ -227,8 +227,8 @@ func createRun(opts *CreateOpts) error {
 		body := &preview_models.SecretServiceCreateGcpIntegrationBody{
 			Name: opts.IntegrationName,
 			FederatedWorkloadIdentity: &preview_models.Secrets20231128GcpFederatedWorkloadIdentityRequest{
-				Audience:            ic.Details[GCPKeys[0]],
-				ServiceAccountEmail: ic.Details[GCPKeys[1]],
+				Audience:            config.Details[GCPKeys[0]],
+				ServiceAccountEmail: config.Details[GCPKeys[1]],
 			},
 			Capabilities: []*preview_models.Secrets20231128Capability{
 				preview_models.Secrets20231128CapabilityDYNAMIC.Pointer(),

--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -257,7 +257,7 @@ func promptUserForConfig(opts *CreateOpts) (IntegrationConfig, error) {
 	var config IntegrationConfig
 
 	if !opts.IO.CanPrompt() {
-		return config, fmt.Errorf("unable to creative integration interactively")
+		return config, fmt.Errorf("unable to create integration interactively")
 	}
 
 	providerPrompt := promptui.Select{

--- a/internal/commands/vaultsecrets/integrations/create_test.go
+++ b/internal/commands/vaultsecrets/integrations/create_test.go
@@ -106,27 +106,11 @@ func TestCreateRun(t *testing.T) {
 			IntegrationName: "sample-integration",
 			Input: []byte(`type = "aws"
 details = {
-  "audience" = "abc",
-  "role_arn" = "def"
+  "federated_workload_identity" = {
+    "audience" = "abc",
+    "role_arn" = "def"
+  }
 }`),
-		},
-		{
-			Name:            "Missing a single required field",
-			IntegrationName: "sample-integration",
-			Input: []byte(`type = "mongodb-atlas"
-details = {
-  "public_key" = "abc"
-}`),
-			Error: "missing required field(s) in the config file: [private_key]",
-		},
-		{
-			Name:            "Missing multiple required fields",
-			IntegrationName: "sample-integration",
-			Input: []byte(`type = "twilio"
-details = {
-  "api_key_sid" = "ghi"
-}`),
-			Error: "missing required field(s) in the config file: [account_sid api_key_secret]",
 		},
 	}
 

--- a/internal/commands/vaultsecrets/integrations/create_test.go
+++ b/internal/commands/vaultsecrets/integrations/create_test.go
@@ -52,12 +52,6 @@ func TestNewCmdCreate(t *testing.T) {
 			Args:    []string{"--config-file", "path/to/file"},
 			Error:   "ERROR: accepts 1 arg(s), received 0",
 		},
-		{
-			Name:    "Failed: No config file flag specified",
-			Profile: testProfile,
-			Args:    []string{"sample-integration"},
-			Error:   "ERROR: missing required flag: --config-file=CONFIG_FILE",
-		},
 	}
 
 	for _, c := range cases {

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -368,44 +368,13 @@ func readConfigFile(filePath string) (SecretConfig, secretConfigInternal, error)
 		return secretConfig, internalConfig, fmt.Errorf("failed to decode config file: %w", err)
 	}
 
-	detailsMap, err := ctyValueToMap(secretConfig.Details)
+	detailsMap, err := integrations.CtyValueToMap(secretConfig.Details)
 	if err != nil {
 		return secretConfig, internalConfig, err
 	}
 	internalConfig.Details = detailsMap
 
 	return secretConfig, internalConfig, nil
-}
-
-func ctyValueToMap(value cty.Value) (map[string]any, error) {
-	fieldsMap := make(map[string]any)
-	for k, v := range value.AsValueMap() {
-		if v.Type() == cty.String {
-			fieldsMap[k] = v.AsString()
-		} else if v.Type() == cty.Bool {
-			fieldsMap[k] = v.True()
-		} else if v.Type().IsObjectType() {
-			nestedMap, err := ctyValueToMap(v)
-			if err != nil {
-				return nil, err
-			}
-			fieldsMap[k] = nestedMap
-		} else if v.Type().IsTupleType() {
-			var items []map[string]any
-			for _, val := range v.AsValueSlice() {
-				nestedMap, err := ctyValueToMap(val)
-				if err != nil {
-					return nil, err
-				}
-				items = append(items, nestedMap)
-			}
-			fieldsMap[k] = items
-		} else {
-			return nil, fmt.Errorf("found unsupported value type")
-		}
-	}
-
-	return fieldsMap, nil
 }
 
 func validateSecretConfig(secretConfig SecretConfig) []string {

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -195,7 +195,7 @@ func TestCreateRun(t *testing.T) {
 			Input: []byte(`type = "mongodb-atlas"
 integration_name = "mongo-db-integration"
 details = {
-  rotation_policy_name: "built-in:60-days-2-active"
+  rotation_policy_name = "built-in:60-days-2-active"
   secret_details = {
     mongodb_group_id = "mbdgi"
     mongodb_roles = [{

--- a/internal/commands/vaultsecrets/secrets/update.go
+++ b/internal/commands/vaultsecrets/secrets/update.go
@@ -248,7 +248,7 @@ func readUpdateConfigFile(filePath string) (SecretUpdateConfig, secretConfigInte
 		return secretConfig, internalConfig, fmt.Errorf("failed to decode config file: %w", err)
 	}
 
-	detailsMap, err := ctyValueToMap(secretConfig.Details)
+	detailsMap, err := integrations.CtyValueToMap(secretConfig.Details)
 	if err != nil {
 		return secretConfig, internalConfig, err
 	}


### PR DESCRIPTION
### Changes proposed in this PR:
For ticket https://hashicorp.atlassian.net/browse/VAULT-29634, we want to provide users with an option to create integrations through interactive CLI prompting. This PR provides that experience when users omit the `config-file` flag.

### How I've tested this PR:
Ran `make go/build to test manually`

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Create a HVS integration `./bin/hcp vault-secrets integration create sample-integration`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
<img width="741" alt="Screenshot 2024-09-16 at 6 19 50 PM" src="https://github.com/user-attachments/assets/c33ffbcf-1cbd-46f5-b884-421cd4889cb3">

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
