### PR TITLE
Update Waypoint client for several command groups

### DIFF
--- a/internal/commands/waypoint/add-ons/create.go
+++ b/internal/commands/waypoint/add-ons/create.go
@@ -6,8 +6,8 @@ package addons
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/internal"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
@@ -16,7 +16,7 @@ import (
 )
 
 func NewCmdCreate(ctx *cmd.Context, opts *AddOnOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "create",
 		ShortHelp: "Create a new HCP Waypoint add-on.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -90,15 +90,10 @@ $ hcp waypoint add-ons create -n=my-addon -a=my-application -d=my-addon-definiti
 		},
 	}
 
-	return cmd
+	return c
 }
 
 func addOnCreate(opts *AddOnOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
 	// Variable Processing
 
 	// a map is used with the key being the variable name, so that
@@ -136,11 +131,12 @@ func addOnCreate(opts *AddOnOpts) error {
 
 	// End Variable Processing
 
-	_, err = opts.WS.WaypointServiceCreateAddOn(
+	_, err := opts.WS2024Client.WaypointServiceCreateAddOn(
 		&waypoint_service.WaypointServiceCreateAddOnParams{
-			NamespaceID: ns.ID,
-			Context:     opts.Ctx,
-			Body: &models.HashicorpCloudWaypointWaypointServiceCreateAddOnBody{
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			Body: &models.HashicorpCloudWaypointV20241122WaypointServiceCreateAddOnBody{
 				Application: &models.HashicorpCloudWaypointRefApplication{
 					Name: opts.ApplicationName,
 				},

--- a/internal/commands/waypoint/add-ons/definitions/create.go
+++ b/internal/commands/waypoint/add-ons/definitions/create.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/internal"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
@@ -153,12 +153,10 @@ $ hcp waypoint add-ons definitions create -n=my-add-on-definition \
 }
 
 func addOnDefinitionCreate(opts *AddOnDefinitionOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	var readmeTpl []byte
+	var (
+		readmeTpl []byte
+		err       error
+	)
 	if opts.ReadmeMarkdownTemplateFile != "" {
 		readmeTpl, err = os.ReadFile(opts.ReadmeMarkdownTemplateFile)
 		if err != nil {
@@ -180,10 +178,11 @@ func addOnDefinitionCreate(opts *AddOnDefinitionOpts) error {
 		}
 	}
 
-	_, err = opts.WS.WaypointServiceCreateAddOnDefinition(
+	_, err = opts.WS2024Client.WaypointServiceCreateAddOnDefinition(
 		&waypoint_service.WaypointServiceCreateAddOnDefinitionParams{
-			NamespaceID: ns.ID,
-			Body: &models.HashicorpCloudWaypointWaypointServiceCreateAddOnDefinitionBody{
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Body: &models.HashicorpCloudWaypointV20241122WaypointServiceCreateAddOnDefinitionBody{
 				AddOnDefinition: &models.HashicorpCloudWaypointAddOnDefinition{
 					Name:                   opts.Name,
 					Summary:                opts.Summary,

--- a/internal/commands/waypoint/add-ons/definitions/delete.go
+++ b/internal/commands/waypoint/add-ons/definitions/delete.go
@@ -6,7 +6,7 @@ package definitions
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -56,16 +56,12 @@ $ hcp waypoint add-ons definitions delete -n=my-addon-definition
 }
 
 func addOnDefinitionDelete(opts *AddOnDefinitionOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	_, err = opts.WS.WaypointServiceDeleteAddOnDefinition2(
+	_, err := opts.WS2024Client.WaypointServiceDeleteAddOnDefinition2(
 		&waypoint_service.WaypointServiceDeleteAddOnDefinition2Params{
-			NamespaceID:         ns.ID,
-			Context:             opts.Ctx,
-			AddOnDefinitionName: opts.Name,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			AddOnDefinitionName:             opts.Name,
 		}, nil,
 	)
 	if err != nil {

--- a/internal/commands/waypoint/add-ons/definitions/list.go
+++ b/internal/commands/waypoint/add-ons/definitions/list.go
@@ -4,8 +4,8 @@
 package definitions
 
 import (
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -43,17 +43,13 @@ $ hcp waypoint add-ons definitions list
 }
 
 func addOnDefinitionsList(opts *AddOnDefinitionOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
 	var addOnDefinitions []*models.HashicorpCloudWaypointAddOnDefinition
 
-	listResp, err := opts.WS.WaypointServiceListAddOnDefinitions(
+	listResp, err := opts.WS2024Client.WaypointServiceListAddOnDefinitions(
 		&waypoint_service.WaypointServiceListAddOnDefinitionsParams{
-			NamespaceID: ns.ID,
-			Context:     opts.Ctx,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
 		}, nil,
 	)
 	if err != nil {
@@ -65,11 +61,12 @@ func addOnDefinitionsList(opts *AddOnDefinitionOpts) error {
 	addOnDefinitions = append(addOnDefinitions, listResp.GetPayload().AddOnDefinitions...)
 
 	for listResp.GetPayload().Pagination.NextPageToken != "" {
-		listResp, err = opts.WS.WaypointServiceListAddOnDefinitions(
+		listResp, err = opts.WS2024Client.WaypointServiceListAddOnDefinitions(
 			&waypoint_service.WaypointServiceListAddOnDefinitionsParams{
-				NamespaceID:             ns.ID,
-				Context:                 opts.Ctx,
-				PaginationNextPageToken: &listResp.GetPayload().Pagination.NextPageToken,
+				NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+				NamespaceLocationProjectID:      opts.Profile.ProjectID,
+				Context:                         opts.Ctx,
+				PaginationNextPageToken:         &listResp.GetPayload().Pagination.NextPageToken,
 			}, nil)
 		if err != nil {
 			return errors.Wrapf(err, "%s failed to list paginated add-on definitions",

--- a/internal/commands/waypoint/add-ons/definitions/read.go
+++ b/internal/commands/waypoint/add-ons/definitions/read.go
@@ -6,7 +6,7 @@ package definitions
 import (
 	"strings"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/format"
@@ -56,16 +56,12 @@ $ hcp waypoint add-ons definitions read -n=my-addon-definition
 }
 
 func addOnDefinitionRead(opts *AddOnDefinitionOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	getResp, err := opts.WS.WaypointServiceGetAddOnDefinition2(
+	getResp, err := opts.WS2024Client.WaypointServiceGetAddOnDefinition2(
 		&waypoint_service.WaypointServiceGetAddOnDefinition2Params{
-			NamespaceID:         ns.ID,
-			Context:             opts.Ctx,
-			AddOnDefinitionName: opts.Name,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			AddOnDefinitionName:             opts.Name,
 		}, nil,
 	)
 	if err != nil {

--- a/internal/commands/waypoint/add-ons/definitions/update.go
+++ b/internal/commands/waypoint/add-ons/definitions/update.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/internal"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
@@ -127,12 +127,10 @@ $ hcp waypoint add-ons definitions update -n=my-add-on-definition \
 }
 
 func addOnDefinitionUpdate(opts *AddOnDefinitionOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	var readmeTpl []byte
+	var (
+		readmeTpl []byte
+		err       error
+	)
 	if opts.ReadmeMarkdownTemplateFile != "" {
 		readmeTpl, err = os.ReadFile(opts.ReadmeMarkdownTemplateFile)
 		if err != nil {
@@ -156,12 +154,13 @@ func addOnDefinitionUpdate(opts *AddOnDefinitionOpts) error {
 		variables = vars
 	}
 
-	_, err = opts.WS.WaypointServiceUpdateAddOnDefinition2(
+	_, err = opts.WS2024Client.WaypointServiceUpdateAddOnDefinition2(
 		&waypoint_service.WaypointServiceUpdateAddOnDefinition2Params{
-			NamespaceID:                 ns.ID,
-			Context:                     opts.Ctx,
-			ExistingAddOnDefinitionName: opts.Name,
-			Body: &models.HashicorpCloudWaypointWaypointServiceUpdateAddOnDefinitionBody{
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			ExistingAddOnDefinitionName:     opts.Name,
+			Body: &models.HashicorpCloudWaypointV20241122WaypointServiceUpdateAddOnDefinitionBody{
 				AddOnDefinition: &models.HashicorpCloudWaypointAddOnDefinition{
 					Summary:                opts.Summary,
 					Description:            opts.Description,

--- a/internal/commands/waypoint/add-ons/destroy.go
+++ b/internal/commands/waypoint/add-ons/destroy.go
@@ -6,7 +6,7 @@ package addons
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -14,7 +14,7 @@ import (
 )
 
 func NewCmdDestroy(ctx *cmd.Context, opts *AddOnOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "destroy",
 		ShortHelp: "Destroy an HCP Waypoint add-ons.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -51,20 +51,16 @@ $ hcp waypoint add-ons destroy -n=my-addon
 			},
 		},
 	}
-	return cmd
+	return c
 }
 
 func addOnDestroy(opts *AddOnOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	_, err = opts.WS.WaypointServiceDestroyAddOn2(
+	_, err := opts.WS2024Client.WaypointServiceDestroyAddOn2(
 		&waypoint_service.WaypointServiceDestroyAddOn2Params{
-			NamespaceID: ns.ID,
-			Context:     opts.Ctx,
-			AddOnName:   opts.Name,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			AddOnName:                       opts.Name,
 		}, nil,
 	)
 	if err != nil {

--- a/internal/commands/waypoint/add-ons/list.go
+++ b/internal/commands/waypoint/add-ons/list.go
@@ -4,7 +4,7 @@
 package addons
 
 import (
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/format"
@@ -13,7 +13,7 @@ import (
 )
 
 func NewCmdList(ctx *cmd.Context, opts *AddOnOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "list",
 		ShortHelp: "List HCP Waypoint add-ons.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -56,20 +56,16 @@ $ hcp waypoint add-ons list --application-name my-application
 			},
 		},
 	}
-	return cmd
+	return c
 }
 
 func addOnsList(opts *AddOnOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	resp, err := opts.WS.WaypointServiceListAddOns(
+	resp, err := opts.WS2024Client.WaypointServiceListAddOns(
 		&waypoint_service.WaypointServiceListAddOnsParams{
-			NamespaceID:     ns.ID,
-			Context:         opts.Ctx,
-			ApplicationName: &opts.ApplicationName,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			ApplicationName:                 &opts.ApplicationName,
 		}, nil,
 	)
 	if err != nil {

--- a/internal/commands/waypoint/add-ons/read.go
+++ b/internal/commands/waypoint/add-ons/read.go
@@ -4,7 +4,7 @@
 package addons
 
 import (
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/format"
@@ -13,7 +13,7 @@ import (
 )
 
 func NewCmdRead(ctx *cmd.Context, opts *AddOnOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "read",
 		ShortHelp: "Read an HCP Waypoint add-on.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -49,20 +49,16 @@ $ hcp waypoint add-ons read -n=my-addon
 			},
 		},
 	}
-	return cmd
+	return c
 }
 
 func addOnRead(opts *AddOnOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	getResp, err := opts.WS.WaypointServiceGetAddOn2(
+	getResp, err := opts.WS2024Client.WaypointServiceGetAddOn2(
 		&waypoint_service.WaypointServiceGetAddOn2Params{
-			NamespaceID: ns.ID,
-			Context:     opts.Ctx,
-			AddOnName:   opts.Name,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			AddOnName:                       opts.Name,
 		}, nil,
 	)
 	if err != nil {

--- a/internal/commands/waypoint/applications/create.go
+++ b/internal/commands/waypoint/applications/create.go
@@ -6,8 +6,8 @@ package applications
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/internal"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
@@ -16,7 +16,7 @@ import (
 )
 
 func NewCmdApplicationsCreate(ctx *cmd.Context, opts *ApplicationOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "create",
 		ShortHelp: "Create a new HCP Waypoint application.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -91,15 +91,10 @@ $ hcp waypoint application create -n=my-application -t=my-template
 		},
 	}
 
-	return cmd
+	return c
 }
 
 func applicationCreate(opts *ApplicationOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
 	actionConfigs := make([]*models.HashicorpCloudWaypointActionCfgRef, len(opts.ActionConfigNames))
 	for i, name := range opts.ActionConfigNames {
 		actionConfigs[i] = &models.HashicorpCloudWaypointActionCfgRef{
@@ -144,11 +139,12 @@ func applicationCreate(opts *ApplicationOpts) error {
 
 	// End Variable Processing
 
-	_, err = opts.WS.WaypointServiceCreateApplicationFromTemplate(
+	_, err := opts.WS2024Client.WaypointServiceCreateApplicationFromTemplate(
 		&waypoint_service.WaypointServiceCreateApplicationFromTemplateParams{
-			NamespaceID: ns.ID,
-			Context:     opts.Ctx,
-			Body: &models.HashicorpCloudWaypointWaypointServiceCreateApplicationFromTemplateBody{
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			Body: &models.HashicorpCloudWaypointV20241122WaypointServiceCreateApplicationFromTemplateBody{
 				Name: opts.Name,
 				ApplicationTemplate: &models.HashicorpCloudWaypointRefApplicationTemplate{
 					Name: opts.TemplateName,

--- a/internal/commands/waypoint/applications/destroy.go
+++ b/internal/commands/waypoint/applications/destroy.go
@@ -6,7 +6,7 @@ package applications
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -14,7 +14,7 @@ import (
 )
 
 func NewCmdApplicationsDestroy(ctx *cmd.Context, opts *ApplicationOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "destroy",
 		ShortHelp: "Destroy an HCP Waypoint application and its infrastructure.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -52,15 +52,10 @@ $ hcp waypoint applications destroy -n=my-application
 		},
 	}
 
-	return cmd
+	return c
 }
 
 func applicationDestroy(opts *ApplicationOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
 	if opts.IO.CanPrompt() {
 		ok, err := opts.IO.PromptConfirm(
 			"The HCP Waypoint application will be deleted.\n\n" +
@@ -75,11 +70,12 @@ func applicationDestroy(opts *ApplicationOpts) error {
 		}
 	}
 
-	_, err = opts.WS.WaypointServiceDestroyApplication2(
+	_, err := opts.WS2024Client.WaypointServiceDestroyApplication2(
 		&waypoint_service.WaypointServiceDestroyApplication2Params{
-			NamespaceID:     ns.ID,
-			Context:         opts.Ctx,
-			ApplicationName: opts.Name,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			ApplicationName:                 opts.Name,
 		}, nil,
 	)
 	if err != nil {

--- a/internal/commands/waypoint/applications/list.go
+++ b/internal/commands/waypoint/applications/list.go
@@ -4,7 +4,7 @@
 package applications
 
 import (
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -12,7 +12,7 @@ import (
 )
 
 func NewCmdApplicationsList(ctx *cmd.Context, opts *ApplicationOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "list",
 		ShortHelp: "List all HCP Waypoint applications.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -27,19 +27,15 @@ func NewCmdApplicationsList(ctx *cmd.Context, opts *ApplicationOpts) *cmd.Comman
 		},
 	}
 
-	return cmd
+	return c
 }
 
 func applicationsList(opts *ApplicationOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	resp, err := opts.WS.WaypointServiceListApplications(
+	resp, err := opts.WS2024Client.WaypointServiceListApplications(
 		&waypoint_service.WaypointServiceListApplicationsParams{
-			NamespaceID: ns.ID,
-			Context:     opts.Ctx,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
 		}, nil,
 	)
 	if err != nil {

--- a/internal/commands/waypoint/applications/read.go
+++ b/internal/commands/waypoint/applications/read.go
@@ -4,7 +4,7 @@
 package applications
 
 import (
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/format"
@@ -13,7 +13,7 @@ import (
 )
 
 func NewCmdApplicationsRead(ctx *cmd.Context, opts *ApplicationOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "read",
 		ShortHelp: "Read details about an HCP Waypoint application.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -49,20 +49,16 @@ details about an HCP Waypoint application.
 		},
 	}
 
-	return cmd
+	return c
 }
 
 func applicationRead(opts *ApplicationOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	getResp, err := opts.WS.WaypointServiceGetApplication2(
+	getResp, err := opts.WS2024Client.WaypointServiceGetApplication2(
 		&waypoint_service.WaypointServiceGetApplication2Params{
-			NamespaceID:     ns.ID,
-			Context:         opts.Ctx,
-			ApplicationName: opts.Name,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			ApplicationName:                 opts.Name,
 		}, nil,
 	)
 	if err != nil {

--- a/internal/commands/waypoint/applications/update.go
+++ b/internal/commands/waypoint/applications/update.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -16,7 +16,7 @@ import (
 )
 
 func NewCmdApplicationsUpdate(ctx *cmd.Context, opts *ApplicationOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "update",
 		ShortHelp: "Update an existing HCP Waypoint application.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -69,16 +69,14 @@ $ hcp waypoint applications update -n=my-application --action-config-name my-act
 		},
 	}
 
-	return cmd
+	return c
 }
 
 func applicationUpdate(opts *ApplicationOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	var acrs []*models.HashicorpCloudWaypointActionCfgRef
+	var (
+		acrs []*models.HashicorpCloudWaypointActionCfgRef
+		err  error
+	)
 	for _, acn := range opts.ActionConfigNames {
 		acrs = append(acrs, &models.HashicorpCloudWaypointActionCfgRef{
 			Name: acn,
@@ -96,12 +94,13 @@ func applicationUpdate(opts *ApplicationOpts) error {
 		}
 	}
 
-	_, err = opts.WS.WaypointServiceUpdateApplication2(
+	_, err = opts.WS2024Client.WaypointServiceUpdateApplication2(
 		&waypoint_service.WaypointServiceUpdateApplication2Params{
-			NamespaceID:     ns.ID,
-			Context:         opts.Ctx,
-			ApplicationName: opts.Name,
-			Body: &models.HashicorpCloudWaypointWaypointServiceUpdateApplicationBody{
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			ApplicationName:                 opts.Name,
+			Body: &models.HashicorpCloudWaypointV20241122WaypointServiceUpdateApplicationBody{
 				ActionCfgRefs:  acrs,
 				ReadmeMarkdown: readme,
 			},

--- a/internal/commands/waypoint/internal/variable_options.go
+++ b/internal/commands/waypoint/internal/variable_options.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsimple"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 )
 
 func ParseVariableOptionsFile(path string) ([]*models.HashicorpCloudWaypointTFModuleVariable, error) {

--- a/internal/commands/waypoint/templates/create.go
+++ b/internal/commands/waypoint/templates/create.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/internal"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
@@ -17,7 +17,7 @@ import (
 )
 
 func NewCmdCreate(ctx *cmd.Context, opts *TemplateOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "create",
 		ShortHelp: "Create a new HCP Waypoint template.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -160,16 +160,14 @@ $ hcp waypoint templates create -n=my-template \
 		},
 	}
 
-	return cmd
+	return c
 }
 
 func templateCreate(opts *TemplateOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	var tags []*models.HashicorpCloudWaypointTag
+	var (
+		tags []*models.HashicorpCloudWaypointTag
+		err  error
+	)
 	for k, v := range opts.Tags {
 		tags = append(tags, &models.HashicorpCloudWaypointTag{
 			Key:   k,
@@ -200,10 +198,11 @@ func templateCreate(opts *TemplateOpts) error {
 		}
 	}
 
-	_, err = opts.WS.WaypointServiceCreateApplicationTemplate(
+	_, err = opts.WS2024Client.WaypointServiceCreateApplicationTemplate(
 		&waypoint_service.WaypointServiceCreateApplicationTemplateParams{
-			NamespaceID: ns.ID,
-			Body: &models.HashicorpCloudWaypointWaypointServiceCreateApplicationTemplateBody{
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Body: &models.HashicorpCloudWaypointV20241122WaypointServiceCreateApplicationTemplateBody{
 				ApplicationTemplate: &models.HashicorpCloudWaypointApplicationTemplate{
 					Name:                   opts.Name,
 					Summary:                opts.Summary,

--- a/internal/commands/waypoint/templates/delete.go
+++ b/internal/commands/waypoint/templates/delete.go
@@ -6,7 +6,7 @@ package templates
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -14,7 +14,7 @@ import (
 )
 
 func NewCmdDelete(ctx *cmd.Context, opts *TemplateOpts) *cmd.Command {
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "delete",
 		ShortHelp: "Delete an existing Waypoint template.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
@@ -52,20 +52,16 @@ $ hcp waypoint templates delete -n=my-template
 		},
 	}
 
-	return cmd
+	return c
 }
 
 func templateDelete(opts *TemplateOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	_, err = opts.WS.WaypointServiceDeleteApplicationTemplate2(
+	_, err := opts.WS2024Client.WaypointServiceDeleteApplicationTemplate2(
 		&waypoint_service.WaypointServiceDeleteApplicationTemplate2Params{
-			NamespaceID:             ns.ID,
-			Context:                 opts.Ctx,
-			ApplicationTemplateName: opts.Name,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			ApplicationTemplateName:         opts.Name,
 		}, nil,
 	)
 	if err != nil {

--- a/internal/commands/waypoint/templates/read.go
+++ b/internal/commands/waypoint/templates/read.go
@@ -6,7 +6,7 @@ package templates
 import (
 	"strings"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/format"
@@ -57,16 +57,12 @@ $ hcp waypoint templates read -n=my-template
 }
 
 func templateRead(opts *TemplateOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	resp, err := opts.WS.WaypointServiceGetApplicationTemplate2(
+	resp, err := opts.WS2024Client.WaypointServiceGetApplicationTemplate2(
 		&waypoint_service.WaypointServiceGetApplicationTemplate2Params{
-			NamespaceID:             ns.ID,
-			Context:                 opts.Ctx,
-			ApplicationTemplateName: opts.Name,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			ApplicationTemplateName:         opts.Name,
 		}, nil,
 	)
 	if err != nil {

--- a/internal/commands/waypoint/templates/update.go
+++ b/internal/commands/waypoint/templates/update.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/hcp/internal/commands/waypoint/internal"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
@@ -144,11 +144,6 @@ $ hcp waypoint templates update -n=my-template \
 }
 
 func templateUpdate(opts *TemplateOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
 	// NOTE (clint): We have to get the existing template to get the collections
 	// (labels, tags, actions, variables) so that we can either omit or post
 	// updates to them based on the inputs here. This is because of how the
@@ -160,11 +155,12 @@ func templateUpdate(opts *TemplateOpts) error {
 	// Unfortunately even if the model had omitempty, this would then cause the
 	// fieldmask to not get set, which is needed for the PATCH semantics, thus
 	// no change would occur.
-	resp, err := opts.WS.WaypointServiceGetApplicationTemplate2(
+	resp, err := opts.WS2024Client.WaypointServiceGetApplicationTemplate2(
 		&waypoint_service.WaypointServiceGetApplicationTemplate2Params{
-			NamespaceID:             ns.ID,
-			Context:                 opts.Ctx,
-			ApplicationTemplateName: opts.Name,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
+			ApplicationTemplateName:         opts.Name,
 		}, nil,
 	)
 	if err != nil {
@@ -253,9 +249,10 @@ func templateUpdate(opts *TemplateOpts) error {
 	// if a variable file is present but represents an empty list of variables,
 	// we need to set the fieldmask for variables to clear them out
 
-	_, err = opts.WS.WaypointServiceUpdateApplicationTemplate6(
+	_, err = opts.WS2024Client.WaypointServiceUpdateApplicationTemplate6(
 		&waypoint_service.WaypointServiceUpdateApplicationTemplate6Params{
-			NamespaceID:                     ns.ID,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
 			Context:                         opts.Ctx,
 			ExistingApplicationTemplateName: opts.Name,
 			ApplicationTemplate:             updatedTpl,

--- a/internal/commands/waypoint/tfcconfig/tfc_config.go
+++ b/internal/commands/waypoint/tfcconfig/tfc_config.go
@@ -4,9 +4,6 @@
 package tfcconfig
 
 import (
-	"context"
-
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 )
@@ -27,21 +24,4 @@ func NewCmdTFCConfig(ctx *cmd.Context) *cmd.Command {
 	cmd.AddChild(NewCmdDelete(ctx, nil))
 	cmd.AddChild(NewCmdRead(ctx, nil))
 	return cmd
-}
-
-func GetNamespace(ctx context.Context, client waypoint_service.ClientService, orgID, projectID string) (string, error) {
-
-	resp, err := client.WaypointServiceGetNamespace(
-		&waypoint_service.WaypointServiceGetNamespaceParams{
-			LocationOrganizationID: orgID,
-			LocationProjectID:      projectID,
-			Context:                ctx,
-		}, nil,
-	)
-	if err != nil {
-		return "", err
-	}
-
-	return resp.Payload.Namespace.ID, nil
-
 }

--- a/internal/commands/waypoint/tfcconfig/tfc_config_delete.go
+++ b/internal/commands/waypoint/tfcconfig/tfc_config_delete.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -16,15 +16,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-func NewCmdDelete(ctx *cmd.Context, runF func(opts *TFCConfigDeleteOpts) error) *cmd.Command {
-	opts := &TFCConfigDeleteOpts{
+func NewCmdDelete(ctx *cmd.Context, runF func(opts *DeleteOpts) error) *cmd.Command {
+	opts := &DeleteOpts{
 		Ctx:            ctx.ShutdownCtx,
 		Profile:        ctx.Profile,
 		Output:         ctx.Output,
 		IO:             ctx.IO,
 		WaypointClient: waypoint_service.New(ctx.HCP, nil),
 	}
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "delete",
 		ShortHelp: "Delete TFC Configuration.",
 		LongHelp: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
@@ -50,20 +50,16 @@ func NewCmdDelete(ctx *cmd.Context, runF func(opts *TFCConfigDeleteOpts) error) 
 			return cmd.RequireOrgAndProject(ctx)
 		},
 	}
-	return cmd
 
+	return c
 }
 
-func deleteRun(opts *TFCConfigDeleteOpts) error {
-	nsID, err := GetNamespace(opts.Ctx, opts.WaypointClient, opts.Profile.OrganizationID, opts.Profile.ProjectID)
-	if err != nil {
-		return err
-	}
-
+func deleteRun(opts *DeleteOpts) error {
 	resp, err := opts.WaypointClient.WaypointServiceDeleteTFCConfig(
 		&waypoint_service.WaypointServiceDeleteTFCConfigParams{
-			NamespaceID: nsID,
-			Context:     opts.Ctx,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
 		}, nil,
 	)
 	if err != nil {
@@ -77,7 +73,7 @@ func deleteRun(opts *TFCConfigDeleteOpts) error {
 	return nil
 }
 
-type TFCConfigDeleteOpts struct {
+type DeleteOpts struct {
 	Ctx            context.Context
 	Profile        *profile.Profile
 	Output         *format.Outputter

--- a/internal/commands/waypoint/tfcconfig/tfc_config_read.go
+++ b/internal/commands/waypoint/tfcconfig/tfc_config_read.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
@@ -17,8 +17,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func NewCmdRead(ctx *cmd.Context, runF func(opts *TFCConfigReadOpts) error) *cmd.Command {
-	opts := &TFCConfigReadOpts{
+func NewCmdRead(ctx *cmd.Context, runF func(opts *ReadOpts) error) *cmd.Command {
+	opts := &ReadOpts{
 		Ctx:            ctx.ShutdownCtx,
 		Profile:        ctx.Profile,
 		Output:         ctx.Output,
@@ -26,7 +26,7 @@ func NewCmdRead(ctx *cmd.Context, runF func(opts *TFCConfigReadOpts) error) *cmd
 		WaypointClient: waypoint_service.New(ctx.HCP, nil),
 	}
 
-	cmd := &cmd.Command{
+	c := &cmd.Command{
 		Name:      "read",
 		ShortHelp: "Read TFC Config properties.",
 		LongHelp: heredoc.New(ctx.IO, heredoc.WithPreserveNewlines()).Must(`
@@ -51,18 +51,15 @@ func NewCmdRead(ctx *cmd.Context, runF func(opts *TFCConfigReadOpts) error) *cmd
 			return cmd.RequireOrgAndProject(ctx)
 		},
 	}
-	return cmd
+	return c
 }
 
-func readRun(opts *TFCConfigReadOpts) error {
-	nsID, err := GetNamespace(opts.Ctx, opts.WaypointClient, opts.Profile.OrganizationID, opts.Profile.ProjectID)
-	if err != nil {
-		return err
-	}
+func readRun(opts *ReadOpts) error {
 	resp, err := opts.WaypointClient.WaypointServiceGetTFCConfig(
 		&waypoint_service.WaypointServiceGetTFCConfigParams{
-			NamespaceID: nsID,
-			Context:     opts.Ctx,
+			NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+			NamespaceLocationProjectID:      opts.Profile.ProjectID,
+			Context:                         opts.Ctx,
 		}, nil,
 	)
 	if err != nil {
@@ -105,7 +102,7 @@ func (d configDisplayer) FieldTemplates() []format.Field {
 	}
 }
 
-type TFCConfigReadOpts struct {
+type ReadOpts struct {
 	Ctx            context.Context
 	Profile        *profile.Profile
 	Output         *format.Outputter


### PR DESCRIPTION
### :hammer_and_wrench:  Description

<!-- What changed?
<!-- Why was it changed? -->
<!-- How does it affect end-user behavior? -->

Update command groups to use new client:
- [x] TFC Configs
- [x] Templates
- [x] Add-on definitions
- [x] Applications
- [x] Add-ons

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->

### :building_construction:  Local Testing

```shell
$ ./bin/hcp waypoint tfc-config delete
✓ TFC Config successfully deleted!

$ ./bin/hcp waypoint tfc-config create REDACTED REDACTED
✓ TFC Config "REDACTED" created!

$ ./bin/hcp waypoint tfc-config read
Organization Name: REDACTED
Token:             ************************

$ ./bin/hcp waypoint templates create -n cli-new-api-test -s "A new template to test the CLI using the new API version." --tf-no-code-module-id=REDACTED --tfc-no-code-module-source=REDACTED --tfc-project-id=REDACTED --tfc-project-name=REDACTED
✓ Template "cli-new-api-test" created.

$ ./bin/hcp waypoint templates list
Name                       ID                                     Summary
cli-new-api-test           e58fe336-597d-42fd-aed9-0571c56b8cf7   A new template to test the CLI using the new API version.

$ ./bin/hcp waypoint add-ons definitions create -n cli-new-api-test -s "A new template to test the CLI using the new API version." --tf-no-code-module-id=REDACTED --tfc-no-code-module-source=REDACTED --tfc-project-id=REDACTED --tfc-project-name=REDACTED
✓ Add-on definition "cli-new-api-test" created.

$ ./bin/hcp waypoint add-ons definitions list
Description:
ID:                                           1e2c2931-1be1-4817-841b-d5ac6e1a5bdd
Labels:                                       []
Module ID:                                    REDACTED
Module Source:                                REDACTED
Name:                                         cli-new-api-test
Readme Markdown Template:
Readme Template:
Summary:                                      A new template to test the CLI using the new API version.
Tags:                                         []
Terraform Cloud Workspace Details Name:       REDACTED
Terraform Cloud Workspace Details Project ID: REDACTED
Tf Agent Pool ID:
Tf Execution Mode:
Variable Options:                             []
Variable Options Out Of Sync:                 false
---

$  ./bin/hcp waypoint applications create -n cli-new-api-test --template-name=cli-new-api-test
✓ Application "cli-new-api-test" created.

$ ./bin/hcp waypoint applications list
Action Cfg Refs:           []
Application Template ID:
Application Template Name: cli-new-api-test
ID:                        dc110987-9403-430a-9744-4477cc15f300
Name:                      cli-new-api-test
Output Values:             []
Readme:
Readme Markdown:
Tags:                      []
Template Name:             cli-new-api-test
Tfc Workspace ID:          REDACTED
---

$ ./bin/hcp waypoint add-ons create -n cli-new-api-test-add-on --add-on-definition-name=cli-new-api-test --app=cli-new-api-test
✓ Add-on "cli-new-api-test-add-on" created!

$ ./bin/hcp waypoint add-ons list
Application ID:         dc110987-9403-430a-9744-4477cc15f300
Application Name:
Count:                  0
Created At:             2025-01-16T20:56:21.537Z
Definition ID:
Definition Name:        cli-new-api-test
Description:
ID:                     576214f1-9069-4182-9095-a3df02681daa
Labels:                 []
Module ID:              REDACTED
Module Source:          REDACTED
Name:                   cli-new-api-test-add-on
Output Values:          [REDACTED]
Readme:
Readme Markdown:
Status:                 SUCCESS
Summary:                A new template to test the CLI using the new API version.
Tags:                   []
Terraform Workspace ID: REDACTED
---

```

### :+1:  Checklist

- [ ] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
