### PR TITLE
Remove dockerfile curl install from edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN apk --no-cache upgrade && apk --no-cache add \
 	nano
 
 ## No patch for vulnerabilities in alpine, downloading fixed versions from edge
-RUN apk --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --no-cache add \
-  curl=8.9.1-r1
+RUN apk --no-cache add curl
   # Vim temporarily removed as there is no available patch on edge yet, although it is fixed in version > 9.1.0697
   # https://pkgs.alpinelinux.org/packages?name=vim&branch=edge&repo=&arch=&maintainer=
   # https://security.alpinelinux.org/vuln/CVE-2024-43802


### PR DESCRIPTION
### Changes proposed in this PR:
* Dockerfile curl install was terminating with an exception when installing from edge.
* Revert to installing curl without specifying the version now that the previous CVE has been addressed.

### How I've tested this PR:
`make docker/dev`

### How I expect reviewers to test this PR:
`make docker/dev` or view the `build` action.

<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
