### PR TITLE
passing in capabilities results in zero results

### DIFF
--- a/.changelog/222.txt
+++ b/.changelog/222.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault-secrets: fixed list integrations request to pull in all integrations when no parameters specified
+```

--- a/internal/commands/vaultsecrets/integrations/list.go
+++ b/internal/commands/vaultsecrets/integrations/list.go
@@ -84,7 +84,6 @@ func listRun(opts *ListOpts) error {
 			Context:        opts.Ctx,
 			ProjectID:      opts.Profile.ProjectID,
 			OrganizationID: opts.Profile.OrganizationID,
-			Capabilities:   []string{"ROTATION", "DYNAMIC"},
 		}
 		for {
 			resp, err := opts.Client.ListIntegrations(params, nil)


### PR DESCRIPTION
### :hammer_and_wrench:  Description

<!-- What changed?
<!-- Why was it changed? -->
<!-- How does it affect end-user behavior? -->
for HCP Vault secrets there is a bug: by passing in capabilities it results in 0 intgrations being returned, user expects to have all integrations returned if no other argument is specified

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->

### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [ ] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
