### PR TITLE
Enable creating an agent-flavored Waypoint Action

### DIFF
--- a/internal/commands/waypoint/actions/action.go
+++ b/internal/commands/waypoint/actions/action.go
@@ -4,6 +4,7 @@
 package actions
 
 import (
+	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 )
@@ -14,14 +15,14 @@ func NewCmdActionConfig(ctx *cmd.Context) *cmd.Command {
 		ShortHelp: "Manage action configuration options for HCP Waypoint.",
 		LongHelp: heredoc.New(ctx.IO).Must(`
 		The {{ template "mdCodeOrBold" "hcp waypoint actions" }} command group
-		manages all action options for HCP Waypoint. An action is a set of 
+		manages all action options for HCP Waypoint. An action is a set of
 		options that define how an action is executed. This includes the action
-		request type, and the action name. The action is used to launch action 
+		request type, and the action name. The action is used to launch action
 		runs depending on the Request type.
 		`),
 	}
 
-	cmd.AddChild(NewCmdCreate(ctx))
+	cmd.AddChild(NewCmdCreate(ctx, &CreateOpts{WaypointOpts: opts.New(ctx)}))
 	cmd.AddChild(NewCmdRead(ctx))
 	cmd.AddChild(NewCmdUpdate(ctx))
 	cmd.AddChild(NewCmdDelete(ctx))

--- a/internal/commands/waypoint/actions/create_test.go
+++ b/internal/commands/waypoint/actions/create_test.go
@@ -1,0 +1,269 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package actions
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
+	mock_waypoint_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmdCreate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Setup   func(ws *mock_waypoint_service.MockClientService)
+		Error   string
+		Expect  *CreateOpts
+	}{
+		{
+			Name:    "No org or project",
+			Profile: profile.TestProfile,
+			Args:    []string{"--name=foo"},
+			Error:   "Organization ID and Project ID must be configured before running the command.",
+		},
+		{
+			Name: "Custom action success",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args: []string{"--name=foo", "--url=https://example.com", "--method=POST"},
+			Expect: &CreateOpts{
+				Name: "foo",
+				Request: &models.HashicorpCloudWaypointActionConfigRequest{
+					Custom: &models.HashicorpCloudWaypointActionConfigFlavorCustom{
+						URL: "https://example.com",
+					},
+				},
+				RequestCustomMethod: "POST",
+			},
+		},
+		{
+			Name: "Custom action with multiple headers",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args: []string{
+				"--name=foo",
+				"--url=https://example.com",
+				"--method=POST",
+				"--header=X-First=abc",
+				"--header=Second=123",
+			},
+			Expect: &CreateOpts{
+				Name: "foo",
+				Request: &models.HashicorpCloudWaypointActionConfigRequest{
+					Custom: &models.HashicorpCloudWaypointActionConfigFlavorCustom{
+						URL: "https://example.com",
+						Headers: []*models.HashicorpCloudWaypointActionConfigFlavorCustomHeader{
+							{Key: "X-First", Value: "abc"},
+							{Key: "Second", Value: "123"},
+						},
+					},
+				},
+				RequestCustomMethod: "POST",
+			},
+		},
+		{
+			Name: "Agent action success",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args: []string{"--name=foo", "--agent-group=bar", "--agent-operation=launch"},
+			Expect: &CreateOpts{
+				Name:           "foo",
+				AgentGroup:     "bar",
+				AgentOperation: "launch",
+			},
+		},
+		{
+			Name: "Mix of custom and agent options",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args:  []string{"--name=foo", "--url=https://example.com", "--agent-group=bar"},
+			Error: "cannot specify both custom action and agent action flags",
+		},
+		{
+			Name: "API error",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args:  []string{"--name=foo", "--url=https://example.com"},
+			Error: "failed to create action \"foo\": api error",
+			Setup: func(ws *mock_waypoint_service.MockClientService) {
+				call := ws.EXPECT().WaypointServiceCreateActionConfig(mock.Anything, mock.Anything)
+				call.Return(nil, errors.New("api error"))
+			},
+		},
+		{
+			Name: "Missing name",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args:  []string{"--description=foo", "--url=https://example.com"},
+			Error: "missing required flag: --name=NAME",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts CreateOpts
+			cmd := NewCmdCreate(ctx, &gotOpts)
+			cmd.SetIO(io)
+
+			ws := mock_waypoint_service.NewMockClientService(t)
+			gotOpts.WS2024Client = ws
+			if c.Error == "" {
+				call := ws.EXPECT().WaypointServiceCreateActionConfig(mock.Anything, mock.Anything)
+				ok := waypoint_service.NewWaypointServiceCreateActionConfigOK()
+				call.Return(ok, nil)
+			}
+			if c.Setup != nil {
+				c.Setup(ws)
+			}
+
+			code := cmd.Run(c.Args)
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			if c.Expect != nil {
+				r.NotNil(gotOpts)
+				r.Equal(c.Expect.Name, gotOpts.Name)
+				if c.Expect.Description != "" {
+					r.Equal(c.Expect.Description, gotOpts.Description)
+				}
+				if c.Expect.Request != nil {
+					r.Equal(c.Expect.Request.Custom.URL, gotOpts.Request.Custom.URL)
+					r.Equal(c.Expect.RequestCustomMethod, gotOpts.RequestCustomMethod)
+					if c.Expect.Request.Custom.Headers != nil {
+						r.ElementsMatch(c.Expect.Request.Custom.Headers, gotOpts.Request.Custom.Headers)
+					}
+				}
+				if c.Expect.AgentGroup != "" {
+					r.Equal(c.Expect.AgentGroup, gotOpts.AgentGroup)
+				}
+				if c.Expect.AgentOperation != "" {
+					r.Equal(c.Expect.AgentOperation, gotOpts.AgentOperation)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateAction(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name      string
+		Setup     func(*CreateOpts, *mock_waypoint_service.MockClientService)
+		ExpectErr string
+		ExpectOut string
+	}{
+		{
+			Name: "Custom action success",
+			Setup: func(opts *CreateOpts, ws *mock_waypoint_service.MockClientService) {
+				opts.Name = "foo"
+				opts.Description = "desc"
+				opts.Request.Custom.URL = "https://example.com"
+				opts.RequestCustomMethod = "POST"
+				call := ws.EXPECT().WaypointServiceCreateActionConfig(mock.Anything, mock.Anything)
+				ok := waypoint_service.NewWaypointServiceCreateActionConfigOK()
+				call.Return(ok, nil)
+			},
+			ExpectErr: "",
+			ExpectOut: "foo",
+		},
+		{
+			Name: "Agent action success",
+			Setup: func(opts *CreateOpts, ws *mock_waypoint_service.MockClientService) {
+				opts.Name = "bar"
+				opts.Description = "desc2"
+				opts.AgentGroup = "group1"
+				opts.AgentOperation = "op1"
+				call := ws.EXPECT().WaypointServiceCreateActionConfig(mock.Anything, mock.Anything)
+				ok := waypoint_service.NewWaypointServiceCreateActionConfigOK()
+				call.Return(ok, nil)
+			},
+			ExpectErr: "",
+			ExpectOut: "bar",
+		},
+		{
+			Name: "API error",
+			Setup: func(opts *CreateOpts, ws *mock_waypoint_service.MockClientService) {
+				opts.Name = "fail"
+				opts.Request.Custom.URL = "https://fail.com"
+				call := ws.EXPECT().WaypointServiceCreateActionConfig(mock.Anything, mock.Anything)
+				call.Return(nil, errors.New("api error"))
+			},
+			ExpectErr: "failed to create action \"fail\": api error",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			ws := mock_waypoint_service.NewMockClientService(t)
+			opts := &CreateOpts{
+				WaypointOpts: opts.WaypointOpts{
+					Ctx:          context.Background(),
+					Profile:      profile.TestProfile(t).SetOrgID("123").SetProjectID("456"),
+					Output:       format.New(io),
+					WS2024Client: ws,
+				},
+				Request: &models.HashicorpCloudWaypointActionConfigRequest{
+					Custom: &models.HashicorpCloudWaypointActionConfigFlavorCustom{},
+				},
+			}
+			c.Setup(opts, ws)
+
+			err := createAction(nil, nil, opts)
+			if c.ExpectErr != "" {
+				r.Error(err)
+				r.Contains(err.Error(), c.ExpectErr)
+				return
+			}
+			r.NoError(err)
+			if c.ExpectOut != "" {
+				r.Contains(io.Output.String(), c.ExpectOut)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### :hammer_and_wrench:  Description

This PR updates the `hcp waypoint actions create` command to enable creating [agent-type Waypoint Actions](https://developer.hashicorp.com/hcp/docs/waypoint/agent-create#create-an-action). It also adds tests and improves the help for the command by adding `DisplayValue`s (and explicitly makes `--name` a required flag, because it is). The command output has been updated to be more consistent with other HCP CLI create commands as well.

WAYP-3275

### :building_construction:  Local Testing

```sh
$ ./bin/hcp waypoint actions create --help
USAGE
  hcp waypoint actions create --name=NAME [Optional Flags]

DESCRIPTION
  The hcp waypoint actions create command creates a new action to be used to
  launch an action with.

REQUIRED FLAGS
  -n, --name=NAME
    The name of the action.

OPTIONAL FLAGS
  --agent-group=GROUP
    The agent group to use for the action.

  --agent-operation=OPERATION
    The operation ID to run in the agent group.

  --body=BODY
    The request body to submit when running the action.

  -d, --description=DESCRIPTION
    The description of the action.

  --header=KEY=VALUE [Repeatable]
    The headers to include in the request. This flag can be specified multiple
    times.

  --method=METHOD
    The HTTP method to use when making the request.

  --url=URL
    The URL of the action.

GLOBAL FLAGS
  --debug, --format=FORMAT, --profile=NAME, --project=ID, --quiet

  For more global flag details, run $ hcp —help

$ ./bin/hcp waypoint actions create --name="test-say-hello" --description="Say hello" --agent-group="group1" --agent-operation="say-hello"
Name:            test-say-hello
Description:     Say hello
Agent Group:     group1
Agent Operation: say-hello
```

### :+1:  Checklist

- [x] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [x] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.