### PR TITLE
VAULT-30892- Implements bug bash fixes for cli parity work

### DIFF
--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -56,7 +56,10 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations create" }} command creates a new Vault Secrets integration.
 		When the {{ template "mdCodeOrBold" "--config-file" }} flag is specified, the configuration for your integration will be read
-		from the provided HCL config file. The following fields are required: [type details]. When the {{ template "mdCodeOrBold" "--config-file" }} 
+		from the provided HCL config file. The following fields are required: [type details]. For help populating the details for an 
+		integration type, please refer to the 
+		{{ Link "API reference documentation" "https://developer.hashicorp.com/hcp/api-docs/vault-secrets/2023-11-28" }}.
+		When the {{ template "mdCodeOrBold" "--config-file" }} 
 		flag is not specified, you will be prompted to create the integration interactively.
 		`),
 		Examples: []cmd.Example{

--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -37,6 +37,8 @@ type CreateOpts struct {
 	Client          secret_service.ClientService
 }
 
+var IntegrationProviders = maps.Keys(providerToRequiredFields)
+
 func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 	opts := &CreateOpts{
 		Ctx:     ctx.ShutdownCtx,
@@ -53,6 +55,9 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 		ShortHelp: "Create a new integration.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations create" }} command creates a new Vault Secrets integration.
+		When the {{ template "mdCodeOrBold" "--config-file" }} flag is specified, the configuration for your integration will be read
+		from the provided HCL config file. The following fields are required: [type details]. When the {{ template "mdCodeOrBold" "--config-file" }} 
+		flag is not specified, you will be prompted to create the integration interactively.
 		`),
 		Examples: []cmd.Example{
 			{
@@ -265,7 +270,7 @@ func promptUserForConfig(opts *CreateOpts) (IntegrationConfig, integrationConfig
 
 	providerPrompt := promptui.Select{
 		Label:  "Please select the provider you would like to configure",
-		Items:  maps.Keys(providerToRequiredFields),
+		Items:  IntegrationProviders,
 		Stdin:  io.NopCloser(opts.IO.In()),
 		Stdout: iostreams.NopWriteCloser(opts.IO.Err()),
 	}

--- a/internal/commands/vaultsecrets/integrations/delete.go
+++ b/internal/commands/vaultsecrets/integrations/delete.go
@@ -42,9 +42,10 @@ func NewCmdDelete(ctx *cmd.Context, runF func(*DeleteOpts) error) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "delete",
 		ShortHelp: "Delete a Vault Secrets integration.",
-		LongHelp: heredoc.New(ctx.IO).Must(`
+		LongHelp: heredoc.New(ctx.IO).Must(fmt.Sprintf(`
       The {{ template "mdCodeOrBold" "hcp vault-secrets integrations delete" }} command deletes a Vault Secrets integration.
-      `),
+      The required {{ template "mdCodeOrBold" "--type" }} flag may be any of the following: %v
+      `, IntegrationProviders)),
 		Examples: []cmd.Example{
 			{
 				Preamble: `Delete an integration:`,

--- a/internal/commands/vaultsecrets/integrations/list.go
+++ b/internal/commands/vaultsecrets/integrations/list.go
@@ -42,9 +42,10 @@ func NewCmdList(ctx *cmd.Context, runF func(*ListOpts) error) *cmd.Command {
 	cmd := &cmd.Command{
 		Name:      "list",
 		ShortHelp: "List Vault Secrets integrations.",
-		LongHelp: heredoc.New(ctx.IO).Must(`
+		LongHelp: heredoc.New(ctx.IO).Must(fmt.Sprintf(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations list" }} command lists Vault Secrets generic integrations.
-		`),
+		The optional {{ template "mdCodeOrBold" "--type" }} flag may be any of the following: %v
+		`, IntegrationProviders)),
 		Examples: []cmd.Example{
 			{
 				Preamble: `List twilio integrations:`,
@@ -86,6 +87,7 @@ func listRun(opts *ListOpts) error {
 			Context:        opts.Ctx,
 			ProjectID:      opts.Profile.ProjectID,
 			OrganizationID: opts.Profile.OrganizationID,
+			Capabilities:   []string{"ROTATION", "DYNAMIC"},
 		}
 		for {
 			resp, err := opts.PreviewClient.ListIntegrations(params, nil)
@@ -180,7 +182,7 @@ func listRun(opts *ListOpts) error {
 			next := resp.Payload.Pagination.NextPageToken
 			params.PaginationNextPageToken = &next
 		}
-		return opts.Output.Display(newAwsDisplayer(false, integrations...))
+		return opts.Output.Display(newAwsDisplayer(false, false, integrations...))
 
 	case GCP:
 		var integrations []*preview_models.Secrets20231128GcpIntegration
@@ -205,7 +207,7 @@ func listRun(opts *ListOpts) error {
 			next := resp.Payload.Pagination.NextPageToken
 			params.PaginationNextPageToken = &next
 		}
-		return opts.Output.Display(newGcpDisplayer(false, integrations...))
+		return opts.Output.Display(newGcpDisplayer(false, false, integrations...))
 
 	default:
 		return fmt.Errorf("not a valid integration type")

--- a/internal/commands/vaultsecrets/integrations/read.go
+++ b/internal/commands/vaultsecrets/integrations/read.go
@@ -68,7 +68,6 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 					DisplayValue: "TYPE",
 					Description:  "The type of the integration to read.",
 					Value:        flagvalue.Simple("", &opts.Type),
-					Required:     true,
 				},
 			},
 		},
@@ -137,7 +136,7 @@ func readRun(opts *ReadOpts) error {
 			return fmt.Errorf("failed to read integration: %w", err)
 		}
 
-		return opts.Output.Display(newAwsDisplayer(true, resp.Payload.Integration))
+		return opts.Output.Display(newAwsDisplayer(true, resp.Payload.Integration.FederatedWorkloadIdentity != nil, resp.Payload.Integration))
 
 	case GCP:
 		resp, err := opts.PreviewClient.GetGcpIntegration(&preview_secret_service.GetGcpIntegrationParams{
@@ -150,7 +149,7 @@ func readRun(opts *ReadOpts) error {
 			return fmt.Errorf("failed to read integration: %w", err)
 		}
 
-		return opts.Output.Display(newGcpDisplayer(true, resp.Payload.Integration))
+		return opts.Output.Display(newGcpDisplayer(true, resp.Payload.Integration.FederatedWorkloadIdentity != nil, resp.Payload.Integration))
 
 	default:
 		return fmt.Errorf("not a valid integration type")

--- a/internal/commands/vaultsecrets/integrations/read_test.go
+++ b/internal/commands/vaultsecrets/integrations/read_test.go
@@ -43,14 +43,6 @@ func TestNewCmdRead(t *testing.T) {
 				Type:            "twilio",
 			},
 		},
-		{
-			Name: "Missing type flag",
-			Profile: func(t *testing.T) *profile.Profile {
-				return profile.TestProfile(t).SetOrgID("123").SetProjectID("abc")
-			},
-			Args:  []string{"sample-integration"},
-			Error: "ERROR: missing required flag: --type=TYPE",
-		},
 	}
 	for _, c := range cases {
 		c := c

--- a/internal/commands/vaultsecrets/integrations/update.go
+++ b/internal/commands/vaultsecrets/integrations/update.go
@@ -49,6 +49,7 @@ func NewCmdUpdate(ctx *cmd.Context, runF func(*UpdateOpts) error) *cmd.Command {
 		ShortHelp: "Update an integration.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations update" }} command updates a Vault Secrets integration.
+		The following fields are required: [type details].
 		`),
 		Examples: []cmd.Example{
 			{

--- a/internal/commands/vaultsecrets/integrations/update.go
+++ b/internal/commands/vaultsecrets/integrations/update.go
@@ -49,7 +49,9 @@ func NewCmdUpdate(ctx *cmd.Context, runF func(*UpdateOpts) error) *cmd.Command {
 		ShortHelp: "Update an integration.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets integrations update" }} command updates a Vault Secrets integration.
-		The following fields are required: [type details].
+		The configuration for updating your integration will be read from the provided HCL config file. The following fields are 
+		required: [type details]. For help populating the details for an integration type, please refer to the 
+		{{ Link "API reference documentation" "https://developer.hashicorp.com/hcp/api-docs/vault-secrets/2023-11-28" }}.
 		`),
 		Examples: []cmd.Example{
 			{

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -43,7 +43,9 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 		ShortHelp: "Create a new static secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets create" }} command creates a new static, rotating, or dynamic secret under a Vault Secrets application.
-		For rotating and dynamic secrets, the following fields are required in the config file: [type integration_name details].
+		The configuration for creating your rotating or dynamic secret will be read from the provided HCL config file. The following fields are required in the config 
+		file: [type integration_name details]. For help populating the details for a dynamic or rotating secret, please refer to the 
+		{{ Link "API reference documentation" "https://developer.hashicorp.com/hcp/api-docs/vault-secrets/2023-11-28" }}.
 		`),
 		Examples: []cmd.Example{
 			{

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -43,6 +43,7 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 		ShortHelp: "Create a new static secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp vault-secrets secrets create" }} command creates a new static, rotating, or dynamic secret under a Vault Secrets application.
+		For rotating and dynamic secrets, the following fields are required in the config file: [type integration_name details].
 		`),
 		Examples: []cmd.Example{
 			{

--- a/internal/commands/vaultsecrets/secrets/update.go
+++ b/internal/commands/vaultsecrets/secrets/update.go
@@ -52,6 +52,7 @@ func NewCmdUpdate(ctx *cmd.Context, runF func(*UpdateOpts) error) *cmd.Command {
 		ShortHelp: "Update an existing secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
       The {{ template "mdCodeOrBold" "hcp vault-secrets secrets update" }} command updates an existing rotating or dynamic secret under a Vault Secrets application.
+	  The following fields are required in the config file: [type details].
       `),
 		Examples: []cmd.Example{
 			{

--- a/internal/commands/vaultsecrets/secrets/update.go
+++ b/internal/commands/vaultsecrets/secrets/update.go
@@ -52,7 +52,9 @@ func NewCmdUpdate(ctx *cmd.Context, runF func(*UpdateOpts) error) *cmd.Command {
 		ShortHelp: "Update an existing secret.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
       The {{ template "mdCodeOrBold" "hcp vault-secrets secrets update" }} command updates an existing rotating or dynamic secret under a Vault Secrets application.
-	  The following fields are required in the config file: [type details].
+	  The configuration for updating your rotating or dynamic secret will be read from the provided HCL config file. The following fields are required in the config 
+	  file: [type details]. For help populating the details for a dynamic or rotating secret, please refer to the 
+	  {{ Link "API reference documentation" "https://developer.hashicorp.com/hcp/api-docs/vault-secrets/2023-11-28" }}.
       `),
 		Examples: []cmd.Example{
 			{


### PR DESCRIPTION
### Changes proposed in this PR:
During the [bug bash](https://docs.google.com/document/d/1FBeHDoeq-cmlbJsbOKdp7Egk8x5l-F0mIDbi9KncXi4/edit#heading=h.g87luvs4f9xs) for HCP CLI Parity on HVS, we tracked bugs/feedback in [this spreadsheet](https://docs.google.com/spreadsheets/d/1oT3_e_P1MaCBRqOkDWvX_0-kLLulV1oK5LV3RZftJdg/edit?gid=0#gid=0). This PR addresses each of these with a fix where possible.

### How I've tested this PR:
Reproducing errors mentioned in the spreadsheet and manually testing the fixes

### How I expect reviewers to test this PR:
Reproducing errors mentioned in the spreadsheet and manually testing the fixes.
1. Checkout this branch
2. Run make go/build
3. Retest commands mentioned [here](https://docs.google.com/spreadsheets/d/1oT3_e_P1MaCBRqOkDWvX_0-kLLulV1oK5LV3RZftJdg/edit?gid=0#gid=0)

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
