### PR TITLE
Support input vars on Waypoint add-ons

### DIFF
--- a/.changelog/173.txt
+++ b/.changelog/173.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+waypoint: Support setting variables when installing add-ons.
+```

--- a/internal/commands/waypoint/add-ons/add_on.go
+++ b/internal/commands/waypoint/add-ons/add_on.go
@@ -17,6 +17,9 @@ type AddOnOpts struct {
 	AddOnDefinitionName string
 	ApplicationName     string
 
+	Variables     map[string]string
+	VariablesFile string
+
 	testFunc func(c *cmd.Command, args []string) error
 }
 

--- a/internal/commands/waypoint/add-ons/create_test.go
+++ b/internal/commands/waypoint/add-ons/create_test.go
@@ -48,11 +48,19 @@ func TestNewCmdCreate(t *testing.T) {
 				"-n=cli-test",
 				"--app=testApp",
 				"--add-on-definition-name=testAddOnDefinition",
+				"--var-file", "vars.hcl",
+				"--var", "key=value",
+				"--var", "key2=value2",
 			},
 			Expect: &AddOnOpts{
 				Name:                "cli-test",
 				ApplicationName:     "testApp",
 				AddOnDefinitionName: "testAddOnDefinition",
+				Variables: map[string]string{
+					"key":  "value",
+					"key2": "value2",
+				},
+				VariablesFile: "vars.hcl",
 			},
 		},
 	}
@@ -86,6 +94,8 @@ func TestNewCmdCreate(t *testing.T) {
 				r.Equal(c.Expect.Name, addOnOpts.Name)
 				r.Equal(c.Expect.ApplicationName, addOnOpts.ApplicationName)
 				r.Equal(c.Expect.AddOnDefinitionName, addOnOpts.AddOnDefinitionName)
+				r.Equal(c.Expect.Variables, addOnOpts.Variables)
+				r.Equal(c.Expect.VariablesFile, addOnOpts.VariablesFile)
 			}
 		})
 	}


### PR DESCRIPTION
### Changes proposed in this PR:

Enable app developers to set variables when installing an add-on.

### How I've tested this PR:

I created an add-on for an application with an input variable using the CLI.

### How I expect reviewers to test this PR:

Create an add-on for an application with an input variable using the CLI.

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
