### PR TITLE
Fix an issue where pretty print was causing a panic.

### DIFF
--- a/.changelog/225.txt
+++ b/.changelog/225.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix a bug preventing the usage of pretty printing
+```

--- a/internal/pkg/format/infer_fields_test.go
+++ b/internal/pkg/format/infer_fields_test.go
@@ -97,7 +97,7 @@ func TestInferFields(t *testing.T) {
 	}
 
 	r.Equal([]Field{
-		{Name: "Metadata Test", ValueFormat: "{{ .Metadata.Test }}"},
+		{Name: "Metadata Test", ValueFormat: "{{ if .Metadata }}{{ if .Metadata.Test }}{{ .Metadata.Test }}{{ end }}{{ end }}"},
 	}, inferFields(s7, nil))
 
 	s8 := struct {
@@ -110,7 +110,7 @@ func TestInferFields(t *testing.T) {
 	}
 
 	r.Equal([]Field{
-		{Name: "Metadata Test", ValueFormat: "{{ .Metadata.Test }}"},
+		{Name: "Metadata Test", ValueFormat: "{{ if .Metadata }}{{ if .Metadata.Test }}{{ .Metadata.Test }}{{ end }}{{ end }}"},
 	}, inferFields(s8, nil))
 
 }

--- a/internal/pkg/format/infer_fields_test.go
+++ b/internal/pkg/format/infer_fields_test.go
@@ -97,7 +97,7 @@ func TestInferFields(t *testing.T) {
 	}
 
 	r.Equal([]Field{
-		{Name: "Metadata Test", ValueFormat: "{{ if .Metadata }}{{ if .Metadata.Test }}{{ .Metadata.Test }}{{ end }}{{ end }}"},
+		{Name: "Metadata Test", ValueFormat: "{{ .Metadata.Test }}"},
 	}, inferFields(s7, nil))
 
 	s8 := struct {
@@ -110,7 +110,7 @@ func TestInferFields(t *testing.T) {
 	}
 
 	r.Equal([]Field{
-		{Name: "Metadata Test", ValueFormat: "{{ if .Metadata }}{{ if .Metadata.Test }}{{ .Metadata.Test }}{{ end }}{{ end }}"},
+		{Name: "Metadata Test", ValueFormat: "{{ .Metadata.Test }}"},
 	}, inferFields(s8, nil))
 
 }

--- a/internal/pkg/format/infer_fields_test.go
+++ b/internal/pkg/format/infer_fields_test.go
@@ -97,7 +97,7 @@ func TestInferFields(t *testing.T) {
 	}
 
 	r.Equal([]Field{
-		{Name: "Metadata Test", ValueFormat: "{{ .Metadata.Test }}"},
+		{Name: "Metadata Test", ValueFormat: "{{ with .Metadata }}{{ .Test }}{{ end }}"},
 	}, inferFields(s7, nil))
 
 	s8 := struct {
@@ -110,7 +110,7 @@ func TestInferFields(t *testing.T) {
 	}
 
 	r.Equal([]Field{
-		{Name: "Metadata Test", ValueFormat: "{{ .Metadata.Test }}"},
+		{Name: "Metadata Test", ValueFormat: "{{ with .Metadata }}{{ .Test }}{{ end }}"},
 	}, inferFields(s8, nil))
 
 }

--- a/internal/pkg/format/output.go
+++ b/internal/pkg/format/output.go
@@ -130,16 +130,12 @@ func inferFields[T any](payload T, columns []string) []Field {
 		return
 	}
 
-	var getFields func(st reflect.Type, val reflect.Value, namePrefix []string)
-	getFields = func(st reflect.Type, val reflect.Value, namePrefix []string) {
+	var getFields func(st reflect.Type, namePrefix []string)
+	getFields = func(st reflect.Type, namePrefix []string) {
 		exportedFields := 0
 		for i := 0; i < st.NumField(); i++ {
 			f := st.Field(i)
-			fieldVal := val.Field(i)
 			if !f.IsExported() {
-				continue
-			}
-			if (fieldVal.Type().Kind() == reflect.Pointer && fieldVal.IsNil()) || fieldVal.IsZero() {
 				continue
 			}
 			exportedFields++
@@ -151,9 +147,8 @@ func inferFields[T any](payload T, columns []string) []Field {
 				t := f.Type
 				if f.Type.Kind() == reflect.Ptr {
 					t = f.Type.Elem()
-					fieldVal = fieldVal.Elem()
 				}
-				getFields(t, fieldVal, parts)
+				getFields(t, parts)
 			} else {
 				dotted, formatted := fieldNames(parts)
 				df := NewField(formatted, fmt.Sprintf("{{ .%s }}", dotted))
@@ -175,8 +170,40 @@ func inferFields[T any](payload T, columns []string) []Field {
 	}
 
 	// Gather the fields
-	getFields(st, rv, nil)
+	getFields(st, nil)
+	for i := range ret {
+		ret[i].ValueFormat = convertToScopedWithBlocks(ret[i].ValueFormat)
+	}
 	return ret
+}
+
+// convertToScopedWithBlocks converts a full dot-path into nested `with` blocks using local field scope.
+// {{ .Request.Agent.Op.ActionRunID }} => {{ with .Request }}{{ with .Agent }}{{ with .Op }}{{ .ActionRunID }}{{ end }}{{ end }}{{ end }}
+func convertToScopedWithBlocks(input string) string {
+	input = strings.TrimSpace(input)
+	// Remove surrounding {{ and }} if present
+	if strings.HasPrefix(input, "{{") && strings.HasSuffix(input, "}}") {
+		input = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(input, "{{"), "}}"))
+	}
+	// Only process if input starts with "."
+	if !strings.HasPrefix(input, ".") {
+		return input
+	}
+	// Split by "." and ignore the leading empty string from input[1:]
+	parts := strings.Split(input[1:], ".")
+	if len(parts) < 2 {
+		return "{{ " + input + " }}"
+	}
+	var builder strings.Builder
+	// Open with blocks
+	for _, part := range parts[:len(parts)-1] {
+		builder.WriteString(fmt.Sprintf("{{ with .%s }}", part))
+	}
+	// Final value
+	builder.WriteString(fmt.Sprintf("{{ .%s }}", parts[len(parts)-1]))
+	// Close all with blocks
+	builder.WriteString(strings.Repeat("{{ end }}", len(parts)-1))
+	return strings.TrimSpace(builder.String())
 }
 
 type internalDisplayer[T any] struct {

--- a/internal/pkg/format/output.go
+++ b/internal/pkg/format/output.go
@@ -103,7 +103,7 @@ func inferFields[T any](payload T, columns []string) []Field {
 	toField := map[string]int{}
 
 	for i, col := range columns {
-		toField[col] = i
+		toField[fmt.Sprintf(".%s", col)] = i
 	}
 
 	st := rv.Type()
@@ -119,7 +119,7 @@ func inferFields[T any](payload T, columns []string) []Field {
 	// and the spaced version is the parts joined by a space (e.g. "Cluster Info
 	// Name") and each part spaced on camel case words.
 	fieldNames := func(parts []string) (dotted, spaced string) {
-		dotted = strings.Join(parts, ".")
+		dotted = "." + strings.Join(parts, ".")
 		for i, part := range parts {
 			if i != 0 {
 				spaced += " "
@@ -128,6 +128,28 @@ func inferFields[T any](payload T, columns []string) []Field {
 			spaced += formatName(part)
 		}
 		return
+	}
+
+	dottedToTmpl := func(dotted string) string {
+		parts := strings.Split(dotted, ".")
+		if len(parts) == 2 { // Input has no dots or is just a dot
+			return fmt.Sprintf("{{ %s }}", dotted)
+		}
+		var result []string
+		current := parts[0] // This will be empty string if input starts with dot
+		for i := 1; i < len(parts); i++ {
+			current += "." + parts[i]
+			result = append(result, current)
+		}
+		var sb strings.Builder
+		for _, r := range result {
+			sb.WriteString(fmt.Sprintf("{{ if %s }}", r))
+		}
+		sb.WriteString(fmt.Sprintf("{{ %s }}", result[len(result)-1]))
+		for i, iLen := 0, len(result); i < iLen; i++ {
+			sb.WriteString("{{ end }}")
+		}
+		return sb.String()
 	}
 
 	var getFields func(st reflect.Type, namePrefix []string)
@@ -151,7 +173,7 @@ func inferFields[T any](payload T, columns []string) []Field {
 				getFields(t, parts)
 			} else {
 				dotted, formatted := fieldNames(parts)
-				df := NewField(formatted, fmt.Sprintf("{{ .%s }}", dotted))
+				df := NewField(formatted, dottedToTmpl(dotted))
 				if all {
 					ret = append(ret, df)
 				} else if idx, ok := toField[dotted]; ok {
@@ -165,7 +187,7 @@ func inferFields[T any](payload T, columns []string) []Field {
 		// any String() method on the struct.
 		if exportedFields == 0 {
 			dotted, formatted := fieldNames(namePrefix)
-			ret = append(ret, NewField(formatted, fmt.Sprintf("{{ .%s}}", dotted)))
+			ret = append(ret, NewField(formatted, dottedToTmpl(dotted)))
 		}
 	}
 

--- a/internal/pkg/format/output_test.go
+++ b/internal/pkg/format/output_test.go
@@ -5,6 +5,7 @@ package format_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/hcp/internal/pkg/format"
@@ -39,4 +40,31 @@ func TestOutputter_SetFormat(t *testing.T) {
 	var parsed *KV
 	r.NoError(json.Unmarshal(io.Output.Bytes(), &parsed))
 	r.Equal(d.KVs[0], parsed)
+}
+
+type InnerStruct struct {
+	Name string
+}
+
+type OuterStruct struct {
+	Name  string
+	Inner *InnerStruct
+}
+
+func TestNilInnerStruct(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	kv := &OuterStruct{
+		Name: "OuterStruct",
+		// we leave inner nil on purpose
+	}
+
+	io := iostreams.Test()
+	out := format.New(io)
+	err := out.Show(kv, format.Pretty)
+
+	fmt.Println("err", err)
+	// r.NoError(err)
+	r.Equal("Name:       OuterStruct\nInner:      <nil>\n", io.Output.String())
 }

--- a/internal/pkg/format/output_test.go
+++ b/internal/pkg/format/output_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	example "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
 )
@@ -72,7 +73,7 @@ func TestNilInnerStruct(t *testing.T) {
 
 	r.NoError(err)
 	fmt.Println(io.Output.String())
-	r.Equal("Name: OuterStruct\n", io.Output.String())
+	r.Equal("Name:             OuterStruct\nInner Name:       \nInner Inner Name: \n", io.Output.String())
 }
 
 func TestNilInnerL2Struct(t *testing.T) {
@@ -93,7 +94,7 @@ func TestNilInnerL2Struct(t *testing.T) {
 
 	r.NoError(err)
 	fmt.Println(io.Output.String())
-	r.Equal("Name:       OuterStruct\nInner Name: InnerL1Struct\n", io.Output.String())
+	r.Equal("Name:             OuterStruct\nInner Name:       InnerL1Struct\nInner Inner Name: \n", io.Output.String())
 }
 
 func TestNonNilInnerStruct(t *testing.T) {
@@ -117,4 +118,76 @@ func TestNonNilInnerStruct(t *testing.T) {
 	r.NoError(err)
 	fmt.Println(io.Output.String())
 	r.Equal("Name:             OuterStruct\nInner Name:       InnerL1Struct\nInner Inner Name: InnerStruct\n", io.Output.String())
+}
+
+func TestWithSlice(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	j := `{
+  "action_configs": [
+    {
+      "id": "00000000-0000-0000-0000-000000000000",
+      "action_url": "",
+      "name": "Agent Smith",
+      "request": {
+        "agent": {
+          "op": {
+            "id": "Agent Smith",
+            "body": "",
+            "action_run_id": "",
+            "group": "Enforcements"
+          }
+        }
+      },
+      "description": "test description",
+      "created_at": "2024-08-16T18:11:19.777071Z"
+    },
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "action_url": "",
+      "name": "Example",
+      "request": {
+        "custom": {
+          "method": "GET",
+          "headers": [],
+          "url": "https://hashicorp.com",
+          "body": ""
+        }
+      },
+      "description": "Runs an action against https://hashicorp.com",
+      "created_at": "2024-06-13T17:31:17.436255Z"
+    },
+    {
+      "id": "22222222-2222-2222-2222-222222222222",
+      "action_url": "",
+      "name": "Variables",
+      "request": {
+        "custom": {
+          "method": "GET",
+          "headers": [],
+          "url": "https://${var.company}.com",
+          "body": ""
+        }
+      },
+      "description": "An action to test the variables feature.",
+      "created_at": "2024-08-07T21:56:00.043627Z"
+    }
+  ],
+  "pagination": {
+    "next_page_token": "",
+    "previous_page_token": ""
+  }
+}`
+	thing := example.HashicorpCloudWaypointListActionConfigResponse{}
+	err := json.Unmarshal([]byte(j), &thing)
+	r.NoError(err)
+	io := iostreams.Test()
+	out := format.New(io)
+	err = out.Show(thing.ActionConfigs, format.Pretty)
+
+	r.NoError(err)
+	fmt.Println(io.Output.String())
+	r.Equal(
+		"Action UR L:                     \nCreated At:                      2024-08-16T18:11:19.777Z\nDescription:                     test description\nID:                              00000000-0000-0000-0000-000000000000\nName:                            Agent Smith\nRequest Agent Op Action Run ID:  \nRequest Agent Op Body:           \nRequest Agent Op Group:          Enforcements\nRequest Agent Op ID:             Agent Smith\nRequest Custom Body:             \nRequest Custom Headers:          \nRequest Custom Method:           \nRequest Custom UR L:             \nRequest Github Auth Token:       \nRequest Github Enable Debug Log: \nRequest Github Inputs:           \nRequest Github Method:           \nRequest Github Ref:              \nRequest Github Repo:             \nRequest Github Run ID:           \nRequest Github Username:         \nRequest Github Workflow ID:      \n---\nAction UR L:                     \nCreated At:                      2024-06-13T17:31:17.436Z\nDescription:                     Runs an action against https://hashicorp.com\nID:                              11111111-1111-1111-1111-111111111111\nName:                            Example\nRequest Agent Op Action Run ID:  \nRequest Agent Op Body:           \nRequest Agent Op Group:          \nRequest Agent Op ID:             \nRequest Custom Body:             \nRequest Custom Headers:          []\nRequest Custom Method:           GET\nRequest Custom UR L:             https://hashicorp.com\nRequest Github Auth Token:       \nRequest Github Enable Debug Log: \nRequest Github Inputs:           \nRequest Github Method:           \nRequest Github Ref:              \nRequest Github Repo:             \nRequest Github Run ID:           \nRequest Github Username:         \nRequest Github Workflow ID:      \n---\nAction UR L:                     \nCreated At:                      2024-08-07T21:56:00.043Z\nDescription:                     An action to test the variables feature.\nID:                              22222222-2222-2222-2222-222222222222\nName:                            Variables\nRequest Agent Op Action Run ID:  \nRequest Agent Op Body:           \nRequest Agent Op Group:          \nRequest Agent Op ID:             \nRequest Custom Body:             \nRequest Custom Headers:          []\nRequest Custom Method:           GET\nRequest Custom UR L:             https://${var.company}.com\nRequest Github Auth Token:       \nRequest Github Enable Debug Log: \nRequest Github Inputs:           \nRequest Github Method:           \nRequest Github Ref:              \nRequest Github Repo:             \nRequest Github Run ID:           \nRequest Github Username:         \nRequest Github Workflow ID:      \n",
+		io.Output.String())
 }

--- a/internal/pkg/format/output_test.go
+++ b/internal/pkg/format/output_test.go
@@ -72,7 +72,7 @@ func TestNilInnerStruct(t *testing.T) {
 
 	r.NoError(err)
 	fmt.Println(io.Output.String())
-	r.Equal("Name:             OuterStruct\nInner Name:       \nInner Inner Name: \n", io.Output.String())
+	r.Equal("Name: OuterStruct\n", io.Output.String())
 }
 
 func TestNilInnerL2Struct(t *testing.T) {
@@ -93,7 +93,7 @@ func TestNilInnerL2Struct(t *testing.T) {
 
 	r.NoError(err)
 	fmt.Println(io.Output.String())
-	r.Equal("Name:             OuterStruct\nInner Name:       InnerL1Struct\nInner Inner Name: \n", io.Output.String())
+	r.Equal("Name:       OuterStruct\nInner Name: InnerL1Struct\n", io.Output.String())
 }
 
 func TestNonNilInnerStruct(t *testing.T) {

--- a/internal/pkg/format/output_test.go
+++ b/internal/pkg/format/output_test.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/iostreams"
-	"github.com/stretchr/testify/require"
 )
 
 func TestOutputter_SetFormat(t *testing.T) {
@@ -42,13 +43,18 @@ func TestOutputter_SetFormat(t *testing.T) {
 	r.Equal(d.KVs[0], parsed)
 }
 
-type InnerStruct struct {
+type InnerL2Struct struct {
 	Name string
+}
+
+type InnerL1Struct struct {
+	Name  string
+	Inner *InnerL2Struct
 }
 
 type OuterStruct struct {
 	Name  string
-	Inner *InnerStruct
+	Inner *InnerL1Struct
 }
 
 func TestNilInnerStruct(t *testing.T) {
@@ -64,7 +70,51 @@ func TestNilInnerStruct(t *testing.T) {
 	out := format.New(io)
 	err := out.Show(kv, format.Pretty)
 
-	fmt.Println("err", err)
-	// r.NoError(err)
-	r.Equal("Name:       OuterStruct\nInner:      <nil>\n", io.Output.String())
+	r.NoError(err)
+	fmt.Println(io.Output.String())
+	r.Equal("Name:             OuterStruct\nInner Name:       \nInner Inner Name: \n", io.Output.String())
+}
+
+func TestNilInnerL2Struct(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	kv := &OuterStruct{
+		Name: "OuterStruct",
+		Inner: &InnerL1Struct{
+			Name: "InnerL1Struct",
+			// we leave inner nil on purpose
+		},
+	}
+
+	io := iostreams.Test()
+	out := format.New(io)
+	err := out.Show(kv, format.Pretty)
+
+	r.NoError(err)
+	fmt.Println(io.Output.String())
+	r.Equal("Name:             OuterStruct\nInner Name:       InnerL1Struct\nInner Inner Name: \n", io.Output.String())
+}
+
+func TestNonNilInnerStruct(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	kv := &OuterStruct{
+		Name: "OuterStruct",
+		Inner: &InnerL1Struct{
+			Name: "InnerL1Struct",
+			Inner: &InnerL2Struct{
+				Name: "InnerStruct",
+			},
+		},
+	}
+
+	io := iostreams.Test()
+	out := format.New(io)
+	err := out.Show(kv, format.Pretty)
+
+	r.NoError(err)
+	fmt.Println(io.Output.String())
+	r.Equal("Name:             OuterStruct\nInner Name:       InnerL1Struct\nInner Inner Name: InnerStruct\n", io.Output.String())
 }


### PR DESCRIPTION
### :hammer_and_wrench:  Description

Fix an issue where pretty print was causing a panic.

Thank you @phanidevavarapu for the fix.

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->

Fixes HCPCP-1710

### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [ ] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
