### PR TITLE
Update Waypoint actions and agent commands to use new service

### DIFF
--- a/internal/commands/waypoint/actions/create.go
+++ b/internal/commands/waypoint/actions/create.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 
 	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
@@ -121,14 +121,11 @@ func createAction(c *cmd.Command, args []string, opts *CreateOpts) error {
 	}
 
 	// Ok, run the command!!
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-	_, err = opts.WS.WaypointServiceCreateActionConfig(&waypoint_service.WaypointServiceCreateActionConfigParams{
-		NamespaceID: ns.ID,
-		Context:     opts.Ctx,
-		Body: &models.HashicorpCloudWaypointWaypointServiceCreateActionConfigBody{
+	_, err := opts.WS2024Client.WaypointServiceCreateActionConfig(&waypoint_service.WaypointServiceCreateActionConfigParams{
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
+		Context:                         opts.Ctx,
+		Body: &models.HashicorpCloudWaypointV20241122WaypointServiceCreateActionConfigBody{
 			ActionConfig: &models.HashicorpCloudWaypointActionConfig{
 				Name:        opts.Name,
 				Description: opts.Description,

--- a/internal/commands/waypoint/actions/delete.go
+++ b/internal/commands/waypoint/actions/delete.go
@@ -6,7 +6,8 @@ package actions
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+
 	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
@@ -29,7 +30,7 @@ func NewCmdDelete(ctx *cmd.Context) *cmd.Command {
 		ShortHelp: "Delete an existing action.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp waypoint actions delete" }}
-		command deletes an existing action. This will remove the action 
+		command deletes an existing action. This will remove the action
 		completely from HCP Waypoint.
 		`),
 		RunF: func(c *cmd.Command, args []string) error {
@@ -55,17 +56,13 @@ func NewCmdDelete(ctx *cmd.Context) *cmd.Command {
 }
 
 func deleteAction(c *cmd.Command, args []string, opts *DeleteOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
 	// Make action name a string pointer
 	actionName := &opts.Name
-	_, err = opts.WS.WaypointServiceDeleteActionConfig(&waypoint_service.WaypointServiceDeleteActionConfigParams{
-		NamespaceID: ns.ID,
-		Context:     opts.Ctx,
-		ActionName:  actionName,
+	_, err := opts.WS2024Client.WaypointServiceDeleteActionConfig(&waypoint_service.WaypointServiceDeleteActionConfigParams{
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
+		Context:                         opts.Ctx,
+		ActionName:                      actionName,
 	}, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete action %q: %w", opts.Name, err)

--- a/internal/commands/waypoint/actions/list.go
+++ b/internal/commands/waypoint/actions/list.go
@@ -42,14 +42,7 @@ func NewCmdList(ctx *cmd.Context) *cmd.Command {
 }
 
 func listActions(c *cmd.Command, args []string, opts *ListOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
 	resp, err := opts.WS2024Client.WaypointServiceListActionConfigs(&waypoint_service.WaypointServiceListActionConfigsParams{
-		// TODO: NamespaceID is still required; remove when SDK is updated
-		NamespaceID:                     &ns.ID,
 		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
 		NamespaceLocationProjectID:      opts.Profile.ProjectID,
 		Context:                         opts.Ctx,

--- a/internal/commands/waypoint/actions/list.go
+++ b/internal/commands/waypoint/actions/list.go
@@ -6,7 +6,8 @@ package actions
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+
 	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
@@ -26,7 +27,7 @@ func NewCmdList(ctx *cmd.Context) *cmd.Command {
 		Name:      "list",
 		ShortHelp: "List all known actions.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp waypoint actions list" }} command 
+		The {{ template "mdCodeOrBold" "hcp waypoint actions list" }} command
 		lists all known actions from HCP Waypoint.
 		`),
 		RunF: func(c *cmd.Command, args []string) error {
@@ -46,9 +47,12 @@ func listActions(c *cmd.Command, args []string, opts *ListOpts) error {
 		return err
 	}
 
-	resp, err := opts.WS.WaypointServiceListActionConfigs(&waypoint_service.WaypointServiceListActionConfigsParams{
-		NamespaceID: ns.ID,
-		Context:     opts.Ctx,
+	resp, err := opts.WS2024Client.WaypointServiceListActionConfigs(&waypoint_service.WaypointServiceListActionConfigsParams{
+		// TODO: NamespaceID is still required; remove when SDK is updated
+		NamespaceID:                     &ns.ID,
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
+		Context:                         opts.Ctx,
 	}, nil)
 	if err != nil {
 		return fmt.Errorf("error listing actions: %w", err)

--- a/internal/commands/waypoint/actions/read.go
+++ b/internal/commands/waypoint/actions/read.go
@@ -6,7 +6,8 @@ package actions
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+
 	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
@@ -55,17 +56,13 @@ func NewCmdRead(ctx *cmd.Context) *cmd.Command {
 }
 
 func readAction(c *cmd.Command, args []string, opts *ReadOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
 	// Make action name a string pointer
 	actionName := &opts.Name
-	resp, err := opts.WS.WaypointServiceGetActionConfig(&waypoint_service.WaypointServiceGetActionConfigParams{
-		NamespaceID: ns.ID,
-		Context:     opts.Ctx,
-		ActionName:  actionName,
+	resp, err := opts.WS2024Client.WaypointServiceGetActionConfig(&waypoint_service.WaypointServiceGetActionConfigParams{
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
+		Context:                         opts.Ctx,
+		ActionName:                      actionName,
 	}, nil)
 	if err != nil {
 		return fmt.Errorf("error getting action for %q: %w",

--- a/internal/commands/waypoint/actions/update.go
+++ b/internal/commands/waypoint/actions/update.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 
 	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
@@ -123,15 +123,11 @@ func updateAction(c *cmd.Command, args []string, opts *UpdateOpts) error {
 	}
 
 	// Ok, run the command!!
-	ns, err := opts.Namespace()
-	if err != nil {
-		return err
-	}
-
-	resp, err := opts.WS.WaypointServiceUpdateActionConfig(&waypoint_service.WaypointServiceUpdateActionConfigParams{
-		NamespaceID: ns.ID,
-		Context:     opts.Ctx,
-		Body: &models.HashicorpCloudWaypointWaypointServiceUpdateActionConfigBody{
+	resp, err := opts.WS2024Client.WaypointServiceUpdateActionConfig(&waypoint_service.WaypointServiceUpdateActionConfigParams{
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
+		Context:                         opts.Ctx,
+		Body: &models.HashicorpCloudWaypointV20241122WaypointServiceUpdateActionConfigBody{
 			ActionConfig: &models.HashicorpCloudWaypointActionConfig{
 				Name:        opts.Name,
 				Description: opts.Description,

--- a/internal/commands/waypoint/agent/agent.go
+++ b/internal/commands/waypoint/agent/agent.go
@@ -13,11 +13,11 @@ func NewCmdAgent(ctx *cmd.Context) *cmd.Command {
 		Name:      "agent",
 		ShortHelp: "Run and manage a Waypoint Agent.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		The {{ template "mdCodeOrBold" "hcp waypoint agent" }} command group lets you 
-		run and manage a local Waypoint agent.
+		The {{ template "mdCodeOrBold" "hcp waypoint agent" }} command group lets you
+run and manage a local Waypoint agent.
 
-		Agents are used in conjunction with HCP Waypoint Actions to allow actions to run on your
-		own systems when initiated from HCP Waypoint.
+Agents are used in conjunction with HCP Waypoint Actions to allow actions to run on your
+own systems when initiated from HCP Waypoint.
 		`),
 	}
 

--- a/internal/commands/waypoint/agent/group_create.go
+++ b/internal/commands/waypoint/agent/group_create.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
-	"github.com/pkg/errors"
 )
 
 func NewCmdGroupCreate(ctx *cmd.Context, opts *GroupOpts) *cmd.Command {
@@ -63,20 +63,16 @@ func NewCmdGroupCreate(ctx *cmd.Context, opts *GroupOpts) *cmd.Command {
 }
 
 func agentGroupCreate(log hclog.Logger, opts *GroupOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return errors.Wrapf(err, "Unable to access HCP project")
-	}
-
 	ctx := opts.Ctx
 
 	grp := &models.HashicorpCloudWaypointAgentGroup{
 		Description: opts.Description,
 		Name:        opts.Name,
 	}
-	_, err = opts.WS.WaypointServiceCreateAgentGroup(&waypoint_service.WaypointServiceCreateAgentGroupParams{
-		NamespaceID: ns.ID,
-		Body: &models.HashicorpCloudWaypointWaypointServiceCreateAgentGroupBody{
+	_, err := opts.WS2024Client.WaypointServiceCreateAgentGroup(&waypoint_service.WaypointServiceCreateAgentGroupParams{
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
+		Body: &models.HashicorpCloudWaypointV20241122WaypointServiceCreateAgentGroupBody{
 			Group: grp,
 		},
 		Context: ctx,

--- a/internal/commands/waypoint/agent/group_delete.go
+++ b/internal/commands/waypoint/agent/group_delete.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
-	"github.com/pkg/errors"
 )
 
 func NewCmdGroupDelete(ctx *cmd.Context, opts *GroupOpts) *cmd.Command {
@@ -51,23 +51,13 @@ func NewCmdGroupDelete(ctx *cmd.Context, opts *GroupOpts) *cmd.Command {
 }
 
 func agentGroupDelete(log hclog.Logger, opts *GroupOpts) error {
-	resp, err := opts.WS.WaypointServiceGetNamespace(&waypoint_service.WaypointServiceGetNamespaceParams{
-		LocationOrganizationID: opts.Profile.OrganizationID,
-		LocationProjectID:      opts.Profile.ProjectID,
-		Context:                opts.Ctx,
-	}, nil)
-	if err != nil {
-		return errors.Wrapf(err, "Unable to access HCP project")
-	}
-
-	ns := resp.Payload.Namespace
-
 	ctx := opts.Ctx
 
-	_, err = opts.WS.WaypointServiceDeleteAgentGroup(&waypoint_service.WaypointServiceDeleteAgentGroupParams{
-		Name:        opts.Name,
-		NamespaceID: ns.ID,
-		Context:     ctx,
+	_, err := opts.WS2024Client.WaypointServiceDeleteAgentGroup(&waypoint_service.WaypointServiceDeleteAgentGroupParams{
+		Name:                            opts.Name,
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
+		Context:                         ctx,
 	}, nil)
 
 	if err != nil {

--- a/internal/commands/waypoint/agent/group_list.go
+++ b/internal/commands/waypoint/agent/group_list.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
-	"github.com/pkg/errors"
 )
 
 func NewCmdGroupList(ctx *cmd.Context, opts *GroupOpts) *cmd.Command {
@@ -39,22 +39,12 @@ func NewCmdGroupList(ctx *cmd.Context, opts *GroupOpts) *cmd.Command {
 }
 
 func agentGroupList(log hclog.Logger, opts *GroupOpts) error {
-	resp, err := opts.WS.WaypointServiceGetNamespace(&waypoint_service.WaypointServiceGetNamespaceParams{
-		LocationOrganizationID: opts.Profile.OrganizationID,
-		LocationProjectID:      opts.Profile.ProjectID,
-		Context:                opts.Ctx,
-	}, nil)
-	if err != nil {
-		return errors.Wrapf(err, "Unable to access HCP project")
-	}
-
-	ns := resp.Payload.Namespace
-
 	ctx := opts.Ctx
 
-	list, err := opts.WS.WaypointServiceListAgentGroups(&waypoint_service.WaypointServiceListAgentGroupsParams{
-		NamespaceID: ns.ID,
-		Context:     ctx,
+	list, err := opts.WS2024Client.WaypointServiceListAgentGroups(&waypoint_service.WaypointServiceListAgentGroupsParams{
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
+		Context:                         ctx,
 	}, nil)
 
 	if err != nil {

--- a/internal/commands/waypoint/agent/queue.go
+++ b/internal/commands/waypoint/agent/queue.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+
 	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
-	"github.com/pkg/errors"
 )
 
 type QueueOpts struct {
@@ -83,11 +83,6 @@ func NewCmdQueue(ctx *cmd.Context) *cmd.Command {
 }
 
 func agentQueue(log hclog.Logger, opts *QueueOpts) error {
-	ns, err := opts.Namespace()
-	if err != nil {
-		return errors.Wrapf(err, "Unable to access HCP project")
-	}
-
 	var body strfmt.Base64
 
 	if strings.HasPrefix(opts.Body, "@") {
@@ -112,9 +107,8 @@ func agentQueue(log hclog.Logger, opts *QueueOpts) error {
 
 	ctx := opts.Ctx
 
-	_, err = opts.WS.WaypointServiceQueueAgentOperation(&waypoint_service.WaypointServiceQueueAgentOperationParams{
-		NamespaceID: ns.ID,
-		Body: &models.HashicorpCloudWaypointWaypointServiceQueueAgentOperationBody{
+	_, err := opts.WS2024Client.WaypointServiceQueueAgentOperation(&waypoint_service.WaypointServiceQueueAgentOperationParams{
+		Body: &models.HashicorpCloudWaypointV20241122WaypointServiceQueueAgentOperationBody{
 			Operation: &models.HashicorpCloudWaypointAgentOperation{
 				ID:          opts.ID,
 				ActionRunID: opts.ActionRunID,
@@ -122,7 +116,9 @@ func agentQueue(log hclog.Logger, opts *QueueOpts) error {
 				Group:       opts.Group,
 			},
 		},
-		Context: ctx,
+		Context:                         ctx,
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
 	}, nil)
 
 	if err != nil {

--- a/internal/pkg/waypoint/agent/execute.go
+++ b/internal/pkg/waypoint/agent/execute.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
 )

--- a/internal/pkg/waypoint/agent/execute_test.go
+++ b/internal/pkg/waypoint/agent/execute_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/pkg/waypoint/agent/status_operation.go
+++ b/internal/pkg/waypoint/agent/status_operation.go
@@ -9,16 +9,17 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 )
 
 type StatusOperation struct {
 	wp waypoint_service.ClientService
 
-	namespace string
-	cfgID     string
-	runID     string
+	orgID  string
+	projID string
+	cfgID  string
+	runID  string
 
 	Message string
 	Values  map[string]string
@@ -27,11 +28,12 @@ type StatusOperation struct {
 
 func (s *StatusOperation) Run(ctx context.Context, log hclog.Logger) (OperationStatus, error) {
 	ret, err := s.wp.WaypointServiceSendStatusLog(&waypoint_service.WaypointServiceSendStatusLogParams{
-		ActionConfigID: s.cfgID,
-		ActionRunSeq:   s.runID,
-		NamespaceID:    s.namespace,
+		ActionConfigID:                  s.cfgID,
+		ActionRunSeq:                    s.runID,
+		NamespaceLocationOrganizationID: s.orgID,
+		NamespaceLocationProjectID:      s.projID,
 
-		Body: &models.HashicorpCloudWaypointWaypointServiceSendStatusLogBody{
+		Body: &models.HashicorpCloudWaypointV20241122WaypointServiceSendStatusLogBody{
 			StatusLog: &models.HashicorpCloudWaypointStatusLog{
 				EmittedAt: strfmt.DateTime(time.Now()),
 				Log:       s.Message,


### PR DESCRIPTION
### :hammer_and_wrench:  Description

Update `waypoint` command groups to use the new `20241122` service:

- `actions`
- `agent`

Tests will be added in future PRs.

### :building_construction:  Local Testing

```sh
$ ./bin/hcp waypoint actions list
Listed 0 items.

# Creating an action is currently broken - this is with local changes (will fix in another PR)
$ ./bin/hcp waypoint actions create --name="test-get-200" --url="https://httpstat.us/200" --method="GET" --description="TEST: Get a 200"
Action "test-get-200" created.%

$ ./bin/hcp waypoint actions list
Action UR L:
Created At:                      2025-02-11T18:09:44.300Z
Description:                     TEST: Get a 200
ID:                              REDACTED
Name:                            test-get-200
Request Agent Op Action Run ID:  ERROR: template: hcp:6:44: executing "hcp" at <.Request.Agent.Op.ActionRunID>: nil pointer evaluating

# Updating an action is currently broken - this is with local changes (will fix in another PR)
$ ./bin/hcp waypoint actions update --name="test-get-200" --description="TEST: New description"
Action "test-get-200" updated.Action UR L:
Created At:                      0001-01-01T00:00:00.000Z
Description:                     TEST: New description
ID:                              REDACTED
Name:                            test-get-200
Request Agent Op Action Run ID:  ERROR: template: hcp:6:44: executing "hcp" at <.Request.Agent.Op.ActionRunID>: nil pointer evaluating
*models.HashicorpCloudWaypointActionConfigFlavorAgent.Op

$ ./bin/hcp waypoint actions read --name="test-get-200"
Action UR L:
Created At:                      2025-02-11T18:09:44.300Z
Description:                     TEST: New description
ID:                              REDACTED
Name:                            test-get-200
Request Agent Op Action Run ID:  ERROR: template: hcp:6:44: executing "hcp" at <.Request.Agent.Op.ActionRunID>: nil pointer evaluating
*models.HashicorpCloudWaypointActionConfigFlavorAgent.Op

$ ./bin/hcp waypoint actions delete --name="test-get-200"
Action "test-get-200" deleted.%

$ ./bin/hcp waypoint agent group create --name="test-group-1" --description="TEST: New agent group"
:
:

$ ./bin/hcp waypoint agent group list
Name           Description
test-group-1   TEST: New agent group

# Create a "test-agent-action-hello" agent action through the HCP UI

$ ./bin/hcp waypoint actions read --name="test-agent-action-hello"
Action UR L:
Created At:                      2025-02-11T19:12:34.221Z
Description:                     TEST: agent action
ID:                              REDACTED
Name:                            test-agent-action-hello
Request Agent Op Action Run ID:
Request Agent Op Body:
Request Agent Op Group:          test-group-1
Request Agent Op ID:             hello-action
Request Custom Body:             ERROR: template: hcp:10:44: executing "hcp" at <.Request.Custom.Body>: nil pointer evaluating
*models.HashicorpCloudWaypointActionConfigFlavorCustom.Body

$ cat ./agent-config.hcl
group "test-group-1" {
  action "hello-action" {
    run {
      command = ["echo", "hello", application.name]
    }
  }
}

$ ./bin/hcp waypoint agent run --config=agent-config.hcl
2025-02-11T13:14:55.866-0600 [INFO]  hcp.waypoint.agent.run: Waypoint agent initialized: hcp-org=REDACTED hcp-project= REDACTED waypoint-namespace= REDACTED groups=["test-group-1"]
2025-02-11T13:15:56.298-0600 [INFO]  hcp.waypoint.agent.run: reporting action run starting: action-run-id=REDACTED group=test-group-1 operation=hello-action
2025-02-11T13:15:56.414-0600 [INFO]  hcp.waypoint.agent.run: finished operation: action-run-id=REDACTED group=test-group-1 operation=hello-action
2025-02-11T13:15:56.414-0600 [INFO]  hcp.waypoint.agent.run: reporting action run ended: action-run-id=REDACTED group=test-group-1 operation=hello-action status="output: hello app1" status-code=0 action-run-sequence=1
^C%

$ ./bin/hcp waypoint agent group delete --name="test-group-1"
Group deleted
```

### :+1:  Checklist

- [x] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
