### PR TITLE
[HCP Vault Secrets] Print out Gateway Pool Resource ID for gateway commands

### DIFF
--- a/.changelog/195.txt
+++ b/.changelog/195.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+vault-secrets: adding Gateway Pool Resource ID to the output of gateway commands.
+```

--- a/internal/commands/vaultsecrets/gatewaypools/create.go
+++ b/internal/commands/vaultsecrets/gatewaypools/create.go
@@ -122,6 +122,10 @@ func createFields(showOauth bool) []format.Field {
 			ValueFormat: "{{ .GatewayPool.Name }}",
 		},
 		{
+			Name:        "Gateway Pool Resource Name",
+			ValueFormat: "{{ .GatewayPool.ResourceName }}",
+		},
+		{
 			Name:        "Gateway Pool Resource ID",
 			ValueFormat: "{{ .GatewayPool.ResourceID }}",
 		},

--- a/internal/commands/vaultsecrets/gatewaypools/create.go
+++ b/internal/commands/vaultsecrets/gatewaypools/create.go
@@ -118,16 +118,16 @@ func NewCmdCreate(ctx *cmd.Context, runF func(*CreateOpts) error) *cmd.Command {
 func createFields(showOauth bool) []format.Field {
 	fields := []format.Field{
 		{
-			Name:        "GatewayPool Name",
+			Name:        "Gateway Pool Name",
 			ValueFormat: "{{ .GatewayPool.Name }}",
+		},
+		{
+			Name:        "Gateway Pool Resource ID",
+			ValueFormat: "{{ .GatewayPool.ResourceId }}",
 		},
 		{
 			Name:        "Description",
 			ValueFormat: "{{ .GatewayPool.Description }}",
-		},
-		{
-			Name:        "Resource Name",
-			ValueFormat: "{{ .GatewayPool.ResourceName }}",
 		},
 	}
 
@@ -143,6 +143,7 @@ func createFields(showOauth bool) []format.Field {
 			},
 		}...)
 	}
+
 	return fields
 }
 
@@ -164,7 +165,6 @@ func createRun(opts *CreateOpts) error {
 			Description: opts.Description,
 		},
 	}, nil)
-
 	if err != nil {
 		return fmt.Errorf("failed to create gateway pool: %w", err)
 	}

--- a/internal/commands/vaultsecrets/gatewaypools/create.go
+++ b/internal/commands/vaultsecrets/gatewaypools/create.go
@@ -175,11 +175,9 @@ func createRun(opts *CreateOpts) error {
 	}
 	if opts.OutDirPath != "" {
 		creds := &gatewayCreds{
-			ProjectID:    resp.Payload.GatewayPool.ProjectID,
-			ResourceName: resp.Payload.GatewayPool.ResourceName,
-			ResourceID:   resp.Payload.GatewayPool.ResourceID,
-			Scheme:       auth.CredentialFileSchemeServicePrincipal,
-			Oauth:        oauth,
+			ProjectID: resp.Payload.GatewayPool.ProjectID,
+			Scheme:    auth.CredentialFileSchemeServicePrincipal,
+			Oauth:     oauth,
 		}
 		if err := writeGatewayCredentialFile(filepath.Join(opts.OutDirPath, CredsFilePath), creds); err != nil {
 			return fmt.Errorf("failed to write the gateway credential file: %w", err)
@@ -207,9 +205,8 @@ func createRun(opts *CreateOpts) error {
 }
 
 type gatewayCreds struct {
-	ProjectID    string `json:"project_id,omitempty"`
-	ResourceName string `json:"resource_name,omitempty"`
-	ResourceID   string `json:"resource_id,omitempty"`
+	ProjectID string `json:"project_id,omitempty"`
+
 	// Scheme is the authentication scheme which is service_principal_creds
 	Scheme string `json:"scheme,omitempty"`
 

--- a/internal/commands/vaultsecrets/gatewaypools/create.go
+++ b/internal/commands/vaultsecrets/gatewaypools/create.go
@@ -123,7 +123,7 @@ func createFields(showOauth bool) []format.Field {
 		},
 		{
 			Name:        "Gateway Pool Resource ID",
-			ValueFormat: "{{ .GatewayPool.ResourceId }}",
+			ValueFormat: "{{ .GatewayPool.ResourceID }}",
 		},
 		{
 			Name:        "Description",
@@ -175,9 +175,11 @@ func createRun(opts *CreateOpts) error {
 	}
 	if opts.OutDirPath != "" {
 		creds := &gatewayCreds{
-			ProjectID: resp.Payload.GatewayPool.ProjectID,
-			Scheme:    auth.CredentialFileSchemeServicePrincipal,
-			Oauth:     oauth,
+			ProjectID:    resp.Payload.GatewayPool.ProjectID,
+			ResourceName: resp.Payload.GatewayPool.ResourceName,
+			ResourceID:   resp.Payload.GatewayPool.ResourceID,
+			Scheme:       auth.CredentialFileSchemeServicePrincipal,
+			Oauth:        oauth,
 		}
 		if err := writeGatewayCredentialFile(filepath.Join(opts.OutDirPath, CredsFilePath), creds); err != nil {
 			return fmt.Errorf("failed to write the gateway credential file: %w", err)
@@ -207,6 +209,7 @@ func createRun(opts *CreateOpts) error {
 type gatewayCreds struct {
 	ProjectID    string `json:"project_id,omitempty"`
 	ResourceName string `json:"resource_name,omitempty"`
+	ResourceID   string `json:"resource_id,omitempty"`
 	// Scheme is the authentication scheme which is service_principal_creds
 	Scheme string `json:"scheme,omitempty"`
 

--- a/internal/commands/vaultsecrets/gatewaypools/list.go
+++ b/internal/commands/vaultsecrets/gatewaypools/list.go
@@ -65,7 +65,7 @@ func listFields() []format.Field {
 		},
 		{
 			Name:        "Gateway Pool Resource ID",
-			ValueFormat: "{{ .ResourceId }}",
+			ValueFormat: "{{ .ResourceID }}",
 		},
 		{
 			Name:        "Description",

--- a/internal/commands/vaultsecrets/gatewaypools/list.go
+++ b/internal/commands/vaultsecrets/gatewaypools/list.go
@@ -64,6 +64,10 @@ func listFields() []format.Field {
 			ValueFormat: "{{ .Name }}",
 		},
 		{
+			Name:        "Gateway Pool Resource Name",
+			ValueFormat: "{{ .ResourceName }}",
+		},
+		{
 			Name:        "Gateway Pool Resource ID",
 			ValueFormat: "{{ .ResourceID }}",
 		},

--- a/internal/commands/vaultsecrets/gatewaypools/list.go
+++ b/internal/commands/vaultsecrets/gatewaypools/list.go
@@ -60,8 +60,12 @@ func NewCmdList(ctx *cmd.Context, runF func(*ListOpts) error) *cmd.Command {
 func listFields() []format.Field {
 	return []format.Field{
 		{
-			Name:        "GatewayPool Name",
+			Name:        "Gateway Pool Name",
 			ValueFormat: "{{ .Name }}",
+		},
+		{
+			Name:        "Gateway Pool Resource ID",
+			ValueFormat: "{{ .ResourceId }}",
 		},
 		{
 			Name:        "Description",

--- a/internal/commands/vaultsecrets/gatewaypools/read.go
+++ b/internal/commands/vaultsecrets/gatewaypools/read.go
@@ -78,7 +78,7 @@ func readFields() []format.Field {
 		},
 		{
 			Name:        "Gateway Pool Resource ID",
-			ValueFormat: "{{ .GatewayPool.ResourceId }}",
+			ValueFormat: "{{ .GatewayPool.ResourceID }}",
 		},
 		{
 			Name:        "Description",

--- a/internal/commands/vaultsecrets/gatewaypools/read.go
+++ b/internal/commands/vaultsecrets/gatewaypools/read.go
@@ -73,8 +73,12 @@ func NewCmdRead(ctx *cmd.Context, runF func(*ReadOpts) error) *cmd.Command {
 func readFields() []format.Field {
 	return []format.Field{
 		{
-			Name:        "GatewayPool Name",
+			Name:        "Gateway Pool Name",
 			ValueFormat: "{{ .GatewayPool.Name }}",
+		},
+		{
+			Name:        "Gateway Pool Resource ID",
+			ValueFormat: "{{ .GatewayPool.ResourceId }}",
 		},
 		{
 			Name:        "Description",
@@ -94,7 +98,6 @@ func readRun(opts *ReadOpts) error {
 		OrganizationID:  opts.Profile.OrganizationID,
 		GatewayPoolName: opts.GatewayPoolName,
 	}, nil)
-
 	if err != nil {
 		return fmt.Errorf("failed to read gateway pool: %w", err)
 	}

--- a/internal/commands/vaultsecrets/gatewaypools/read.go
+++ b/internal/commands/vaultsecrets/gatewaypools/read.go
@@ -77,6 +77,10 @@ func readFields() []format.Field {
 			ValueFormat: "{{ .GatewayPool.Name }}",
 		},
 		{
+			Name:        "Gateway Pool Resource Name",
+			ValueFormat: "{{ .GatewayPool.ResourceName }}",
+		},
+		{
 			Name:        "Gateway Pool Resource ID",
 			ValueFormat: "{{ .GatewayPool.ResourceID }}",
 		},

--- a/internal/commands/vaultsecrets/gatewaypools/read.go
+++ b/internal/commands/vaultsecrets/gatewaypools/read.go
@@ -85,12 +85,12 @@ func readFields() []format.Field {
 			ValueFormat: "{{ .GatewayPool.ResourceID }}",
 		},
 		{
-			Name:        "Description",
-			ValueFormat: "{{ .GatewayPool.Description }}",
-		},
-		{
 			Name:        "Integrations",
 			ValueFormat: "{{ .Integrations }}",
+		},
+		{
+			Name:        "Description",
+			ValueFormat: "{{ .GatewayPool.Description }}",
 		},
 	}
 }


### PR DESCRIPTION
### :hammer_and_wrench:  Description

Gateway Pool Resource ID is needed when creating new gateway integrations. This PR exposes the ID on create / read /list as well as writes it into the `creds.json` file.

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->

### :building_construction:  Local Testing

#### Create

```sh
> ./bin/hcp vs gateway-pools create foo --output-dir=gw                                      
Gateway Pool Name:          foo
Gateway Pool Resource Name: secrets/project/ad203a6b-b390-46a5-b9b7-98d192be2159/gateway-pool/foo
Gateway Pool Resource ID:   774e045f-60f7-4cd9-b550-470c41498553
Description:

> cat gw/creds.json
{
  "project_id": "ad203a6b-b390-46a5-b9b7-98d192be2159",
  "scheme": "service_principal_creds",
  "oauth": {
    "client_id": "...",
    "client_secret": "..."
  }
}
```

#### Read

```sh
> ./bin/hcp vs gateway-pools read foo
Gateway Pool Name   Gateway Pool Resource Name                                              Gateway Pool Resource ID               Integrations   Description
foo                 secrets/project/ad203a6b-b390-46a5-b9b7-98d192be2159/gateway-pool/foo   774e045f-60f7-4cd9-b550-470c41498553   []
                                                                                            
```

#### List

```sh
> ./bin/hcp vs gateway-pools list
Gateway Pool Name   Gateway Pool Resource Name                                              Gateway Pool Resource ID               Description
foo                 secrets/project/ad203a6b-b390-46a5-b9b7-98d192be2159/gateway-pool/foo   774e045f-60f7-4cd9-b550-470c41498553

```


### :+1:  Checklist

- [ ] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
