### PR TITLE
VAULT-30011 update dynamic secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.22.0
-	github.com/hashicorp/hcp-sdk-go v0.112.0
+	github.com/hashicorp/hcp-sdk-go v0.113.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.22.0 h1:hkZ3nCtqeJsDhPRFz5EA9iwcG1hNWGePOTw6oyul12M=
 github.com/hashicorp/hcl/v2 v2.22.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/hcp-sdk-go v0.112.0 h1:gKzxaPhzJj4NobFw7Sc1rGf3nMSqUKBgTtsbZ6bzd14=
-github.com/hashicorp/hcp-sdk-go v0.112.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.113.0 h1:JuA6mZosEezE550lNMEq43VLUCzVc+/jPmPC1Nd39Gk=
+github.com/hashicorp/hcp-sdk-go v0.113.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/commands/vaultsecrets/secrets/update_test.go
+++ b/internal/commands/vaultsecrets/secrets/update_test.go
@@ -307,6 +307,7 @@ details = {
 							OrganizationID: testProfile(t).OrganizationID,
 							ProjectID:      testProfile(t).ProjectID,
 							AppName:        testProfile(t).VaultSecrets.AppName,
+							Name:           opts.SecretName,
 							Body: &preview_models.SecretServiceUpdateAwsDynamicSecretBody{
 								DefaultTTL: "3600s",
 								AssumeRole: &preview_models.Secrets20231128AssumeRoleRequest{

--- a/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service/mock_ClientService.go
+++ b/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service/mock_ClientService.go
@@ -4643,6 +4643,80 @@ func (_c *MockClientService_UpdateApp_Call) RunAndReturn(run func(*secret_servic
 	return _c
 }
 
+// UpdateAwsDynamicSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdateAwsDynamicSecret(params *secret_service.UpdateAwsDynamicSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateAwsDynamicSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateAwsDynamicSecret")
+	}
+
+	var r0 *secret_service.UpdateAwsDynamicSecretOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateAwsDynamicSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateAwsDynamicSecretOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateAwsDynamicSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateAwsDynamicSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdateAwsDynamicSecretOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdateAwsDynamicSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdateAwsDynamicSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateAwsDynamicSecret'
+type MockClientService_UpdateAwsDynamicSecret_Call struct {
+	*mock.Call
+}
+
+// UpdateAwsDynamicSecret is a helper method to define mock.On call
+//   - params *secret_service.UpdateAwsDynamicSecretParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdateAwsDynamicSecret(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateAwsDynamicSecret_Call {
+	return &MockClientService_UpdateAwsDynamicSecret_Call{Call: _e.mock.On("UpdateAwsDynamicSecret",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdateAwsDynamicSecret_Call) Run(run func(params *secret_service.UpdateAwsDynamicSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateAwsDynamicSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdateAwsDynamicSecretParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdateAwsDynamicSecret_Call) Return(_a0 *secret_service.UpdateAwsDynamicSecretOK, _a1 error) *MockClientService_UpdateAwsDynamicSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdateAwsDynamicSecret_Call) RunAndReturn(run func(*secret_service.UpdateAwsDynamicSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateAwsDynamicSecretOK, error)) *MockClientService_UpdateAwsDynamicSecret_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateAwsIAMUserAccessKeyRotatingSecret provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) UpdateAwsIAMUserAccessKeyRotatingSecret(params *secret_service.UpdateAwsIAMUserAccessKeyRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateAwsIAMUserAccessKeyRotatingSecretOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -4861,6 +4935,80 @@ func (_c *MockClientService_UpdateGatewayPool_Call) Return(_a0 *secret_service.U
 }
 
 func (_c *MockClientService_UpdateGatewayPool_Call) RunAndReturn(run func(*secret_service.UpdateGatewayPoolParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateGatewayPoolOK, error)) *MockClientService_UpdateGatewayPool_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateGcpDynamicSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdateGcpDynamicSecret(params *secret_service.UpdateGcpDynamicSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateGcpDynamicSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateGcpDynamicSecret")
+	}
+
+	var r0 *secret_service.UpdateGcpDynamicSecretOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateGcpDynamicSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateGcpDynamicSecretOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateGcpDynamicSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateGcpDynamicSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdateGcpDynamicSecretOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdateGcpDynamicSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdateGcpDynamicSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateGcpDynamicSecret'
+type MockClientService_UpdateGcpDynamicSecret_Call struct {
+	*mock.Call
+}
+
+// UpdateGcpDynamicSecret is a helper method to define mock.On call
+//   - params *secret_service.UpdateGcpDynamicSecretParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdateGcpDynamicSecret(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateGcpDynamicSecret_Call {
+	return &MockClientService_UpdateGcpDynamicSecret_Call{Call: _e.mock.On("UpdateGcpDynamicSecret",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdateGcpDynamicSecret_Call) Run(run func(params *secret_service.UpdateGcpDynamicSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateGcpDynamicSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdateGcpDynamicSecretParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdateGcpDynamicSecret_Call) Return(_a0 *secret_service.UpdateGcpDynamicSecretOK, _a1 error) *MockClientService_UpdateGcpDynamicSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdateGcpDynamicSecret_Call) RunAndReturn(run func(*secret_service.UpdateGcpDynamicSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateGcpDynamicSecretOK, error)) *MockClientService_UpdateGcpDynamicSecret_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds the update command for hvs rotating secrets for ticket https://hashicorp.atlassian.net/browse/VAULT-30011

### How I've tested this PR:
Ran `make go/build` to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Update a HVS rotating secret `./bin/hcp vault-secrets secrets update --secret-type=dynamic --data-file=path/to/file/config.hcl

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
<img width="1101" alt="Screenshot 2024-09-20 at 5 51 00 PM" src="https://github.com/user-attachments/assets/c8be47e9-b318-43a1-955b-eb36948d603d">

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
