### PR TITLE
Fixed Waypoint actions create and update

### DIFF
--- a/.changelog/224.txt
+++ b/.changelog/224.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+waypoint: Fix a bug preventing Waypoint actions from being created or updated.
+```

--- a/internal/commands/waypoint/actions/create.go
+++ b/internal/commands/waypoint/actions/create.go
@@ -96,10 +96,10 @@ func NewCmdCreate(ctx *cmd.Context) *cmd.Command {
 func createAction(c *cmd.Command, args []string, opts *CreateOpts) error {
 	// Validate Request Type is not set to all options
 	if opts.Request != nil {
-		if opts.Request.Custom != nil && opts.Request.Custom.URL != "" && opts.Request.Github != nil && opts.Request.Github.Repo != "" {
+		if opts.Request.Custom != nil && opts.Request.Custom.URL != "" && opts.Request.Github != nil {
 			return errors.New("only one request type can be set")
 		}
-		if opts.Request.Github != nil && opts.Request.Github.Repo != "" {
+		if opts.Request.Github != nil {
 			return errors.New("gitHub request types are not yet supported")
 		}
 	}

--- a/internal/commands/waypoint/actions/create.go
+++ b/internal/commands/waypoint/actions/create.go
@@ -33,7 +33,6 @@ func NewCmdCreate(ctx *cmd.Context) *cmd.Command {
 		WaypointOpts: opts.New(ctx),
 		Request: &models.HashicorpCloudWaypointActionConfigRequest{
 			Custom: &models.HashicorpCloudWaypointActionConfigFlavorCustom{},
-			Github: &models.HashicorpCloudWaypointActionConfigFlavorGitHub{},
 		},
 	}
 
@@ -97,10 +96,10 @@ func NewCmdCreate(ctx *cmd.Context) *cmd.Command {
 func createAction(c *cmd.Command, args []string, opts *CreateOpts) error {
 	// Validate Request Type is not set to all options
 	if opts.Request != nil {
-		if opts.Request.Custom != nil && opts.Request.Github != nil {
+		if opts.Request.Custom != nil && opts.Request.Custom.URL != "" && opts.Request.Github != nil && opts.Request.Github.Repo != "" {
 			return errors.New("only one request type can be set")
 		}
-		if opts.Request.Custom != nil {
+		if opts.Request.Github != nil && opts.Request.Github.Repo != "" {
 			return errors.New("gitHub request types are not yet supported")
 		}
 	}

--- a/internal/commands/waypoint/actions/update.go
+++ b/internal/commands/waypoint/actions/update.go
@@ -34,7 +34,6 @@ func NewCmdUpdate(ctx *cmd.Context) *cmd.Command {
 		WaypointOpts: opts.New(ctx),
 		Request: &models.HashicorpCloudWaypointActionConfigRequest{
 			Custom: &models.HashicorpCloudWaypointActionConfigFlavorCustom{},
-			Github: &models.HashicorpCloudWaypointActionConfigFlavorGitHub{},
 		},
 	}
 
@@ -99,10 +98,10 @@ func NewCmdUpdate(ctx *cmd.Context) *cmd.Command {
 func updateAction(c *cmd.Command, args []string, opts *UpdateOpts) error {
 	// Validate Request Type is not set to all options
 	if opts.Request != nil {
-		if opts.Request.Custom != nil && opts.Request.Github != nil {
+		if opts.Request.Custom != nil && opts.Request.Custom.URL != "" && opts.Request.Github != nil && opts.Request.Github.Repo != "" {
 			return errors.New("only one request type can be set")
 		}
-		if opts.Request.Custom != nil {
+		if opts.Request.Github != nil && opts.Request.Github.Repo != "" {
 			return errors.New("gitHub request types are not yet supported")
 		}
 	}

--- a/internal/commands/waypoint/actions/update.go
+++ b/internal/commands/waypoint/actions/update.go
@@ -98,10 +98,10 @@ func NewCmdUpdate(ctx *cmd.Context) *cmd.Command {
 func updateAction(c *cmd.Command, args []string, opts *UpdateOpts) error {
 	// Validate Request Type is not set to all options
 	if opts.Request != nil {
-		if opts.Request.Custom != nil && opts.Request.Custom.URL != "" && opts.Request.Github != nil && opts.Request.Github.Repo != "" {
+		if opts.Request.Custom != nil && opts.Request.Custom.URL != "" && opts.Request.Github != nil {
 			return errors.New("only one request type can be set")
 		}
-		if opts.Request.Github != nil && opts.Request.Github.Repo != "" {
+		if opts.Request.Github != nil {
 			return errors.New("gitHub request types are not yet supported")
 		}
 	}


### PR DESCRIPTION
Previously a bug had prevented Waypoint actions from being created or updated from the CLI, this pull request corrects that.
