### PR TITLE
Waypoint action sequence numbers are now reported on agent run completion

### DIFF
--- a/.changelog/165.txt
+++ b/.changelog/165.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Waypoint: Action sequence numbers are now reported on agent run completion
+```

--- a/internal/commands/waypoint/agent/run.go
+++ b/internal/commands/waypoint/agent/run.go
@@ -154,8 +154,9 @@ func runOp(
 	ns string,
 ) {
 	var (
-		status     string
-		statusCode int
+		status      string
+		statusCode  int
+		sequenceNum string
 	)
 
 	log = log.With("group", ao.Group, "operation", ao.ID, "action-run-id", ao.ActionRunID)
@@ -175,8 +176,12 @@ func runOp(
 		if err != nil {
 			log.Error("unable to register action as starting", "error", err)
 		} else {
+			if resp != nil && resp.Payload != nil {
+				sequenceNum = resp.Payload.Sequence
+
+			}
 			defer func() {
-				log.Info("reporting action run ended", "status", status, "status-code", statusCode)
+				log.Info("reporting action run ended", "status", status, "status-code", statusCode, "action-run-sequence", sequenceNum)
 
 				_, err = opts.WS.WaypointServiceEndingAction(&waypoint_service.WaypointServiceEndingActionParams{
 					NamespaceID: ns,


### PR DESCRIPTION
### Changes proposed in this PR:

When Waypoint agents have completed an action, they will now report the action sequence number like other types of Waypoint actions.

>[!NOTE]
> The linter is failing on this PR with errors logged for `cloud-vault-secrets` commands, the failure is unrelated to changes in this PR. This is due to the update to the hcp-sdk-go version.

### How I've tested this PR:

I have manually tested this by creating an agent group and a corresponding action, then running `hcp waypoint agent run` and launching the action to allow the Waypoint agent to pick it up. I then verified that the correct sequence number was displayed.

### How I expect reviewers to test this PR:

Reviewers can test this PR by running an agent action of their own.

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

```
% ./hcp waypoint agent run --config=./agent.hcl 
2024-09-23T12:30:37.315-0700 [INFO]  hcp.waypoint.agent.run: Waypoint agent initialized: hcp-org=*** hcp-project=*** waypoint-namespace=*** groups=["sequence-num-testing"]
2024-09-23T12:31:37.924-0700 [INFO]  hcp.waypoint.agent.run: reporting action run starting: action-run-id=fe192bd6-30e7-4037-8734-e7f3ca6c8648 group=sequence-num-testing operation=test-null
2024-09-23T12:31:38.082-0700 [INFO]  hcp.waypoint.agent.run: finished operation: action-run-id=fe192bd6-30e7-4037-8734-e7f3ca6c8648 group=sequence-num-testing operation=test-null
2024-09-23T12:31:38.082-0700 [INFO]  hcp.waypoint.agent.run: reporting action run ended: action-run-id=fe192bd6-30e7-4037-8734-e7f3ca6c8648 group=sequence-num-testing operation=test-null status="output: hello" status-code=0 sequence=2
```

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
