### PR TITLE
Format: Exclude empty field values for pretty print formatter

### DIFF
--- a/internal/pkg/format/output_test.go
+++ b/internal/pkg/format/output_test.go
@@ -72,7 +72,7 @@ func TestNilInnerStruct(t *testing.T) {
 
 	r.NoError(err)
 	fmt.Println(io.Output.String())
-	r.Equal("Name:             OuterStruct\nInner Name:       \nInner Inner Name: \n", io.Output.String())
+	r.Equal("Name: OuterStruct\n", io.Output.String())
 }
 
 func TestNilInnerL2Struct(t *testing.T) {
@@ -93,7 +93,7 @@ func TestNilInnerL2Struct(t *testing.T) {
 
 	r.NoError(err)
 	fmt.Println(io.Output.String())
-	r.Equal("Name:             OuterStruct\nInner Name:       InnerL1Struct\nInner Inner Name: \n", io.Output.String())
+	r.Equal("Name:       OuterStruct\nInner Name: InnerL1Struct\n", io.Output.String())
 }
 
 func TestNonNilInnerStruct(t *testing.T) {


### PR DESCRIPTION
Prior to this commit, the CLI would keep any nil or empty field values while pretty printing, unlike the json format which will omit any empty fields. This commit updates the pretty print formatter to behave in the same way the json formatter does by omitting any empty fields.

### :hammer_and_wrench:  Description

Prior to this commit, using PR https://github.com/hashicorp/hcp/pull/225, although it would fix the panic:

```
brian@brian-LNQ0KYW6HD:hcp λ hcp waypoint actions list                  ±[●][format/exclude-nil-field-values-on-pretty-print]
Action UR L:
Created At:                      2024-08-16T18:11:19.777Z
Description:                     You hear that Mr. Anderson?...That is the sound of inevitability...It is the sound of your death...Goodbye, Mr. Anderson...
ID:                              <OMITTED>
Name:                            Agent Smith
Request Agent Op Action Run ID:
Request Agent Op Body:
Request Agent Op Group:          Enforcements
Request Agent Op ID:             Agent Smith
Request Custom Body:             ERROR: template: hcp:10:44: executing "hcp" at <.Request.Custom.Body>: nil pointer evaluating
*models.HashicorpCloudWaypointActionConfigFlavorCustom.Body
```

Now, we'll be printing extra empty values which clutters the CLI output:

```
brian@brian-LNQ0KYW6HD:hcp λ hcp waypoint actions list                                                             ±[●][main]
Action UR L:
Created At:                      2024-08-16T18:11:19.777Z
Description:                     You hear that Mr. Anderson?...That is the sound of inevitability...It is the sound of your death...Goodbye, Mr. Anderson...
ID:                              <OMITTED>
Name:                            Agent Smith
Request Agent Op Action Run ID:
Request Agent Op Body:
Request Agent Op Group:          Enforcements
Request Agent Op ID:             Agent Smith
Request Custom Body:
Request Custom Headers:
Request Custom Method:
Request Custom UR L:
Request Github Auth Token:
Request Github Enable Debug Log:
Request Github Inputs:
Request Github Method:
Request Github Ref:
Request Github Repo:
Request Github Run ID:
Request Github Username:
Request Github Workflow ID:
---
Action UR L:
Created At:                      2024-06-13T17:31:17.436Z
Description:                     Runs an action against https://hashicorp.com
ID:                              <OMITTED>
Name:                            Example
Request Agent Op Action Run ID:
Request Agent Op Body:
Request Agent Op Group:
Request Agent Op ID:
Request Custom Body:
Request Custom Headers:
Request Custom Method:           GET
Request Custom UR L:             https://hashicorp.com
Request Github Auth Token:
Request Github Enable Debug Log:
Request Github Inputs:
Request Github Method:
Request Github Ref:
Request Github Repo:
Request Github Run ID:
Request Github Username:
Request Github Workflow ID:
---
Action UR L:
Created At:                      2024-08-07T21:56:00.043Z
Description:                     An action to test the variables feature.
ID:                              <OMITTED>
Name:                            Variables
Request Agent Op Action Run ID:
Request Agent Op Body:
Request Agent Op Group:
Request Agent Op ID:
Request Custom Body:
Request Custom Headers:
Request Custom Method:           GET
Request Custom UR L:             https://${var.company}.com
Request Github Auth Token:
Request Github Enable Debug Log:
Request Github Inputs:
Request Github Method:
Request Github Ref:
Request Github Repo:
Request Github Run ID:
Request Github Username:
Request Github Workflow ID:
```

With this PR, it now omits empty value structs from the fields list, which keeps the pretty print displayer _only_ displaying structs with values:

```
brian@brian-LNQ0KYW6HD:hcp λ hcp waypoint actions list                  ±[●][format/exclude-nil-field-values-on-pretty-print]
Created At:             2024-08-16T18:11:19.777Z
Description:            You hear that Mr. Anderson?...That is the sound of inevitability...It is the sound of your death...Goodbye, Mr. Anderson...
ID:                     <OMITTED>
Name:                   Agent Smith
Request Agent Op Body:
Request Agent Op Group: Enforcements
Request Agent Op ID:    Agent Smith
---
Created At:             2024-06-13T17:31:17.436Z
Description:            Runs an action against https://hashicorp.com
ID:                     <OMITTED>
Name:                   Example
Request Agent Op Body:
Request Agent Op Group:
Request Agent Op ID:
---
Created At:             2024-08-07T21:56:00.043Z
Description:            An action to test the variables feature.
ID:                     <OMITTED>
Name:                   Variables
Request Agent Op Body:
Request Agent Op Group:
Request Agent Op ID:
```

### :link:  Additional Link

Fixes HCPCP-1710

### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [x] The PR has a descriptive title.
- [x] Input validation updated
- [x] Unit tests updated
- [x] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)
