### PR TITLE
HV-1702 create postgres rotating secret

### DIFF
--- a/.changelog/192.txt
+++ b/.changelog/192.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+hvs: support postgres rotating secret CRUDL
+```

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.22.0
-	github.com/hashicorp/hcp-sdk-go v0.117.0
+	github.com/hashicorp/hcp-sdk-go v0.120.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/cli v1.1.5

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.22.0
-	github.com/hashicorp/hcp-sdk-go v0.120.0
+	github.com/hashicorp/hcp-sdk-go v0.121.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.22.0 h1:hkZ3nCtqeJsDhPRFz5EA9iwcG1hNWGePOTw6oyul12M=
 github.com/hashicorp/hcl/v2 v2.22.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/hcp-sdk-go v0.120.0 h1:U2uEVkjYMQFbf/M+Q44l9BRX9qZkNr8J5/uzKXA/DQA=
-github.com/hashicorp/hcp-sdk-go v0.120.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.121.0 h1:fDCB0sexSNontS7LLuhF1RJd7eYx1hmFVBFmY4kXU78=
+github.com/hashicorp/hcp-sdk-go v0.121.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.22.0 h1:hkZ3nCtqeJsDhPRFz5EA9iwcG1hNWGePOTw6oyul12M=
 github.com/hashicorp/hcl/v2 v2.22.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/hcp-sdk-go v0.117.0 h1:7lJpkinpWdsXtejC+X7MdaE/3zhFMweB9Ym3uJ7qFJw=
-github.com/hashicorp/hcp-sdk-go v0.117.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.120.0 h1:U2uEVkjYMQFbf/M+Q44l9BRX9qZkNr8J5/uzKXA/DQA=
+github.com/hashicorp/hcp-sdk-go v0.120.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/internal/commands/vaultsecrets/integrations/integrations.go
+++ b/internal/commands/vaultsecrets/integrations/integrations.go
@@ -15,6 +15,7 @@ const (
 	MongoDBAtlas IntegrationType = "mongodb-atlas"
 	AWS          IntegrationType = "aws"
 	GCP          IntegrationType = "gcp"
+	Postgres     IntegrationType = "postgres"
 )
 
 func NewCmdIntegrations(ctx *cmd.Context) *cmd.Command {

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -190,7 +190,7 @@ var (
 		"integration_name":     "",
 		"rotation_policy_name": "",
 		"postgres_params": map[string]any{
-			"usernames": "",
+			"usernames": []string{},
 		},
 	}
 
@@ -376,6 +376,7 @@ func createRun(opts *CreateOpts) error {
 		case integrations.Postgres:
 			req := preview_secret_service.NewCreatePostgresRotatingSecretParamsWithContext(opts.Ctx)
 			req.OrganizationID = opts.Profile.OrganizationID
+			req.ProjectID = opts.Profile.ProjectID
 			req.AppName = opts.AppName
 
 			var postgresBody preview_models.SecretServiceCreatePostgresRotatingSecretBody

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -376,7 +376,7 @@ func createRun(opts *CreateOpts) error {
 		case integrations.Postgres:
 			req := preview_secret_service.NewCreatePostgresRotatingSecretParamsWithContext(opts.Ctx)
 			req.OrganizationID = opts.Profile.OrganizationID
-			req.ProjectID = opts.Profile.ProjectID
+			req.AppName = opts.AppName
 
 			var postgresBody preview_models.SecretServiceCreatePostgresRotatingSecretBody
 			detailBytes, err := json.Marshal(internalConfig.Details)

--- a/internal/commands/vaultsecrets/secrets/create.go
+++ b/internal/commands/vaultsecrets/secrets/create.go
@@ -186,6 +186,14 @@ var (
 		},
 	}
 
+	postgresRotatingSecretTemplate = map[string]any{
+		"integration_name":     "",
+		"rotation_policy_name": "",
+		"postgres_params": map[string]any{
+			"usernames": "",
+		},
+	}
+
 	awsDynamicSecretTemplate = map[string]any{
 		"integration_name": "",
 		"default_ttl":      "",
@@ -365,6 +373,30 @@ func createRun(opts *CreateOpts) error {
 				return fmt.Errorf("failed to create secret with name %q: %w", opts.SecretName, err)
 			}
 
+		case integrations.Postgres:
+			req := preview_secret_service.NewCreatePostgresRotatingSecretParamsWithContext(opts.Ctx)
+			req.OrganizationID = opts.Profile.OrganizationID
+			req.ProjectID = opts.Profile.ProjectID
+
+			var postgresBody preview_models.SecretServiceCreatePostgresRotatingSecretBody
+			detailBytes, err := json.Marshal(internalConfig.Details)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			err = postgresBody.UnmarshalBinary(detailBytes)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			postgresBody.Name = opts.SecretName
+			req.Body = &postgresBody
+
+			_, err = opts.PreviewClient.CreatePostgresRotatingSecret(req, nil)
+			if err != nil {
+				return fmt.Errorf("failed to create secret with name %q: %w", opts.SecretName, err)
+			}
+
 		default:
 			return fmt.Errorf("unsupported rotating secret provider type")
 		}
@@ -538,6 +570,7 @@ var availableRotatingSecretProviders = map[string]map[string]any{
 	string(integrations.MongoDBAtlas): mongoDBAtlasRotatingSecretTemplate,
 	string(integrations.AWS):          awsRotatingSecretTemplate,
 	string(integrations.GCP):          gcpRotatingSecretTemplate,
+	string(integrations.Postgres):     postgresRotatingSecretTemplate,
 }
 
 var availableDynamicSecretProviders = map[string]map[string]any{

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/integrations"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/integrations"
 
 	"github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"

--- a/internal/commands/vaultsecrets/secrets/create_test.go
+++ b/internal/commands/vaultsecrets/secrets/create_test.go
@@ -222,7 +222,7 @@ details = {
   integration_name = "postgres-integration"
   rotation_policy_name = "built-in:60-days-2-active"
   postgres_params = {
-  	usernames = ["postgres_user_1"]
+  	usernames = ["postgres_user_1", "postgres_user_2"]
   }
 }`),
 		},
@@ -386,7 +386,7 @@ details = {
 									Name:               opts.SecretName,
 									IntegrationName:    "postgres-integration",
 									RotationPolicyName: "built-in:60-days-2-active",
-									PostgresParams:     &preview_models.Secrets20231128PostgresParams{Usernames: []string{"postgres_user_1"}},
+									PostgresParams:     &preview_models.Secrets20231128PostgresParams{Usernames: []string{"postgres_user_1", "postgres_user_2"}},
 								},
 								Context: opts.Ctx,
 							}, mock.Anything).Return(&preview_secret_service.CreatePostgresRotatingSecretOK{
@@ -397,7 +397,7 @@ details = {
 										IntegrationName:    "postgres-integration",
 										RotationPolicyName: "built-in:60-days-2-active",
 										Name:               opts.SecretName,
-										PostgresParams:     &preview_models.Secrets20231128PostgresParams{Usernames: []string{"postgres_user_1"}},
+										PostgresParams:     &preview_models.Secrets20231128PostgresParams{Usernames: []string{"postgres_user_1", "postgres_user_2"}},
 									},
 								},
 							}, nil).Once()

--- a/internal/commands/vaultsecrets/secrets/update.go
+++ b/internal/commands/vaultsecrets/secrets/update.go
@@ -235,6 +235,31 @@ func updateRun(opts *UpdateOpts) error {
 			if err != nil {
 				return fmt.Errorf("failed to update secret with name %q: %w", opts.SecretName, err)
 			}
+
+		case integrations.Postgres:
+			req := preview_secret_service.NewUpdatePostgresRotatingSecretParamsWithContext(opts.Ctx)
+			req.OrganizationID = opts.Profile.OrganizationID
+			req.ProjectID = opts.Profile.ProjectID
+			req.AppName = opts.AppName
+			req.Name = opts.SecretName
+
+			var postgresBody preview_models.SecretServiceUpdatePostgresRotatingSecretBody
+			detailBytes, err := json.Marshal(internalConfig.Details)
+			if err != nil {
+				return fmt.Errorf("error marshaling details config: %w", err)
+			}
+
+			err = postgresBody.UnmarshalBinary(detailBytes)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling details config: %w", err)
+			}
+
+			req.Body = &postgresBody
+
+			_, err = opts.PreviewClient.UpdatePostgresRotatingSecret(req, nil)
+			if err != nil {
+				return fmt.Errorf("failed to update secret with name %q: %w", opts.SecretName, err)
+			}
 		}
 
 	case secretTypeDynamic:

--- a/internal/commands/vaultsecrets/secrets/update_test.go
+++ b/internal/commands/vaultsecrets/secrets/update_test.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/integrations"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/hashicorp/hcp/internal/commands/vaultsecrets/integrations"
 
 	"github.com/go-openapi/strfmt"
 	preview_secret_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"

--- a/internal/commands/vaultsecrets/secrets/update_test.go
+++ b/internal/commands/vaultsecrets/secrets/update_test.go
@@ -184,7 +184,7 @@ details = {
   integration_name = "postgres-integration"
   rotation_policy_name = "built-in:60-days-2-active"
   postgres_params = {
-  	usernames = ["postgres_user_1"]
+  	usernames = ["postgres_user_1", "postgres_user_2"]
   }
 }`),
 		},
@@ -343,7 +343,7 @@ details = {
 									Config: &preview_models.Secrets20231128PostgresRotatingSecretConfig{
 										AppName:            opts.AppName,
 										CreatedAt:          dt,
-										IntegrationName:    "mongo-db-integration",
+										IntegrationName:    "postgres-integration",
 										RotationPolicyName: "built-in:60-days-2-active",
 										Name:               opts.SecretName,
 									},

--- a/internal/commands/vaultsecrets/secrets/update_test.go
+++ b/internal/commands/vaultsecrets/secrets/update_test.go
@@ -334,7 +334,7 @@ details = {
 									RotateOnUpdate:     true,
 									RotationPolicyName: "built-in:60-days-2-active",
 									PostgresParams: &preview_models.Secrets20231128PostgresParams{
-										Usernames: []string{"postgres_user_1"},
+										Usernames: []string{"postgres_user_1", "postgres_user_2"},
 									},
 								},
 								Context: opts.Ctx,
@@ -346,6 +346,9 @@ details = {
 										IntegrationName:    "postgres-integration",
 										RotationPolicyName: "built-in:60-days-2-active",
 										Name:               opts.SecretName,
+										PostgresParams: &preview_models.Secrets20231128PostgresParams{
+											Usernames: []string{"postgres_user_1", "postgres_user_2"},
+										},
 									},
 								},
 							}, nil).Once()

--- a/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/resource_service/mock_ClientService.go
+++ b/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/resource_service/mock_ClientService.go
@@ -95,6 +95,80 @@ func (_c *MockClientService_ResourceServiceGetIamPolicy_Call) RunAndReturn(run f
 	return _c
 }
 
+// ResourceServiceGetResource provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) ResourceServiceGetResource(params *resource_service.ResourceServiceGetResourceParams, authInfo runtime.ClientAuthInfoWriter, opts ...resource_service.ClientOption) (*resource_service.ResourceServiceGetResourceOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResourceServiceGetResource")
+	}
+
+	var r0 *resource_service.ResourceServiceGetResourceOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*resource_service.ResourceServiceGetResourceParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) (*resource_service.ResourceServiceGetResourceOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*resource_service.ResourceServiceGetResourceParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) *resource_service.ResourceServiceGetResourceOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resource_service.ResourceServiceGetResourceOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*resource_service.ResourceServiceGetResourceParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_ResourceServiceGetResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourceServiceGetResource'
+type MockClientService_ResourceServiceGetResource_Call struct {
+	*mock.Call
+}
+
+// ResourceServiceGetResource is a helper method to define mock.On call
+//   - params *resource_service.ResourceServiceGetResourceParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...resource_service.ClientOption
+func (_e *MockClientService_Expecter) ResourceServiceGetResource(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_ResourceServiceGetResource_Call {
+	return &MockClientService_ResourceServiceGetResource_Call{Call: _e.mock.On("ResourceServiceGetResource",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_ResourceServiceGetResource_Call) Run(run func(params *resource_service.ResourceServiceGetResourceParams, authInfo runtime.ClientAuthInfoWriter, opts ...resource_service.ClientOption)) *MockClientService_ResourceServiceGetResource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]resource_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(resource_service.ClientOption)
+			}
+		}
+		run(args[0].(*resource_service.ResourceServiceGetResourceParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_ResourceServiceGetResource_Call) Return(_a0 *resource_service.ResourceServiceGetResourceOK, _a1 error) *MockClientService_ResourceServiceGetResource_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_ResourceServiceGetResource_Call) RunAndReturn(run func(*resource_service.ResourceServiceGetResourceParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) (*resource_service.ResourceServiceGetResourceOK, error)) *MockClientService_ResourceServiceGetResource_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ResourceServiceList provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) ResourceServiceList(params *resource_service.ResourceServiceListParams, authInfo runtime.ClientAuthInfoWriter, opts ...resource_service.ClientOption) (*resource_service.ResourceServiceListOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -165,6 +239,154 @@ func (_c *MockClientService_ResourceServiceList_Call) Return(_a0 *resource_servi
 }
 
 func (_c *MockClientService_ResourceServiceList_Call) RunAndReturn(run func(*resource_service.ResourceServiceListParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) (*resource_service.ResourceServiceListOK, error)) *MockClientService_ResourceServiceList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResourceServiceListAccessibleResources provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) ResourceServiceListAccessibleResources(params *resource_service.ResourceServiceListAccessibleResourcesParams, authInfo runtime.ClientAuthInfoWriter, opts ...resource_service.ClientOption) (*resource_service.ResourceServiceListAccessibleResourcesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResourceServiceListAccessibleResources")
+	}
+
+	var r0 *resource_service.ResourceServiceListAccessibleResourcesOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*resource_service.ResourceServiceListAccessibleResourcesParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) (*resource_service.ResourceServiceListAccessibleResourcesOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*resource_service.ResourceServiceListAccessibleResourcesParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) *resource_service.ResourceServiceListAccessibleResourcesOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resource_service.ResourceServiceListAccessibleResourcesOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*resource_service.ResourceServiceListAccessibleResourcesParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_ResourceServiceListAccessibleResources_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourceServiceListAccessibleResources'
+type MockClientService_ResourceServiceListAccessibleResources_Call struct {
+	*mock.Call
+}
+
+// ResourceServiceListAccessibleResources is a helper method to define mock.On call
+//   - params *resource_service.ResourceServiceListAccessibleResourcesParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...resource_service.ClientOption
+func (_e *MockClientService_Expecter) ResourceServiceListAccessibleResources(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_ResourceServiceListAccessibleResources_Call {
+	return &MockClientService_ResourceServiceListAccessibleResources_Call{Call: _e.mock.On("ResourceServiceListAccessibleResources",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_ResourceServiceListAccessibleResources_Call) Run(run func(params *resource_service.ResourceServiceListAccessibleResourcesParams, authInfo runtime.ClientAuthInfoWriter, opts ...resource_service.ClientOption)) *MockClientService_ResourceServiceListAccessibleResources_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]resource_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(resource_service.ClientOption)
+			}
+		}
+		run(args[0].(*resource_service.ResourceServiceListAccessibleResourcesParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_ResourceServiceListAccessibleResources_Call) Return(_a0 *resource_service.ResourceServiceListAccessibleResourcesOK, _a1 error) *MockClientService_ResourceServiceListAccessibleResources_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_ResourceServiceListAccessibleResources_Call) RunAndReturn(run func(*resource_service.ResourceServiceListAccessibleResourcesParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) (*resource_service.ResourceServiceListAccessibleResourcesOK, error)) *MockClientService_ResourceServiceListAccessibleResources_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResourceServiceListRoles provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) ResourceServiceListRoles(params *resource_service.ResourceServiceListRolesParams, authInfo runtime.ClientAuthInfoWriter, opts ...resource_service.ClientOption) (*resource_service.ResourceServiceListRolesOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResourceServiceListRoles")
+	}
+
+	var r0 *resource_service.ResourceServiceListRolesOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*resource_service.ResourceServiceListRolesParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) (*resource_service.ResourceServiceListRolesOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*resource_service.ResourceServiceListRolesParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) *resource_service.ResourceServiceListRolesOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*resource_service.ResourceServiceListRolesOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*resource_service.ResourceServiceListRolesParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_ResourceServiceListRoles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourceServiceListRoles'
+type MockClientService_ResourceServiceListRoles_Call struct {
+	*mock.Call
+}
+
+// ResourceServiceListRoles is a helper method to define mock.On call
+//   - params *resource_service.ResourceServiceListRolesParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...resource_service.ClientOption
+func (_e *MockClientService_Expecter) ResourceServiceListRoles(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_ResourceServiceListRoles_Call {
+	return &MockClientService_ResourceServiceListRoles_Call{Call: _e.mock.On("ResourceServiceListRoles",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_ResourceServiceListRoles_Call) Run(run func(params *resource_service.ResourceServiceListRolesParams, authInfo runtime.ClientAuthInfoWriter, opts ...resource_service.ClientOption)) *MockClientService_ResourceServiceListRoles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]resource_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(resource_service.ClientOption)
+			}
+		}
+		run(args[0].(*resource_service.ResourceServiceListRolesParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_ResourceServiceListRoles_Call) Return(_a0 *resource_service.ResourceServiceListRolesOK, _a1 error) *MockClientService_ResourceServiceListRoles_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_ResourceServiceListRoles_Call) RunAndReturn(run func(*resource_service.ResourceServiceListRolesParams, runtime.ClientAuthInfoWriter, ...resource_service.ClientOption) (*resource_service.ResourceServiceListRolesOK, error)) *MockClientService_ResourceServiceListRoles_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service/mock_ClientService.go
+++ b/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service/mock_ClientService.go
@@ -1058,6 +1058,154 @@ func (_c *MockClientService_CreateMongoDBAtlasRotatingSecret_Call) RunAndReturn(
 	return _c
 }
 
+// CreatePostgresIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) CreatePostgresIntegration(params *secret_service.CreatePostgresIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreatePostgresIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreatePostgresIntegration")
+	}
+
+	var r0 *secret_service.CreatePostgresIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.CreatePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreatePostgresIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.CreatePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.CreatePostgresIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.CreatePostgresIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.CreatePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_CreatePostgresIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreatePostgresIntegration'
+type MockClientService_CreatePostgresIntegration_Call struct {
+	*mock.Call
+}
+
+// CreatePostgresIntegration is a helper method to define mock.On call
+//   - params *secret_service.CreatePostgresIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) CreatePostgresIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_CreatePostgresIntegration_Call {
+	return &MockClientService_CreatePostgresIntegration_Call{Call: _e.mock.On("CreatePostgresIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_CreatePostgresIntegration_Call) Run(run func(params *secret_service.CreatePostgresIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_CreatePostgresIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.CreatePostgresIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_CreatePostgresIntegration_Call) Return(_a0 *secret_service.CreatePostgresIntegrationOK, _a1 error) *MockClientService_CreatePostgresIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_CreatePostgresIntegration_Call) RunAndReturn(run func(*secret_service.CreatePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreatePostgresIntegrationOK, error)) *MockClientService_CreatePostgresIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreatePostgresRotatingSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) CreatePostgresRotatingSecret(params *secret_service.CreatePostgresRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreatePostgresRotatingSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreatePostgresRotatingSecret")
+	}
+
+	var r0 *secret_service.CreatePostgresRotatingSecretOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.CreatePostgresRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreatePostgresRotatingSecretOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.CreatePostgresRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.CreatePostgresRotatingSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.CreatePostgresRotatingSecretOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.CreatePostgresRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_CreatePostgresRotatingSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreatePostgresRotatingSecret'
+type MockClientService_CreatePostgresRotatingSecret_Call struct {
+	*mock.Call
+}
+
+// CreatePostgresRotatingSecret is a helper method to define mock.On call
+//   - params *secret_service.CreatePostgresRotatingSecretParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) CreatePostgresRotatingSecret(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_CreatePostgresRotatingSecret_Call {
+	return &MockClientService_CreatePostgresRotatingSecret_Call{Call: _e.mock.On("CreatePostgresRotatingSecret",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_CreatePostgresRotatingSecret_Call) Run(run func(params *secret_service.CreatePostgresRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_CreatePostgresRotatingSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.CreatePostgresRotatingSecretParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_CreatePostgresRotatingSecret_Call) Return(_a0 *secret_service.CreatePostgresRotatingSecretOK, _a1 error) *MockClientService_CreatePostgresRotatingSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_CreatePostgresRotatingSecret_Call) RunAndReturn(run func(*secret_service.CreatePostgresRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreatePostgresRotatingSecretOK, error)) *MockClientService_CreatePostgresRotatingSecret_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateSync provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) CreateSync(params *secret_service.CreateSyncParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateSyncOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -2090,6 +2238,80 @@ func (_c *MockClientService_DeleteMongoDBAtlasIntegration_Call) Return(_a0 *secr
 }
 
 func (_c *MockClientService_DeleteMongoDBAtlasIntegration_Call) RunAndReturn(run func(*secret_service.DeleteMongoDBAtlasIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.DeleteMongoDBAtlasIntegrationOK, error)) *MockClientService_DeleteMongoDBAtlasIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeletePostgresIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) DeletePostgresIntegration(params *secret_service.DeletePostgresIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.DeletePostgresIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeletePostgresIntegration")
+	}
+
+	var r0 *secret_service.DeletePostgresIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.DeletePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.DeletePostgresIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.DeletePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.DeletePostgresIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.DeletePostgresIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.DeletePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_DeletePostgresIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeletePostgresIntegration'
+type MockClientService_DeletePostgresIntegration_Call struct {
+	*mock.Call
+}
+
+// DeletePostgresIntegration is a helper method to define mock.On call
+//   - params *secret_service.DeletePostgresIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) DeletePostgresIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_DeletePostgresIntegration_Call {
+	return &MockClientService_DeletePostgresIntegration_Call{Call: _e.mock.On("DeletePostgresIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_DeletePostgresIntegration_Call) Run(run func(params *secret_service.DeletePostgresIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_DeletePostgresIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.DeletePostgresIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_DeletePostgresIntegration_Call) Return(_a0 *secret_service.DeletePostgresIntegrationOK, _a1 error) *MockClientService_DeletePostgresIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_DeletePostgresIntegration_Call) RunAndReturn(run func(*secret_service.DeletePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.DeletePostgresIntegrationOK, error)) *MockClientService_DeletePostgresIntegration_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3496,6 +3718,154 @@ func (_c *MockClientService_GetMongoDBAtlasRotatingSecretConfig_Call) Return(_a0
 }
 
 func (_c *MockClientService_GetMongoDBAtlasRotatingSecretConfig_Call) RunAndReturn(run func(*secret_service.GetMongoDBAtlasRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetMongoDBAtlasRotatingSecretConfigOK, error)) *MockClientService_GetMongoDBAtlasRotatingSecretConfig_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetPostgresIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetPostgresIntegration(params *secret_service.GetPostgresIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetPostgresIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPostgresIntegration")
+	}
+
+	var r0 *secret_service.GetPostgresIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.GetPostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetPostgresIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.GetPostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.GetPostgresIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.GetPostgresIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.GetPostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_GetPostgresIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPostgresIntegration'
+type MockClientService_GetPostgresIntegration_Call struct {
+	*mock.Call
+}
+
+// GetPostgresIntegration is a helper method to define mock.On call
+//   - params *secret_service.GetPostgresIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) GetPostgresIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_GetPostgresIntegration_Call {
+	return &MockClientService_GetPostgresIntegration_Call{Call: _e.mock.On("GetPostgresIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_GetPostgresIntegration_Call) Run(run func(params *secret_service.GetPostgresIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_GetPostgresIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.GetPostgresIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_GetPostgresIntegration_Call) Return(_a0 *secret_service.GetPostgresIntegrationOK, _a1 error) *MockClientService_GetPostgresIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_GetPostgresIntegration_Call) RunAndReturn(run func(*secret_service.GetPostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetPostgresIntegrationOK, error)) *MockClientService_GetPostgresIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetPostgresRotatingSecretConfig provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetPostgresRotatingSecretConfig(params *secret_service.GetPostgresRotatingSecretConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetPostgresRotatingSecretConfigOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPostgresRotatingSecretConfig")
+	}
+
+	var r0 *secret_service.GetPostgresRotatingSecretConfigOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.GetPostgresRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetPostgresRotatingSecretConfigOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.GetPostgresRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.GetPostgresRotatingSecretConfigOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.GetPostgresRotatingSecretConfigOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.GetPostgresRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_GetPostgresRotatingSecretConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPostgresRotatingSecretConfig'
+type MockClientService_GetPostgresRotatingSecretConfig_Call struct {
+	*mock.Call
+}
+
+// GetPostgresRotatingSecretConfig is a helper method to define mock.On call
+//   - params *secret_service.GetPostgresRotatingSecretConfigParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) GetPostgresRotatingSecretConfig(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_GetPostgresRotatingSecretConfig_Call {
+	return &MockClientService_GetPostgresRotatingSecretConfig_Call{Call: _e.mock.On("GetPostgresRotatingSecretConfig",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_GetPostgresRotatingSecretConfig_Call) Run(run func(params *secret_service.GetPostgresRotatingSecretConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_GetPostgresRotatingSecretConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.GetPostgresRotatingSecretConfigParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_GetPostgresRotatingSecretConfig_Call) Return(_a0 *secret_service.GetPostgresRotatingSecretConfigOK, _a1 error) *MockClientService_GetPostgresRotatingSecretConfig_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_GetPostgresRotatingSecretConfig_Call) RunAndReturn(run func(*secret_service.GetPostgresRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetPostgresRotatingSecretConfigOK, error)) *MockClientService_GetPostgresRotatingSecretConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4976,6 +5346,80 @@ func (_c *MockClientService_ListOpenAppSecretVersions_Call) Return(_a0 *secret_s
 }
 
 func (_c *MockClientService_ListOpenAppSecretVersions_Call) RunAndReturn(run func(*secret_service.ListOpenAppSecretVersionsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.ListOpenAppSecretVersionsOK, error)) *MockClientService_ListOpenAppSecretVersions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListPostgresIntegrations provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) ListPostgresIntegrations(params *secret_service.ListPostgresIntegrationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.ListPostgresIntegrationsOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListPostgresIntegrations")
+	}
+
+	var r0 *secret_service.ListPostgresIntegrationsOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.ListPostgresIntegrationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.ListPostgresIntegrationsOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.ListPostgresIntegrationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.ListPostgresIntegrationsOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.ListPostgresIntegrationsOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.ListPostgresIntegrationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_ListPostgresIntegrations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListPostgresIntegrations'
+type MockClientService_ListPostgresIntegrations_Call struct {
+	*mock.Call
+}
+
+// ListPostgresIntegrations is a helper method to define mock.On call
+//   - params *secret_service.ListPostgresIntegrationsParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) ListPostgresIntegrations(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_ListPostgresIntegrations_Call {
+	return &MockClientService_ListPostgresIntegrations_Call{Call: _e.mock.On("ListPostgresIntegrations",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_ListPostgresIntegrations_Call) Run(run func(params *secret_service.ListPostgresIntegrationsParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_ListPostgresIntegrations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.ListPostgresIntegrationsParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_ListPostgresIntegrations_Call) Return(_a0 *secret_service.ListPostgresIntegrationsOK, _a1 error) *MockClientService_ListPostgresIntegrations_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_ListPostgresIntegrations_Call) RunAndReturn(run func(*secret_service.ListPostgresIntegrationsParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.ListPostgresIntegrationsOK, error)) *MockClientService_ListPostgresIntegrations_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6563,6 +7007,80 @@ func (_c *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call) Return(_a0 *s
 }
 
 func (_c *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call) RunAndReturn(run func(*secret_service.UpdateMongoDBAtlasRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateMongoDBAtlasRotatingSecretOK, error)) *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdatePostgresRotatingSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdatePostgresRotatingSecret(params *secret_service.UpdatePostgresRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdatePostgresRotatingSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdatePostgresRotatingSecret")
+	}
+
+	var r0 *secret_service.UpdatePostgresRotatingSecretOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdatePostgresRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdatePostgresRotatingSecretOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdatePostgresRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdatePostgresRotatingSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdatePostgresRotatingSecretOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdatePostgresRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdatePostgresRotatingSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdatePostgresRotatingSecret'
+type MockClientService_UpdatePostgresRotatingSecret_Call struct {
+	*mock.Call
+}
+
+// UpdatePostgresRotatingSecret is a helper method to define mock.On call
+//   - params *secret_service.UpdatePostgresRotatingSecretParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdatePostgresRotatingSecret(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdatePostgresRotatingSecret_Call {
+	return &MockClientService_UpdatePostgresRotatingSecret_Call{Call: _e.mock.On("UpdatePostgresRotatingSecret",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdatePostgresRotatingSecret_Call) Run(run func(params *secret_service.UpdatePostgresRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdatePostgresRotatingSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdatePostgresRotatingSecretParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdatePostgresRotatingSecret_Call) Return(_a0 *secret_service.UpdatePostgresRotatingSecretOK, _a1 error) *MockClientService_UpdatePostgresRotatingSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdatePostgresRotatingSecret_Call) RunAndReturn(run func(*secret_service.UpdatePostgresRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdatePostgresRotatingSecretOK, error)) *MockClientService_UpdatePostgresRotatingSecret_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service/mock_ClientService.go
+++ b/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service/mock_ClientService.go
@@ -7011,6 +7011,80 @@ func (_c *MockClientService_UpdateMongoDBAtlasRotatingSecret_Call) RunAndReturn(
 	return _c
 }
 
+// UpdatePostgresIntegration provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdatePostgresIntegration(params *secret_service.UpdatePostgresIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdatePostgresIntegrationOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdatePostgresIntegration")
+	}
+
+	var r0 *secret_service.UpdatePostgresIntegrationOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdatePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdatePostgresIntegrationOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdatePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdatePostgresIntegrationOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdatePostgresIntegrationOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdatePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdatePostgresIntegration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdatePostgresIntegration'
+type MockClientService_UpdatePostgresIntegration_Call struct {
+	*mock.Call
+}
+
+// UpdatePostgresIntegration is a helper method to define mock.On call
+//   - params *secret_service.UpdatePostgresIntegrationParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdatePostgresIntegration(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdatePostgresIntegration_Call {
+	return &MockClientService_UpdatePostgresIntegration_Call{Call: _e.mock.On("UpdatePostgresIntegration",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdatePostgresIntegration_Call) Run(run func(params *secret_service.UpdatePostgresIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdatePostgresIntegration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdatePostgresIntegrationParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdatePostgresIntegration_Call) Return(_a0 *secret_service.UpdatePostgresIntegrationOK, _a1 error) *MockClientService_UpdatePostgresIntegration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdatePostgresIntegration_Call) RunAndReturn(run func(*secret_service.UpdatePostgresIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdatePostgresIntegrationOK, error)) *MockClientService_UpdatePostgresIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdatePostgresRotatingSecret provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) UpdatePostgresRotatingSecret(params *secret_service.UpdatePostgresRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdatePostgresRotatingSecretOK, error) {
 	_va := make([]interface{}, len(opts))


### PR DESCRIPTION
### Changes proposed in this PR:

Adds support for creating postgres rotating secrets.

### How I've tested this PR:

### How I expect reviewers to test this PR:


<!-- If you are adding a new command or editing an existing one, please provide
     an example of the command being invoked.
### Output of affected commands:
-->

### Checklist:
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
