### PR TITLE
Adds missing AWS and GCP provider calls

### DIFF
--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -87,6 +87,19 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 
 func readRun(opts *ReadOpts) error {
 	switch opts.Type {
+	case "":
+		resp, err := opts.PreviewClient.GetIntegration(&preview_secret_service.GetIntegrationParams{
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Name:           opts.IntegrationName,
+		}, nil)
+		if err != nil {
+			return fmt.Errorf("failed to read integration: %w", err)
+		}
+
+		return opts.Output.Display(newGenericDisplayer(true, resp.Payload.Integration))
+
 	case Twilio:
 		resp, err := opts.PreviewClient.GetTwilioIntegration(&preview_secret_service.GetTwilioIntegrationParams{
 			Context:        opts.Ctx,
@@ -112,6 +125,32 @@ func readRun(opts *ReadOpts) error {
 		}
 
 		return opts.Output.Display(newMongoDBDisplayer(true, resp.Payload.Integration))
+
+	case AWS:
+		resp, err := opts.PreviewClient.GetAwsIntegration(&preview_secret_service.GetAwsIntegrationParams{
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Name:           opts.IntegrationName,
+		}, nil)
+		if err != nil {
+			return fmt.Errorf("failed to read integration: %w", err)
+		}
+
+		return opts.Output.Display(newAwsDisplayer(true, resp.Payload.Integration))
+
+	case GCP:
+		resp, err := opts.PreviewClient.GetGcpIntegration(&preview_secret_service.GetGcpIntegrationParams{
+			Context:        opts.Ctx,
+			ProjectID:      opts.Profile.ProjectID,
+			OrganizationID: opts.Profile.OrganizationID,
+			Name:           opts.IntegrationName,
+		}, nil)
+		if err != nil {
+			return fmt.Errorf("failed to read integration: %w", err)
+		}
+
+		return opts.Output.Display(newGcpDisplayer(true, resp.Payload.Integration))
 
 	default:
 		return fmt.Errorf("not a valid integration type")

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -231,6 +231,58 @@ func createRun(opts *CreateOpts) error {
 				return err
 			}
 
+		case integrations.AWS:
+			req := preview_secret_service.NewCreateAwsIAMUserAccessKeyRotatingSecretParamsWithContext(opts.Ctx)
+			req.OrganizationID = opts.Profile.OrganizationID
+			req.ProjectID = opts.Profile.ProjectID
+			req.AppName = opts.AppName
+
+			var awsBody preview_models.SecretServiceCreateAwsIAMUserAccessKeyRotatingSecretBody
+			detailBytes, err := json.Marshal(internalConfig.Details)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			err = awsBody.UnmarshalBinary(detailBytes)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			awsBody.IntegrationName = secretConfig.IntegrationName
+			awsBody.Name = opts.SecretName
+			req.Body = &awsBody
+
+			_, err = opts.PreviewClient.CreateAwsIAMUserAccessKeyRotatingSecret(req, nil)
+			if err != nil {
+				return fmt.Errorf("failed to create secret with name %q: %w", opts.SecretName, err)
+			}
+
+		case integrations.GCP:
+			req := preview_secret_service.NewCreateGcpServiceAccountKeyRotatingSecretParamsWithContext(opts.Ctx)
+			req.OrganizationID = opts.Profile.OrganizationID
+			req.ProjectID = opts.Profile.ProjectID
+			req.AppName = opts.AppName
+
+			var gcpBody preview_models.SecretServiceCreateGcpServiceAccountKeyRotatingSecretBody
+			detailBytes, err := json.Marshal(internalConfig.Details)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			err = gcpBody.UnmarshalBinary(detailBytes)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			gcpBody.IntegrationName = secretConfig.IntegrationName
+			gcpBody.Name = opts.SecretName
+			req.Body = &gcpBody
+
+			_, err = opts.PreviewClient.CreateGcpServiceAccountKeyRotatingSecret(req, nil)
+			if err != nil {
+				return fmt.Errorf("failed to create secret with name %q: %w", opts.SecretName, err)
+			}
+
 		default:
 			return fmt.Errorf("unsupported rotating secret provider type")
 		}


### PR DESCRIPTION
### Changes proposed in this PR:
The [original ticket](https://github.com/hashicorp/hcp/pull/141) that added rotating secrets creation was merged before the recent addition of `AwsIAMUserAccessKeyRotatingSecrets` and `GcpServiceAccountKeyRotatingSecrets` in the cloud-vault-secrets repo, so this PR simply adds them to the existing code.

This PR also adds AWS, GCP, and generic "get integration" calls

### How I've tested this PR:
Ran `make go/build` to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Create a rotating secret `./bin/hcp vault-secrets secrets create {SECRET_NAME} --secret-type rotating --data-file "/path/to/file/config.yaml"`
4. Read a AWS integration `./bin/hcp vault-secrets integrations read sample-integration --type=aws`

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
