### PR TITLE
Send status code on error executing Waypoint agent operation

### DIFF
--- a/.changelog/239.txt
+++ b/.changelog/239.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+waypoint: Send status code on error executing Waypoint agent operation
+```

--- a/internal/commands/waypoint/agent/run.go
+++ b/internal/commands/waypoint/agent/run.go
@@ -218,6 +218,7 @@ func runOp(
 	opStat, err := exec.Execute(ctx, ao)
 	if err != nil {
 		status = "error execution operation: " + err.Error()
+		statusCode = 2
 
 		log.Error("error executing operation", "error", err)
 		return

--- a/internal/pkg/waypoint/agent/shell_operation.go
+++ b/internal/pkg/waypoint/agent/shell_operation.go
@@ -54,6 +54,8 @@ func (s *ShellOperation) exec(ctx context.Context, log hclog.Logger, cmd []strin
 
 	data := bytes.TrimSpace(out.Bytes())
 
+	// Only return last line of output for security reasons.
+	// Users can use the API to send more output as a status log, if desired.
 	if idx := bytes.LastIndexByte(data, '\n'); idx != -1 {
 		status.Status = "output: " + string(data[idx:])
 	} else if len(data) > 0 {


### PR DESCRIPTION
### :hammer_and_wrench:  Description

We weren't sending a status code for errors when executing Waypoint agent operations (for example, when there is an unknown variable error). This PR fixes that by sending a status code of 2 in this case. It also adds a note about the historical reasoning for why we only return the last line of agent shell operation output (I had to track this down and wanted to preserve the info).

### :building_construction:  Local Testing

Without this change:

```sh
$ cat agent-config-bad.hcl
group "group1" {
  action "say-hello" {
    run {
      command = ["echo", "hello", bad.var]
    }
  }
}

$ ./bin/hcp waypoint agent run --config=agent-config-bad.hcl —debug
...
{"action_run_id":"a3b870c7-0a4b-4c21-85eb-62cadb78e3e4","final_status":"error execution operation: agent-config-bad.hcl:4,35-38: Unknown variable; There is no variable named \"bad\"."}
...
```

With this change:

```sh
$ cat agent-config-bad.hcl
group "group1" {
  action "say-hello" {
    run {
      command = ["echo", "hello", bad.var]
    }
  }
}

$ ./bin/hcp waypoint agent run --config=agent-config-bad.hcl —debug
...
{"action_run_id":"420ce96e-8bf2-4073-a1f4-f8af5920d129","final_status":"error execution operation: agent-config-bad.hcl:4,35-38: Unknown variable; There is no variable named \"bad\".","status_code":2}
...
```

### :+1:  Checklist

- [x] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.