### PR TITLE
Add commands to read and update a Waypoint Agent group

### DIFF
--- a/.changelog/237.txt
+++ b/.changelog/237.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+waypoint: Add `hcp waypoint agent group read` and `hcp waypoint agent group update` commands to read and update Waypoint Agent groups.
+```

--- a/internal/commands/waypoint/agent/group.go
+++ b/internal/commands/waypoint/agent/group.go
@@ -37,6 +37,8 @@ func NewCmdGroup(ctx *cmd.Context) *cmd.Command {
 	cmd.AddChild(NewCmdGroupCreate(ctx, opts))
 	cmd.AddChild(NewCmdGroupList(ctx, opts))
 	cmd.AddChild(NewCmdGroupDelete(ctx, opts))
+	cmd.AddChild(NewCmdGroupUpdate(ctx, opts))
+	cmd.AddChild(NewCmdGroupRead(ctx, opts))
 
 	return cmd
 }

--- a/internal/commands/waypoint/agent/group_create.go
+++ b/internal/commands/waypoint/agent/group_create.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
-	"github.com/hashicorp/hcp/internal/pkg/format"
 	"github.com/hashicorp/hcp/internal/pkg/heredoc"
 )
 
@@ -36,7 +35,7 @@ func NewCmdGroupCreate(ctx *cmd.Context, opts *GroupOpts) *cmd.Command {
 				{
 					Name:         "description",
 					Shorthand:    "d",
-					DisplayValue: "TEXT",
+					DisplayValue: "DESCRIPTION",
 					Description:  "Description for the group.",
 					Value:        flagvalue.Simple("", &opts.Description),
 				},
@@ -82,5 +81,9 @@ func agentGroupCreate(log hclog.Logger, opts *GroupOpts) error {
 		return fmt.Errorf("error creating group: %w", err)
 	}
 
-	return opts.Output.Show(grp, format.Pretty, "name", "description")
+	fmt.Fprintf(opts.IO.Err(), "%s Group %q created\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name,
+	)
+	return nil
 }

--- a/internal/commands/waypoint/agent/group_delete.go
+++ b/internal/commands/waypoint/agent/group_delete.go
@@ -64,6 +64,9 @@ func agentGroupDelete(log hclog.Logger, opts *GroupOpts) error {
 		return fmt.Errorf("error deleting group: %w", err)
 	}
 
-	fmt.Fprintf(opts.IO.Err(), "Group deleted\n")
+	fmt.Fprintf(opts.IO.Err(), "%s Group %q deleted\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name,
+	)
 	return nil
 }

--- a/internal/commands/waypoint/agent/group_read.go
+++ b/internal/commands/waypoint/agent/group_read.go
@@ -1,0 +1,77 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package agent
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+	"github.com/pkg/errors"
+)
+
+func NewCmdGroupRead(ctx *cmd.Context, opts *GroupOpts) *cmd.Command {
+	cmd := &cmd.Command{
+		Name:      "read",
+		ShortHelp: "Read details about a Waypoint Agent group.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp waypoint agent group read" }} command reads details about a Waypoint Agent group.
+		`),
+		Examples: []cmd.Example{
+			{
+				Preamble: "Read a group by name:",
+				Command:  "$ hcp waypoint agent group read -n='prod:us-west-2'",
+			},
+		},
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "name",
+					Shorthand:    "n",
+					DisplayValue: "NAME",
+					Description:  "Name of the group to read.",
+					Value:        flagvalue.Simple("", &opts.Name),
+					Required:     true,
+				},
+			},
+		},
+		PersistentPreRun: func(c *cmd.Command, args []string) error {
+			return cmd.RequireOrgAndProject(ctx)
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			if opts.testFunc != nil {
+				return opts.testFunc(c, args)
+			}
+			return agentGroupRead(opts)
+		},
+	}
+	return cmd
+}
+
+func agentGroupRead(opts *GroupOpts) error {
+	resp, err := opts.WS2024Client.WaypointServiceGetAgentGroup(&waypoint_service.WaypointServiceGetAgentGroupParams{
+		Name:                            opts.Name,
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
+		Context:                         opts.Ctx,
+	}, nil)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get agent group %q", opts.Name)
+	}
+
+	if resp.GetPayload() == nil || resp.GetPayload().Group == nil {
+		return fmt.Errorf("no group found with name %q", opts.Name)
+	}
+	group := resp.GetPayload().Group
+
+	fields := []format.Field{
+		format.NewField("Name", "{{ .Name }}"),
+		format.NewField("Description", "{{ .Description }}"),
+	}
+	d := format.NewDisplayer(group, format.Pretty, fields)
+	return opts.Output.Display(d)
+}

--- a/internal/commands/waypoint/agent/group_read_test.go
+++ b/internal/commands/waypoint/agent/group_read_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
+	mock_waypoint_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmdGroupRead(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *GroupOpts
+	}{
+		{
+			Name:    "No org or project",
+			Profile: profile.TestProfile,
+			Args:    []string{"--name=foo"},
+			Error:   "Organization ID and Project ID must be configured before running the command.",
+		},
+		{
+			Name: "No name",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args:  []string{},
+			Error: "missing required flag: --name=NAME",
+		},
+		{
+			Name: "Good",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args: []string{"-n", "foo"},
+			Expect: &GroupOpts{
+				Name: "foo",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts GroupOpts
+			gotOpts.testFunc = func(c *cmd.Command, args []string) error {
+				return nil
+			}
+			gotOpts.WS2024Client = mock_waypoint_service.NewMockClientService(t)
+			cmd := NewCmdGroupRead(ctx, &gotOpts)
+			cmd.SetIO(io)
+
+			code := cmd.Run(c.Args)
+
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+			if c.Expect != nil {
+				r.Equal(c.Expect.Name, gotOpts.Name)
+			}
+		})
+	}
+}
+
+func TestAgentGroupRead(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name      string
+		SetupMock func(ws *mock_waypoint_service.MockClientService)
+		Opts      *GroupOpts
+		Error     string
+	}{
+		{
+			Name: "API error",
+			SetupMock: func(ws *mock_waypoint_service.MockClientService) {
+				ws.EXPECT().WaypointServiceGetAgentGroup(mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded)
+			},
+			Opts: &GroupOpts{
+				Name: "foo",
+				WaypointOpts: opts.WaypointOpts{
+					Ctx:     context.Background(),
+					Profile: profile.TestProfile(t).SetOrgID("123").SetProjectID("456"),
+					IO:      iostreams.Test(),
+					Output:  format.New(iostreams.Test()),
+				},
+			},
+			Error: "failed to get agent group \"foo\"",
+		},
+		{
+			Name: "Not found",
+			SetupMock: func(ws *mock_waypoint_service.MockClientService) {
+				ok := waypoint_service.NewWaypointServiceGetAgentGroupOK()
+				ok.Payload = &models.HashicorpCloudWaypointGetAgentGroupResponse{Group: nil}
+				ws.EXPECT().WaypointServiceGetAgentGroup(mock.Anything, mock.Anything).Return(ok, nil)
+			},
+			Opts: &GroupOpts{
+				Name: "foo",
+				WaypointOpts: opts.WaypointOpts{
+					Ctx:     context.Background(),
+					Profile: profile.TestProfile(t).SetOrgID("123").SetProjectID("456"),
+					IO:      iostreams.Test(),
+					Output:  format.New(iostreams.Test()),
+				},
+			},
+			Error: "no group found with name \"foo\"",
+		},
+		{
+			Name: "Success",
+			SetupMock: func(ws *mock_waypoint_service.MockClientService) {
+				ok := waypoint_service.NewWaypointServiceGetAgentGroupOK()
+				ok.Payload = &models.HashicorpCloudWaypointGetAgentGroupResponse{
+					Group: &models.HashicorpCloudWaypointAgentGroup{
+						Name:        "foo",
+						Description: "desc",
+					},
+				}
+				ws.EXPECT().WaypointServiceGetAgentGroup(mock.Anything, mock.Anything).Return(ok, nil)
+			},
+			Opts: &GroupOpts{
+				Name: "foo",
+				WaypointOpts: opts.WaypointOpts{
+					Ctx:     context.Background(),
+					Profile: profile.TestProfile(t).SetOrgID("123").SetProjectID("456"),
+					IO:      iostreams.Test(),
+					Output:  format.New(iostreams.Test()),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			ws := mock_waypoint_service.NewMockClientService(t)
+			if c.SetupMock != nil {
+				c.SetupMock(ws)
+			}
+			c.Opts.WS2024Client = ws
+
+			err := agentGroupRead(c.Opts)
+			if c.Error != "" {
+				r.ErrorContains(err, c.Error)
+				return
+			}
+			r.NoError(err)
+		})
+	}
+}

--- a/internal/commands/waypoint/agent/group_update.go
+++ b/internal/commands/waypoint/agent/group_update.go
@@ -1,0 +1,88 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package agent
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/flagvalue"
+	"github.com/hashicorp/hcp/internal/pkg/heredoc"
+)
+
+func NewCmdGroupUpdate(ctx *cmd.Context, opts *GroupOpts) *cmd.Command {
+	cmd := &cmd.Command{
+		Name:      "update",
+		ShortHelp: "Update an HCP Waypoint Agent group.",
+		LongHelp: heredoc.New(ctx.IO).Must(`
+		The {{ template "mdCodeOrBold" "hcp waypoint agent group update" }} command updates an existing Agent group.
+		`),
+		Flags: cmd.Flags{
+			Local: []*cmd.Flag{
+				{
+					Name:         "name",
+					Shorthand:    "n",
+					DisplayValue: "NAME",
+					Description:  "Name of the group to update.",
+					Value:        flagvalue.Simple("", &opts.Name),
+					Required:     true,
+				},
+				{
+					Name:         "description",
+					Shorthand:    "d",
+					DisplayValue: "DESCRIPTION",
+					Description:  "New description for the group.",
+					Value:        flagvalue.Simple("", &opts.Description),
+				},
+			},
+		},
+		Examples: []cmd.Example{
+			{
+				Preamble: "Update a group's description:",
+				Command:  "$ hcp waypoint agent group update -n='prod:us-west-2' -d='updated description'",
+			},
+		},
+		PersistentPreRun: func(c *cmd.Command, args []string) error {
+			return cmd.RequireOrgAndProject(ctx)
+		},
+		RunF: func(c *cmd.Command, args []string) error {
+			if opts.testFunc != nil {
+				return opts.testFunc(c, args)
+			}
+			return agentGroupUpdate(c.Logger(), opts)
+		},
+	}
+
+	return cmd
+}
+
+func agentGroupUpdate(log hclog.Logger, opts *GroupOpts) error {
+	ctx := opts.Ctx
+
+	update := &models.HashicorpCloudWaypointV20241122WaypointServiceUpdateAgentGroupBody{
+		Description: opts.Description,
+	}
+
+	_, err := opts.WS2024Client.WaypointServiceUpdateAgentGroup(&waypoint_service.WaypointServiceUpdateAgentGroupParams{
+		Name:                            opts.Name,
+		NamespaceLocationOrganizationID: opts.Profile.OrganizationID,
+		NamespaceLocationProjectID:      opts.Profile.ProjectID,
+		Body:                            update,
+		Context:                         ctx,
+	}, nil)
+
+	if err != nil {
+		return fmt.Errorf("error updating group: %w", err)
+	}
+
+	fmt.Fprintf(opts.IO.Err(), "%s Group %q updated\n",
+		opts.IO.ColorScheme().SuccessIcon(),
+		opts.Name,
+	)
+	return nil
+}

--- a/internal/commands/waypoint/agent/group_update_test.go
+++ b/internal/commands/waypoint/agent/group_update_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp/internal/commands/waypoint/opts"
+	mock_waypoint_service "github.com/hashicorp/hcp/internal/pkg/api/mocks/github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp/internal/pkg/cmd"
+	"github.com/hashicorp/hcp/internal/pkg/format"
+	"github.com/hashicorp/hcp/internal/pkg/iostreams"
+	"github.com/hashicorp/hcp/internal/pkg/profile"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmdGroupUpdate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name    string
+		Args    []string
+		Profile func(t *testing.T) *profile.Profile
+		Error   string
+		Expect  *GroupOpts
+	}{
+		{
+			Name:    "No org or project",
+			Profile: profile.TestProfile,
+			Args:    []string{"--name=foo"},
+			Error:   "Organization ID and Project ID must be configured before running the command.",
+		},
+		{
+			Name: "No name",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args:  []string{"--description=foo"},
+			Error: "missing required flag: --name=NAME",
+		},
+		{
+			Name: "Good",
+			Profile: func(t *testing.T) *profile.Profile {
+				return profile.TestProfile(t).SetOrgID("123").SetProjectID("456")
+			},
+			Args: []string{"-n", "foo", "--description=updated"},
+			Expect: &GroupOpts{
+				Name:        "foo",
+				Description: "updated",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			io := iostreams.Test()
+			ctx := &cmd.Context{
+				IO:          io,
+				Profile:     c.Profile(t),
+				Output:      format.New(io),
+				HCP:         &client.Runtime{},
+				ShutdownCtx: context.Background(),
+			}
+
+			var gotOpts GroupOpts
+			gotOpts.testFunc = func(c *cmd.Command, args []string) error {
+				return nil
+			}
+			cmd := NewCmdGroupUpdate(ctx, &gotOpts)
+			cmd.SetIO(io)
+
+			code := cmd.Run(c.Args)
+
+			if c.Error != "" {
+				r.NotZero(code)
+				r.Contains(io.Error.String(), c.Error)
+				return
+			}
+
+			r.Zero(code, io.Error.String())
+			r.NotNil(gotOpts)
+			if c.Expect != nil {
+				r.Equal(c.Expect.Name, gotOpts.Name)
+				r.Equal(c.Expect.Description, gotOpts.Description)
+			}
+		})
+	}
+}
+
+func TestAgentGroupUpdate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name      string
+		SetupMock func(ws *mock_waypoint_service.MockClientService)
+		Opts      *GroupOpts
+		Error     string
+	}{
+		{
+			Name: "API error",
+			SetupMock: func(ws *mock_waypoint_service.MockClientService) {
+				ws.EXPECT().WaypointServiceUpdateAgentGroup(mock.Anything, mock.Anything).Return(nil, errors.New("api error"))
+			},
+			Opts: &GroupOpts{
+				Name:        "foo",
+				Description: "desc",
+				WaypointOpts: opts.WaypointOpts{
+					Ctx:     context.Background(),
+					Profile: profile.TestProfile(t).SetOrgID("123").SetProjectID("456"),
+					IO:      iostreams.Test(),
+				},
+			},
+			Error: "error updating group: api error",
+		},
+		{
+			Name: "Success",
+			SetupMock: func(ws *mock_waypoint_service.MockClientService) {
+				ws.EXPECT().WaypointServiceUpdateAgentGroup(mock.Anything, mock.Anything).Return(&waypoint_service.WaypointServiceUpdateAgentGroupOK{}, nil)
+			},
+			Opts: &GroupOpts{
+				Name:        "foo",
+				Description: "desc",
+				WaypointOpts: opts.WaypointOpts{
+					Ctx:     context.Background(),
+					Profile: profile.TestProfile(t).SetOrgID("123").SetProjectID("456"),
+					IO:      iostreams.Test(),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			r := require.New(t)
+
+			ws := mock_waypoint_service.NewMockClientService(t)
+			if c.SetupMock != nil {
+				c.SetupMock(ws)
+			}
+			c.Opts.WS2024Client = ws
+
+			err := agentGroupUpdate(hclog.NewNullLogger(), c.Opts)
+			if c.Error != "" {
+				r.ErrorContains(err, c.Error)
+				return
+			}
+			r.NoError(err)
+		})
+	}
+}


### PR DESCRIPTION
### :hammer_and_wrench:  Description

This PR adds two new commands to read and update a Waypoint Agent group:
`hcp waypoint agent group read`
`hcp waypoint agent group update`

It also makes the output of the agent create and delete commands more consistent with other similar commands.

### :building_construction:  Local Testing

```sh
$ ./bin/hcp waypoint agent group list
Name   Description

$ ./bin/hcp waypoint agent group create --name=group1 --description="Test group 1"
✓ Group "group1" created

$ ./bin/hcp waypoint agent group list
Name     Description
group1   Test group 1

$ ./bin/hcp waypoint agent group read --name=group1
Name:        group1
Description: Test group 1

$ ./bin/hcp waypoint agent group update --name=group1 --description="Updated description"
✓ Group "group1" updated

$ ./bin/hcp waypoint agent group read --name=group1
Name:        group1
Description: Updated description

$ ./bin/hcp waypoint agent group list
Name     Description
group1   Updated description

$ ./bin/hcp waypoint agent group delete --name=group1
✓ Group "group1" deleted
```

### :+1:  Checklist

- [x] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [x] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.