### PR TITLE
Update HVS integrations

### DIFF
--- a/internal/commands/vaultsecrets/integrations/integrations.go
+++ b/internal/commands/vaultsecrets/integrations/integrations.go
@@ -34,5 +34,6 @@ func NewCmdIntegrations(ctx *cmd.Context) *cmd.Command {
 	cmd.AddChild(NewCmdDelete(ctx, nil))
 	cmd.AddChild(NewCmdList(ctx, nil))
 	cmd.AddChild(NewCmdCreate(ctx, nil))
+	cmd.AddChild(NewCmdUpdate(ctx, nil))
 	return cmd
 }

--- a/internal/commands/vaultsecrets/integrations/update.go
+++ b/internal/commands/vaultsecrets/integrations/update.go
@@ -1,0 +1,210 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package integrations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2/hclsimple"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+)
+
+type UpdateOpts struct {
+	Ctx     context.Context
+	Profile *profile.Profile
+	IO      iostreams.IOStreams
+	Output  *format.Outputter
+
+	IntegrationName string
+	ConfigFilePath  string
+	PreviewClient   preview_secret_service.ClientService
+	Client          secret_service.ClientService
+}
+
+func NewCmdUpdate(ctx *cmd.Context, runF func(*UpdateOpts) error) *cmd.Command {
+	opts := &UpdateOpts{
+		Ctx:     ctx.ShutdownCtx,
+		Profile: ctx.Profile,
+		IO:      ctx.IO,
+		Output:  ctx.Output,
+
+		PreviewClient: preview_secret_service.New(ctx.HCP, nil),
+		Client:        secret_service.New(ctx.HCP, nil),
+	}
+
+	cmd := &cmd.Command{
+		Name:      "update",
+		ShortHelp: "Update an integration.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations update" }} command updates a Vault Secrets integration.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: `Update a Vault Secrets integration:`,
+				Command: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
+				$ hcp vault-secrets integrations update sample-integration --config-file=path-to-file/config.hcl
+				`),
+			},
+		},
+		Args: cmd.PositionalArguments{
+			Args: []cmd.PositionalArgument{
+				{
+					Name:          "NAME",
+					Documentation: "The name of the integration to update.",
+				},
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "config-file",
+					DisplayValue: "CONFIG_FILE",
+					Description:  "File path to read integration config data.",
+					Value:        flagvalue.Simple("", &opts.ConfigFilePath),
+					Required:     true,
+				},
+			},
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			opts.IntegrationName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return updateRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+func updateRun(opts *UpdateOpts) error {
+	var (
+		config         IntegrationConfig
+		internalConfig integrationConfigInternal
+	)
+
+	if err := hclsimple.DecodeFile(opts.ConfigFilePath, nil, &config); err != nil {
+		return fmt.Errorf("failed to decode config file: %w", err)
+	}
+
+	detailsMap, err := CtyValueToMap(config.Details)
+	if err != nil {
+		return fmt.Errorf("failed to process config file: %w", err)
+	}
+	internalConfig.Details = detailsMap
+
+	switch config.Type {
+	case Twilio:
+		req := preview_secret_service.NewUpdateTwilioIntegrationParamsWithContext(opts.Ctx)
+		req.OrganizationID = opts.Profile.OrganizationID
+		req.ProjectID = opts.Profile.ProjectID
+		req.Name = opts.IntegrationName
+
+		var twilioBody preview_models.SecretServiceUpdateTwilioIntegrationBody
+		detailBytes, err := json.Marshal(internalConfig.Details)
+		if err != nil {
+			return fmt.Errorf("error marshaling details config: %w", err)
+		}
+
+		err = twilioBody.UnmarshalBinary(detailBytes)
+		if err != nil {
+			return fmt.Errorf("error marshaling details config: %w", err)
+		}
+		req.Body = &twilioBody
+
+		_, err = opts.PreviewClient.UpdateTwilioIntegration(req, nil)
+		if err != nil {
+			return fmt.Errorf("failed to update Twilio integration: %w", err)
+		}
+
+	case MongoDBAtlas:
+		req := preview_secret_service.NewUpdateMongoDBAtlasIntegrationParamsWithContext(opts.Ctx)
+		req.OrganizationID = opts.Profile.OrganizationID
+		req.ProjectID = opts.Profile.ProjectID
+		req.Name = opts.IntegrationName
+
+		var mongoDBBody preview_models.SecretServiceUpdateMongoDBAtlasIntegrationBody
+		detailBytes, err := json.Marshal(internalConfig.Details)
+		if err != nil {
+			return fmt.Errorf("error marshaling details config: %w", err)
+		}
+
+		err = mongoDBBody.UnmarshalBinary(detailBytes)
+		if err != nil {
+			return fmt.Errorf("error marshaling details config: %w", err)
+		}
+		req.Body = &mongoDBBody
+
+		_, err = opts.PreviewClient.UpdateMongoDBAtlasIntegration(req, nil)
+
+		if err != nil {
+			return fmt.Errorf("failed to update MongoDB Atlas integration: %w", err)
+		}
+
+	case AWS:
+		req := preview_secret_service.NewUpdateAwsIntegrationParamsWithContext(opts.Ctx)
+		req.OrganizationID = opts.Profile.OrganizationID
+		req.ProjectID = opts.Profile.ProjectID
+		req.Name = opts.IntegrationName
+
+		var awsBody preview_models.SecretServiceUpdateAwsIntegrationBody
+		detailBytes, err := json.Marshal(internalConfig.Details)
+		if err != nil {
+			return fmt.Errorf("error marshaling details config: %w", err)
+		}
+
+		err = awsBody.UnmarshalBinary(detailBytes)
+		if err != nil {
+			return fmt.Errorf("error marshaling details config: %w", err)
+		}
+		req.Body = &awsBody
+
+		_, err = opts.PreviewClient.UpdateAwsIntegration(req, nil)
+
+		if err != nil {
+			return fmt.Errorf("failed to update AWS integration: %w", err)
+		}
+
+	case GCP:
+		req := preview_secret_service.NewUpdateGcpIntegrationParamsWithContext(opts.Ctx)
+		req.OrganizationID = opts.Profile.OrganizationID
+		req.ProjectID = opts.Profile.ProjectID
+		req.Name = opts.IntegrationName
+
+		var gcpBody preview_models.SecretServiceUpdateGcpIntegrationBody
+		detailBytes, err := json.Marshal(internalConfig.Details)
+		if err != nil {
+			return fmt.Errorf("error marshaling details config: %w", err)
+		}
+
+		err = gcpBody.UnmarshalBinary(detailBytes)
+		if err != nil {
+			return fmt.Errorf("error marshaling details config: %w", err)
+		}
+		req.Body = &gcpBody
+
+		_, err = opts.PreviewClient.UpdateGcpIntegration(req, nil)
+
+		if err != nil {
+			return fmt.Errorf("failed to update GCP integration: %w", err)
+		}
+	}
+
+	fmt.Fprintln(opts.IO.Err())
+	fmt.Fprintf(opts.IO.Err(), "%s Successfully updated integration with name %q\n", opts.IO.ColorScheme().SuccessIcon(), opts.IntegrationName)
+
+	return nil
+}

--- a/internal/commands/vaultsecrets/integrations/update_test.go
+++ b/internal/commands/vaultsecrets/integrations/update_test.go
@@ -6,9 +6,6 @@ package integrations
 import (
 	"context"
 	"fmt"
-	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
-	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,6 +13,9 @@ import (
 	"github.com/go-openapi/runtime/client"
 	"github.com/stretchr/testify/require"
 
+	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	preview_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	mock_preview_secret_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"


### PR DESCRIPTION
### Changes proposed in this PR:
This PR adds the `update` command for hvs integrations

### How I've tested this PR:
Ran `make go/build` to manually test local changes, and added unit tests.

### How I expect reviewers to test this PR:
1. Checkout this branch
2. Run `make go/build`
3. Update a HVS integration `./bin/hcp vault-secrets integrations update --data-file=path/to/file/config.hcl

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->
<img width="906" alt="Screenshot 2024-09-30 at 1 49 34 PM" src="https://github.com/user-attachments/assets/859c9d20-7ce5-4758-a69a-803f7395f4f3">
<img width="398" alt="Screenshot 2024-09-30 at 1 49 20 PM" src="https://github.com/user-attachments/assets/25a55d78-1ef6-4b48-b4e0-c1184a6a0449">

### Checklist:
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
