### PR TITLE
Support input variables for Waypoint apps

### DIFF
--- a/.changelog/172.txt
+++ b/.changelog/172.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+waypoint: Support setting variables when creating apps.
+```

--- a/internal/commands/waypoint/applications/applications.go
+++ b/internal/commands/waypoint/applications/applications.go
@@ -17,6 +17,9 @@ type ApplicationOpts struct {
 	ActionConfigNames  []string
 	ReadmeMarkdownFile string
 
+	Variables     map[string]string
+	VariablesFile string
+
 	testFunc func(c *cmd.Command, args []string) error
 }
 

--- a/internal/commands/waypoint/applications/create.go
+++ b/internal/commands/waypoint/applications/create.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp/internal/commands/waypoint/internal"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -65,6 +66,27 @@ $ hcp waypoint application create -n=my-application -t=my-template
 					Required:     false,
 					Repeatable:   true,
 				},
+				{
+					Name:         "var",
+					DisplayValue: "KEY=VALUE",
+					Description: "A variable to be used in the application. The" +
+						" flag can be repeated to specify multiple variables. " +
+						"Variables specified with the flag will override " +
+						"variables specified in a file.",
+					Value:      flagvalue.SimpleMap(nil, &opts.Variables),
+					Required:   false,
+					Repeatable: true,
+				},
+				{
+					Name:         "var-file",
+					DisplayValue: "FILE",
+					Description: "A file containing variables to be used in the " +
+						"application. The file should be in HCL format Variables" +
+						" in the file will be overridden by variables specified" +
+						" with the --var flag.",
+					Value:    flagvalue.Simple("", &opts.VariablesFile),
+					Required: false,
+				},
 			},
 		},
 	}
@@ -85,6 +107,43 @@ func applicationCreate(opts *ApplicationOpts) error {
 		}
 	}
 
+	// Variable Processing
+
+	// a map is used with the key being the variable name, so that
+	// flags can override file values.
+	ivs := make(map[string]*models.HashicorpCloudWaypointInputVariable)
+	if opts.VariablesFile != "" {
+		variables, err := internal.ParseInputVariablesFile(opts.VariablesFile)
+		if err != nil {
+			return errors.Wrapf(err, "%s failed to parse input variables file %q",
+				opts.IO.ColorScheme().FailureIcon(),
+				opts.VariablesFile,
+			)
+		}
+		for _, v := range variables {
+			ivs[v.Name] = &models.HashicorpCloudWaypointInputVariable{
+				Name:  v.Name,
+				Value: v.Value,
+			}
+		}
+	}
+
+	// Flags are processed second, so that they can override file values.
+	// Flags take precedence over file values.
+	for k, v := range opts.Variables {
+		ivs[k] = &models.HashicorpCloudWaypointInputVariable{
+			Name:  k,
+			Value: v,
+		}
+	}
+
+	var vars []*models.HashicorpCloudWaypointInputVariable
+	for _, v := range ivs {
+		vars = append(vars, v)
+	}
+
+	// End Variable Processing
+
 	_, err = opts.WS.WaypointServiceCreateApplicationFromTemplate(
 		&waypoint_service.WaypointServiceCreateApplicationFromTemplateParams{
 			NamespaceID: ns.ID,
@@ -95,6 +154,7 @@ func applicationCreate(opts *ApplicationOpts) error {
 					Name: opts.TemplateName,
 				},
 				ActionCfgRefs: actionConfigs,
+				Variables:     vars,
 			},
 		}, nil)
 	if err != nil {

--- a/internal/commands/waypoint/applications/create_test.go
+++ b/internal/commands/waypoint/applications/create_test.go
@@ -46,10 +46,19 @@ func TestNewCmdCreateApplication(t *testing.T) {
 		{
 			Name:    "Happy",
 			Profile: profile.TestProfile,
-			Args:    []string{"-n", "app-name", "-t", "templates-name"},
+			Args: []string{
+				"-n", "app-name",
+				"-t", "templates-name",
+				"--var", "var1=val1",
+				"--var-file", "vars.hcl",
+			},
 			Expect: &ApplicationOpts{
 				Name:         "app-name",
 				TemplateName: "templates-name",
+				Variables: map[string]string{
+					"var1": "val1",
+				},
+				VariablesFile: "vars.hcl",
 			},
 		},
 	}

--- a/internal/commands/waypoint/internal/input_variables.go
+++ b/internal/commands/waypoint/internal/input_variables.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+	"os"
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsimple"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+)
+
+func ParseInputVariablesFile(path string) ([]*models.HashicorpCloudWaypointInputVariable, error) {
+	input, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return parseInputVariables(path, input)
+}
+
+func parseInputVariables(filename string, input []byte) ([]*models.HashicorpCloudWaypointInputVariable, error) {
+	var hc hclInputVariablesFile
+	var ctx hcl.EvalContext
+	if err := hclsimple.Decode(filename, input, &ctx, &hc); err != nil {
+		return nil, err
+	}
+
+	var variables []*models.HashicorpCloudWaypointInputVariable
+	if len(hc.Variables) > 0 {
+		for k, v := range hc.Variables {
+			variables = append(variables, &models.HashicorpCloudWaypointInputVariable{
+				Name:  k,
+				Value: v,
+			})
+		}
+	}
+
+	sort.Slice(variables, func(i, j int) bool {
+		return variables[i].Name < variables[j].Name
+	})
+	return variables, nil
+}
+
+type hclInputVariablesFile struct {
+	Variables map[string]string `hcl:"variables,remain"`
+}

--- a/internal/commands/waypoint/internal/input_variables_test.go
+++ b/internal/commands/waypoint/internal/input_variables_test.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_InputVariablesFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("can parse variables", func(t *testing.T) {
+		t.Parallel()
+
+		r := require.New(t)
+
+		hcl := `
+key="value"
+key2="value2"
+`
+
+		inputVars, err := parseInputVariables("blah.hcl", []byte(hcl))
+		r.NoError(err)
+		r.Equal(2, len(inputVars))
+		r.Equal("key", inputVars[0].Name)
+		r.Equal("value", inputVars[0].Value)
+		r.Equal("key2", inputVars[1].Name)
+		r.Equal("value2", inputVars[1].Value)
+	})
+
+	t.Run("handles empty file", func(t *testing.T) {
+		t.Parallel()
+
+		r := require.New(t)
+
+		hcl := ``
+
+		inputVars, err := parseInputVariables("blah.hcl", []byte(hcl))
+		r.NoError(err)
+		r.Equal(0, len(inputVars))
+	})
+
+	t.Run("handles empty values", func(t *testing.T) {
+		t.Parallel()
+
+		r := require.New(t)
+
+		hcl := `
+key=""
+key2=""
+`
+
+		inputVars, err := parseInputVariables("blah.hcl", []byte(hcl))
+		r.NoError(err)
+		r.Equal(2, len(inputVars))
+		r.Equal("key", inputVars[0].Name)
+		r.Equal("", inputVars[0].Value)
+		r.Equal("key2", inputVars[1].Name)
+		r.Equal("", inputVars[1].Value)
+	})
+
+	t.Run("fail to parse", func(t *testing.T) {
+		t.Parallel()
+
+		r := require.New(t)
+
+		hcl := `
+key======
+`
+
+		_, err := parseInputVariables("blah.hcl", []byte(hcl))
+		r.Error(err)
+	})
+}


### PR DESCRIPTION
### Changes proposed in this PR:

This enables the app developer to configure input variables when creating applications.

### How I've tested this PR:

I used the CLI to create an app with an input variable that was user editable.

### How I expect reviewers to test this PR:

Use the CLI to create an app with an input variable that was user editable.

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
