### PR TITLE
Remove Waypoint variable option field

### DIFF
--- a/.changelog/174.txt
+++ b/.changelog/174.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+waypoint: Remove type field from variable options config file.
+```

--- a/internal/commands/waypoint/internal/variable_options.go
+++ b/internal/commands/waypoint/internal/variable_options.go
@@ -24,7 +24,6 @@ func ParseVariableOptionsFile(path string) ([]*models.HashicorpCloudWaypointTFMo
 // # Example contents of a vars.hcl file
 //
 //	variable_option "string_variable" {
-//	  type = "string"
 //	  options = [
 //	    "a string value",
 //	  ]
@@ -32,7 +31,6 @@ func ParseVariableOptionsFile(path string) ([]*models.HashicorpCloudWaypointTFMo
 //	}
 //
 //	variable_option "misc_variable" {
-//	  type = "string"
 //	  options = [
 //	    "another string value",
 //	  ]
@@ -53,7 +51,6 @@ func parseVariableOptions(filename string, input []byte) ([]*models.HashicorpClo
 		for _, v := range hc.VariableOptions {
 			variables = append(variables, &models.HashicorpCloudWaypointTFModuleVariable{
 				Name:         v.Name,
-				VariableType: v.Type,
 				Options:      v.Options,
 				UserEditable: v.UserEditable,
 			})
@@ -64,7 +61,6 @@ func parseVariableOptions(filename string, input []byte) ([]*models.HashicorpClo
 
 type hclVariableOption struct {
 	Name         string   `hcl:",label"`
-	Type         string   `hcl:"type"`
 	Options      []string `hcl:"options"`
 	UserEditable bool     `hcl:"user_editable,optional"`
 }

--- a/internal/commands/waypoint/internal/variable_options_test.go
+++ b/internal/commands/waypoint/internal/variable_options_test.go
@@ -18,7 +18,6 @@ func Test_VariableOptionsFileParse(t *testing.T) {
 
 		hcl := `
           variable_option "string_variable" {
-            type = "string"
             options = [
               "a string value",
             ]
@@ -30,7 +29,6 @@ func Test_VariableOptionsFileParse(t *testing.T) {
 		r.NoError(err)
 		r.Equal(1, len(variableInputs))
 		r.Equal("string_variable", variableInputs[0].Name)
-		r.Equal("string", variableInputs[0].VariableType)
 		r.Equal(false, variableInputs[0].UserEditable)
 	})
 
@@ -41,7 +39,6 @@ func Test_VariableOptionsFileParse(t *testing.T) {
 
 		hcl := `
           variable_option "string_variable" {
-            type = "string"
             options = [
               "a string value",
         		"another string value",
@@ -65,7 +62,6 @@ func Test_VariableOptionsFileParse(t *testing.T) {
 
 		hcl := `
 variable_option "string_variable" {
-  type = "string"
   options = [
     "a string value",
 		"another",
@@ -74,7 +70,6 @@ variable_option "string_variable" {
 }
 
 variable_option "misc_variable" {
-  type = "int"
   options = [
     8,
 		2,
@@ -92,7 +87,6 @@ variable_option "misc_variable" {
 
 		r.Equal("misc_variable", variableInputs[1].Name)
 		r.Equal(2, len(variableInputs[1].Options))
-		r.Equal("int", variableInputs[1].VariableType)
 		r.Equal(false, variableInputs[1].UserEditable)
 	})
 
@@ -102,12 +96,7 @@ variable_option "misc_variable" {
 		r := require.New(t)
 
 		hcl := `
-variable_option "" {
-  options = [
-    8,
-		2,
-  ]
-}
+variable_option "" {}
 `
 
 		_, err := parseVariableOptions("blah.hcl", []byte(hcl))


### PR DESCRIPTION
### Changes proposed in this PR:

This PR includes a breaking change. The format of a variable options config file is changed.

The "type" field of a variable is removed. This field is now output only, in terms of the HCP Waypoint API, and should not be set by API clients. Therefore, it is removed from the config file for the CLI here.

### How I've tested this PR:

I created a template with a newly formatted variable config file.

### How I expect reviewers to test this PR:

Create a template with a newly formatted variable config file.

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
