### PR TITLE
add json tags to vs gateway pool display

### DIFF
--- a/.changelog/201.txt
+++ b/.changelog/201.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault-secrets: corrected json output for gateways, GatewayPool -> gateway_pool
+```

--- a/internal/commands/vaultsecrets/gatewaypools/displayer.go
+++ b/internal/commands/vaultsecrets/gatewaypools/displayer.go
@@ -11,7 +11,7 @@ import (
 
 type gatewayPoolWithIntegrations struct {
 	GatewayPool  *preview_models.Secrets20231128GatewayPool `json:"gateway_pool"`
-	Integrations []string                                   `json:"integrations"`
+	Integrations []string                                   `json:"integrations,omitempty"`
 }
 
 type gatewayPoolWithOauth struct {

--- a/internal/commands/vaultsecrets/gatewaypools/displayer.go
+++ b/internal/commands/vaultsecrets/gatewaypools/displayer.go
@@ -10,13 +10,13 @@ import (
 )
 
 type gatewayPoolWithIntegrations struct {
-	GatewayPool  *preview_models.Secrets20231128GatewayPool
-	Integrations []string
+	GatewayPool  *preview_models.Secrets20231128GatewayPool `json:"gateway_pool"`
+	Integrations []string                                   `json:"integrations"`
 }
 
 type gatewayPoolWithOauth struct {
-	GatewayPool *preview_models.Secrets20231128GatewayPool
-	Oauth       *auth.OauthConfig
+	GatewayPool *preview_models.Secrets20231128GatewayPool `json:"gateway_pool"`
+	Oauth       *auth.OauthConfig                          `json:"oauth,omitempty"`
 }
 
 type displayer struct {


### PR DESCRIPTION
### :hammer_and_wrench:  Description

<!-- What changed?
<!-- Why was it changed? -->
<!-- How does it affect end-user behavior? -->
adds json tags for json output
we encountered a bug expected `gateway_pool` and got `GatewayPool`

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->

### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [ ] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
