### PR TITLE
Create Waypoint resources with module ID

### DIFF
--- a/.changelog/198.txt
+++ b/.changelog/198.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+waypoint: Require no-code module ID for creating templates and add-on defintiions.
+```

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl/v2 v2.23.0
-	github.com/hashicorp/hcp-sdk-go v0.123.0
+	github.com/hashicorp/hcp-sdk-go v0.125.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/cli v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/hcp-sdk-go v0.123.0 h1:kUf/kSCVkQ4XXyny8GUyUWjvIIIanGRRkhRmgj2lC+4=
-github.com/hashicorp/hcp-sdk-go v0.123.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.125.0 h1:pak7lGeNmoQTR5Dkx+CxYF6xLjn1UJ4XPg43ldyle+Y=
+github.com/hashicorp/hcp-sdk-go v0.125.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=

--- a/internal/commands/waypoint/add-ons/definitions/add_on_definition.go
+++ b/internal/commands/waypoint/add-ons/definitions/add_on_definition.go
@@ -23,6 +23,7 @@ type AddOnDefinitionOpts struct {
 	TerraformCloudProjectID     string
 	TerraformExecutionMode      string
 	TerraformAgentPoolID        string
+	TerraformNoCodeModuleID     string
 
 	VariableOptionsFile string
 

--- a/internal/commands/waypoint/add-ons/definitions/create.go
+++ b/internal/commands/waypoint/add-ons/definitions/create.go
@@ -33,6 +33,7 @@ $ hcp waypoint add-ons definitions create -n=my-add-on-definition \
   -d="My Add-on Definition description." \
   --readme-markdown-template-file="README.tpl" \
   --tfc-no-code-module-source="app.terraform.io/hashicorp/dir/template" \
+  --tf-no-code-module-id="nocode-123456" \
   --tfc-project-name="my-tfc-project" \
   --tfc-project-id="prj-123456" \
   -l=label1 \

--- a/internal/commands/waypoint/add-ons/definitions/create.go
+++ b/internal/commands/waypoint/add-ons/definitions/create.go
@@ -135,6 +135,15 @@ $ hcp waypoint add-ons definitions create -n=my-add-on-definition \
 						"when the execution mode is set to 'agent'.",
 					Value: flagvalue.Simple("", &opts.TerraformAgentPoolID),
 				},
+				{
+					Name:         "tf-no-code-module-id",
+					DisplayValue: "TF_NO_CODE_MODULE_ID",
+					Description: "The ID of the Terraform no-code module to use for " +
+						"running Terraform operations. This is in the format " +
+						"of 'nocode-<ID>'.",
+					Value:    flagvalue.Simple("", &opts.TerraformNoCodeModuleID),
+					Required: true,
+				},
 			},
 		},
 	}
@@ -174,17 +183,20 @@ func addOnDefinitionCreate(opts *AddOnDefinitionOpts) error {
 		&waypoint_service.WaypointServiceCreateAddOnDefinitionParams{
 			NamespaceID: ns.ID,
 			Body: &models.HashicorpCloudWaypointWaypointServiceCreateAddOnDefinitionBody{
-				Name:                   opts.Name,
-				Summary:                opts.Summary,
-				Description:            opts.Description,
-				ReadmeMarkdownTemplate: readmeTpl,
-				Labels:                 opts.Labels,
-				TerraformCloudWorkspaceDetails: &models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
-					Name:      opts.TerraformCloudProjectName,
-					ProjectID: opts.TerraformCloudProjectID,
+				AddOnDefinition: &models.HashicorpCloudWaypointAddOnDefinition{
+					Name:                   opts.Name,
+					Summary:                opts.Summary,
+					Description:            opts.Description,
+					ReadmeMarkdownTemplate: readmeTpl,
+					Labels:                 opts.Labels,
+					TerraformCloudWorkspaceDetails: &models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+						Name:      opts.TerraformCloudProjectName,
+						ProjectID: opts.TerraformCloudProjectID,
+					},
+					ModuleSource:    opts.TerraformNoCodeModuleSource,
+					VariableOptions: variables,
+					ModuleID:        opts.TerraformNoCodeModuleID,
 				},
-				ModuleSource:    opts.TerraformNoCodeModuleSource,
-				VariableOptions: variables,
 			},
 			Context: opts.Ctx,
 		}, nil)

--- a/internal/commands/waypoint/add-ons/definitions/create_test.go
+++ b/internal/commands/waypoint/add-ons/definitions/create_test.go
@@ -56,6 +56,7 @@ func TestCmdAddOnDefinitionCreate(t *testing.T) {
 				"--tf-execution-mode", "agent",
 				"--tf-agent-pool-id", "pool-abc123",
 				"--variable-options-file", "vars.hcl",
+				"--tf-no-code-module-id", "nocode-abc123",
 			},
 			Expect: &AddOnDefinitionOpts{
 				Name:                        "cli-test",
@@ -69,6 +70,7 @@ func TestCmdAddOnDefinitionCreate(t *testing.T) {
 				TerraformExecutionMode:      "agent",
 				TerraformAgentPoolID:        "pool-abc123",
 				VariableOptionsFile:         "vars.hcl",
+				TerraformNoCodeModuleID:     "nocode-abc123",
 			},
 		},
 	}

--- a/internal/commands/waypoint/add-ons/definitions/read.go
+++ b/internal/commands/waypoint/add-ons/definitions/read.go
@@ -100,6 +100,7 @@ func addOnDefinitionRead(opts *AddOnDefinitionOpts) error {
 		format.NewField("Execution Mode", "{{ .TfExecutionMode }}"),
 		format.NewField("Agent Pool ID", "{{ .TfAgentPoolID }}"),
 		format.NewField("Variable Options", optionNamesStr),
+		format.NewField("Terraform No-code Module ID", "{{ .ModuleID }}"),
 	}
 
 	return opts.Output.Display(format.NewDisplayer(addOnDef, format.Pretty, fields))

--- a/internal/commands/waypoint/add-ons/definitions/update.go
+++ b/internal/commands/waypoint/add-ons/definitions/update.go
@@ -162,17 +162,19 @@ func addOnDefinitionUpdate(opts *AddOnDefinitionOpts) error {
 			Context:                     opts.Ctx,
 			ExistingAddOnDefinitionName: opts.Name,
 			Body: &models.HashicorpCloudWaypointWaypointServiceUpdateAddOnDefinitionBody{
-				Summary:                opts.Summary,
-				Description:            opts.Description,
-				ReadmeMarkdownTemplate: readmeTpl,
-				Labels:                 opts.Labels,
-				TerraformCloudWorkspaceDetails: &models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
-					ProjectID: opts.TerraformCloudProjectID,
-					Name:      opts.TerraformCloudProjectName,
+				AddOnDefinition: &models.HashicorpCloudWaypointAddOnDefinition{
+					Summary:                opts.Summary,
+					Description:            opts.Description,
+					ReadmeMarkdownTemplate: readmeTpl,
+					Labels:                 opts.Labels,
+					TerraformCloudWorkspaceDetails: &models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+						ProjectID: opts.TerraformCloudProjectID,
+						Name:      opts.TerraformCloudProjectName,
+					},
+					TfExecutionMode: opts.TerraformExecutionMode,
+					TfAgentPoolID:   opts.TerraformAgentPoolID,
+					VariableOptions: variables,
 				},
-				TfExecutionMode: opts.TerraformExecutionMode,
-				TfAgentPoolID:   opts.TerraformAgentPoolID,
-				VariableOptions: variables,
 			},
 		}, nil,
 	)

--- a/internal/commands/waypoint/templates/create.go
+++ b/internal/commands/waypoint/templates/create.go
@@ -33,6 +33,7 @@ $ hcp waypoint templates create -n=my-template \
   -d="My Template Description" \
   --readme-markdown-template-file "README.tpl" \
   --tfc-no-code-module-source="app.terraform.io/hashicorp/dir/template" \
+  --tf-no-code-module-id="nocode-123456" \
   --tfc-project-name="my-tfc-project" \
   --tfc-project-id="prj-123456" \
   -l="label1" \

--- a/internal/commands/waypoint/templates/create.go
+++ b/internal/commands/waypoint/templates/create.go
@@ -146,6 +146,15 @@ $ hcp waypoint templates create -n=my-template \
 						"when the execution mode is set to 'agent'.",
 					Value: flagvalue.Simple("", &opts.TerraformAgentPoolID),
 				},
+				{
+					Name:         "tf-no-code-module-id",
+					DisplayValue: "TF_NO_CODE_MODULE_ID",
+					Description: "The ID of the Terraform no-code module to use for " +
+						"running Terraform operations. This is in the format " +
+						"of 'nocode-<ID>'.",
+					Value:    flagvalue.Simple("", &opts.TerraformNoCodeModuleID),
+					Required: true,
+				},
 			},
 		},
 	}
@@ -209,6 +218,7 @@ func templateCreate(opts *TemplateOpts) error {
 					VariableOptions: variables,
 					TfExecutionMode: opts.TerraformExecutionMode,
 					TfAgentPoolID:   opts.TerraformAgentPoolID,
+					ModuleID:        opts.TerraformNoCodeModuleID,
 				},
 			},
 			Context: opts.Ctx,

--- a/internal/commands/waypoint/templates/create_test.go
+++ b/internal/commands/waypoint/templates/create_test.go
@@ -56,6 +56,7 @@ func TestCmdTemplateCreate(t *testing.T) {
 				"--readme-markdown-template-file", "readme_test.txt",
 				"--tf-execution-mode", "agent",
 				"--tf-agent-pool-id", "pool-abc123",
+				"--tf-no-code-module-id", "nocode-abc123",
 			},
 			Expect: &TemplateOpts{
 				Name:                        "cli-test",
@@ -69,6 +70,7 @@ func TestCmdTemplateCreate(t *testing.T) {
 				Tags:                        map[string]string{"cli": "true"},
 				TerraformExecutionMode:      "agent",
 				TerraformAgentPoolID:        "pool-abc123",
+				TerraformNoCodeModuleID:     "nocode-abc123",
 			},
 		},
 		{
@@ -87,6 +89,7 @@ func TestCmdTemplateCreate(t *testing.T) {
 				"-l", "cli",
 				"-t", "cli=true",
 				"--variable-options-file", "variable_options.hcl",
+				"--tf-no-code-module-id", "nocode-abc123",
 			},
 			Expect: &TemplateOpts{
 				Name:                        "cli-test",
@@ -99,6 +102,7 @@ func TestCmdTemplateCreate(t *testing.T) {
 				VariableOptionsFile:         "variable_options.hcl",
 				Labels:                      []string{"cli"},
 				Tags:                        map[string]string{"cli": "true"},
+				TerraformNoCodeModuleID:     "nocode-abc123",
 			},
 		},
 	}
@@ -142,6 +146,7 @@ func TestCmdTemplateCreate(t *testing.T) {
 				r.Equal(c.Expect.VariableOptionsFile, tplOpts.VariableOptionsFile)
 				r.Equal(c.Expect.Labels, tplOpts.Labels)
 				r.Equal(c.Expect.Tags, tplOpts.Tags)
+				r.Equal(c.Expect.TerraformNoCodeModuleID, tplOpts.TerraformNoCodeModuleID)
 			}
 		})
 	}

--- a/internal/commands/waypoint/templates/read.go
+++ b/internal/commands/waypoint/templates/read.go
@@ -101,10 +101,11 @@ func templateRead(opts *TemplateOpts) error {
 		format.NewField("Labels", "{{ .Labels }}"),
 		format.NewField("Readme Template", "{{ .ReadmeTemplate }}"),
 		format.NewField("Tags", "{{ .Tags}}"),
-		format.NewField("Terraform Nocode Source", "{{ .ModuleSource}}"),
+		format.NewField("Terraform No-Code Module Source", "{{ .ModuleSource}}"),
 		format.NewField("Execution Mode", "{{ .TfExecutionMode}}"),
 		format.NewField("Agent Pool ID", "{{ .TfAgentPoolID}}"),
 		format.NewField("Variable Options", optionNamesStr),
+		format.NewField("Terraform No-code Module ID", "{{ .ModuleID }}"),
 	}
 
 	// Display the created project

--- a/internal/commands/waypoint/templates/template.go
+++ b/internal/commands/waypoint/templates/template.go
@@ -32,6 +32,7 @@ type TemplateOpts struct {
 	TerraformCloudProjectID     string
 	TerraformExecutionMode      string
 	TerraformAgentPoolID        string
+	TerraformNoCodeModuleID     string
 
 	VariableOptionsFile string
 

--- a/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service/mock_ClientService.go
+++ b/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service/mock_ClientService.go
@@ -392,6 +392,80 @@ func (_c *MockClientService_CreateAwsIntegration_Call) RunAndReturn(run func(*se
 	return _c
 }
 
+// CreateAzureApplicationPasswordRotatingSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) CreateAzureApplicationPasswordRotatingSecret(params *secret_service.CreateAzureApplicationPasswordRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateAzureApplicationPasswordRotatingSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAzureApplicationPasswordRotatingSecret")
+	}
+
+	var r0 *secret_service.CreateAzureApplicationPasswordRotatingSecretOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateAzureApplicationPasswordRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateAzureApplicationPasswordRotatingSecretOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.CreateAzureApplicationPasswordRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.CreateAzureApplicationPasswordRotatingSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.CreateAzureApplicationPasswordRotatingSecretOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.CreateAzureApplicationPasswordRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_CreateAzureApplicationPasswordRotatingSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAzureApplicationPasswordRotatingSecret'
+type MockClientService_CreateAzureApplicationPasswordRotatingSecret_Call struct {
+	*mock.Call
+}
+
+// CreateAzureApplicationPasswordRotatingSecret is a helper method to define mock.On call
+//   - params *secret_service.CreateAzureApplicationPasswordRotatingSecretParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) CreateAzureApplicationPasswordRotatingSecret(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_CreateAzureApplicationPasswordRotatingSecret_Call {
+	return &MockClientService_CreateAzureApplicationPasswordRotatingSecret_Call{Call: _e.mock.On("CreateAzureApplicationPasswordRotatingSecret",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_CreateAzureApplicationPasswordRotatingSecret_Call) Run(run func(params *secret_service.CreateAzureApplicationPasswordRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_CreateAzureApplicationPasswordRotatingSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.CreateAzureApplicationPasswordRotatingSecretParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_CreateAzureApplicationPasswordRotatingSecret_Call) Return(_a0 *secret_service.CreateAzureApplicationPasswordRotatingSecretOK, _a1 error) *MockClientService_CreateAzureApplicationPasswordRotatingSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_CreateAzureApplicationPasswordRotatingSecret_Call) RunAndReturn(run func(*secret_service.CreateAzureApplicationPasswordRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.CreateAzureApplicationPasswordRotatingSecretOK, error)) *MockClientService_CreateAzureApplicationPasswordRotatingSecret_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateAzureIntegration provides a mock function with given fields: params, authInfo, opts
 func (_m *MockClientService) CreateAzureIntegration(params *secret_service.CreateAzureIntegrationParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.CreateAzureIntegrationOK, error) {
 	_va := make([]interface{}, len(opts))
@@ -3126,6 +3200,80 @@ func (_c *MockClientService_GetAwsIntegration_Call) Return(_a0 *secret_service.G
 }
 
 func (_c *MockClientService_GetAwsIntegration_Call) RunAndReturn(run func(*secret_service.GetAwsIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetAwsIntegrationOK, error)) *MockClientService_GetAwsIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAzureApplicationPasswordRotatingSecretConfig provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) GetAzureApplicationPasswordRotatingSecretConfig(params *secret_service.GetAzureApplicationPasswordRotatingSecretConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.GetAzureApplicationPasswordRotatingSecretConfigOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAzureApplicationPasswordRotatingSecretConfig")
+	}
+
+	var r0 *secret_service.GetAzureApplicationPasswordRotatingSecretConfigOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.GetAzureApplicationPasswordRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetAzureApplicationPasswordRotatingSecretConfigOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.GetAzureApplicationPasswordRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.GetAzureApplicationPasswordRotatingSecretConfigOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.GetAzureApplicationPasswordRotatingSecretConfigOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.GetAzureApplicationPasswordRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_GetAzureApplicationPasswordRotatingSecretConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAzureApplicationPasswordRotatingSecretConfig'
+type MockClientService_GetAzureApplicationPasswordRotatingSecretConfig_Call struct {
+	*mock.Call
+}
+
+// GetAzureApplicationPasswordRotatingSecretConfig is a helper method to define mock.On call
+//   - params *secret_service.GetAzureApplicationPasswordRotatingSecretConfigParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) GetAzureApplicationPasswordRotatingSecretConfig(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_GetAzureApplicationPasswordRotatingSecretConfig_Call {
+	return &MockClientService_GetAzureApplicationPasswordRotatingSecretConfig_Call{Call: _e.mock.On("GetAzureApplicationPasswordRotatingSecretConfig",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_GetAzureApplicationPasswordRotatingSecretConfig_Call) Run(run func(params *secret_service.GetAzureApplicationPasswordRotatingSecretConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_GetAzureApplicationPasswordRotatingSecretConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.GetAzureApplicationPasswordRotatingSecretConfigParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_GetAzureApplicationPasswordRotatingSecretConfig_Call) Return(_a0 *secret_service.GetAzureApplicationPasswordRotatingSecretConfigOK, _a1 error) *MockClientService_GetAzureApplicationPasswordRotatingSecretConfig_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_GetAzureApplicationPasswordRotatingSecretConfig_Call) RunAndReturn(run func(*secret_service.GetAzureApplicationPasswordRotatingSecretConfigParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.GetAzureApplicationPasswordRotatingSecretConfigOK, error)) *MockClientService_GetAzureApplicationPasswordRotatingSecretConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6711,6 +6859,80 @@ func (_c *MockClientService_UpdateAwsIntegration_Call) Return(_a0 *secret_servic
 }
 
 func (_c *MockClientService_UpdateAwsIntegration_Call) RunAndReturn(run func(*secret_service.UpdateAwsIntegrationParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateAwsIntegrationOK, error)) *MockClientService_UpdateAwsIntegration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateAzureApplicationPasswordRotatingSecret provides a mock function with given fields: params, authInfo, opts
+func (_m *MockClientService) UpdateAzureApplicationPasswordRotatingSecret(params *secret_service.UpdateAzureApplicationPasswordRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption) (*secret_service.UpdateAzureApplicationPasswordRotatingSecretOK, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, params, authInfo)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateAzureApplicationPasswordRotatingSecret")
+	}
+
+	var r0 *secret_service.UpdateAzureApplicationPasswordRotatingSecretOK
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateAzureApplicationPasswordRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateAzureApplicationPasswordRotatingSecretOK, error)); ok {
+		return rf(params, authInfo, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(*secret_service.UpdateAzureApplicationPasswordRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) *secret_service.UpdateAzureApplicationPasswordRotatingSecretOK); ok {
+		r0 = rf(params, authInfo, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*secret_service.UpdateAzureApplicationPasswordRotatingSecretOK)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*secret_service.UpdateAzureApplicationPasswordRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) error); ok {
+		r1 = rf(params, authInfo, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClientService_UpdateAzureApplicationPasswordRotatingSecret_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateAzureApplicationPasswordRotatingSecret'
+type MockClientService_UpdateAzureApplicationPasswordRotatingSecret_Call struct {
+	*mock.Call
+}
+
+// UpdateAzureApplicationPasswordRotatingSecret is a helper method to define mock.On call
+//   - params *secret_service.UpdateAzureApplicationPasswordRotatingSecretParams
+//   - authInfo runtime.ClientAuthInfoWriter
+//   - opts ...secret_service.ClientOption
+func (_e *MockClientService_Expecter) UpdateAzureApplicationPasswordRotatingSecret(params interface{}, authInfo interface{}, opts ...interface{}) *MockClientService_UpdateAzureApplicationPasswordRotatingSecret_Call {
+	return &MockClientService_UpdateAzureApplicationPasswordRotatingSecret_Call{Call: _e.mock.On("UpdateAzureApplicationPasswordRotatingSecret",
+		append([]interface{}{params, authInfo}, opts...)...)}
+}
+
+func (_c *MockClientService_UpdateAzureApplicationPasswordRotatingSecret_Call) Run(run func(params *secret_service.UpdateAzureApplicationPasswordRotatingSecretParams, authInfo runtime.ClientAuthInfoWriter, opts ...secret_service.ClientOption)) *MockClientService_UpdateAzureApplicationPasswordRotatingSecret_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]secret_service.ClientOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(secret_service.ClientOption)
+			}
+		}
+		run(args[0].(*secret_service.UpdateAzureApplicationPasswordRotatingSecretParams), args[1].(runtime.ClientAuthInfoWriter), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClientService_UpdateAzureApplicationPasswordRotatingSecret_Call) Return(_a0 *secret_service.UpdateAzureApplicationPasswordRotatingSecretOK, _a1 error) *MockClientService_UpdateAzureApplicationPasswordRotatingSecret_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClientService_UpdateAzureApplicationPasswordRotatingSecret_Call) RunAndReturn(run func(*secret_service.UpdateAzureApplicationPasswordRotatingSecretParams, runtime.ClientAuthInfoWriter, ...secret_service.ClientOption) (*secret_service.UpdateAzureApplicationPasswordRotatingSecretOK, error)) *MockClientService_UpdateAzureApplicationPasswordRotatingSecret_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
BREAKING CHANGE: The no-code module ID is required when creating a template or add-on definition for Waypoint.

### :hammer_and_wrench:  Description

<!-- What changed?
<!-- Why was it changed? -->
<!-- How does it affect end-user behavior? -->

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->

### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [x] The PR has a descriptive title.
- [x] Input validation updated
- [x] Unit tests updated
- [x] Documentation updated
- [x] Major architecture changes have a corresponding RFC
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
