### PR TITLE
Failure to create a postgres integration should not be labelled as a mongodb error

### DIFF
--- a/internal/commands/vaultsecrets/integrations/create.go
+++ b/internal/commands/vaultsecrets/integrations/create.go
@@ -271,7 +271,7 @@ func createRun(opts *CreateOpts) error {
 
 		_, err = opts.Client.CreatePostgresIntegration(req, nil)
 		if err != nil {
-			return fmt.Errorf("failed to create MongoDB Atlas integration: %w", err)
+			return fmt.Errorf("failed to create Postgres integration: %w", err)
 		}
 
 	default:


### PR DESCRIPTION
### :hammer_and_wrench:  Description

<!-- What changed?
<!-- Why was it changed? -->
<!-- How does it affect end-user behavior? -->

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->

### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [ ] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
