### PR TITLE
Docs Repo Migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ docs/gen: go/build ## Generate the HCP CLI documentation
 .PHONY: docs/move
 docs/move: go/build ## Copy the generated documentation to the HCP docs repository
 	@./bin/mvdocs -generated-commands-dir web-docs/commands --generated-nav-json web-docs/nav.json \
-		--dest-commands-dir ../hcp-docs/content/docs/cli/commands --dest-nav-json ../hcp-docs/data/docs-nav-data.json
+		--dest-commands-dir ../web-unified-docs/content/docs/cli/commands --dest-nav-json ../web-unified-docs/data/docs-nav-data.json
 
 .PHONY: gen/screenshot
 gen/screenshot: go/install ## Create a screenshot of the HCP CLI

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -466,15 +466,15 @@ To check that the generated documentation for your command is correct before
 committing the code, generate the documentation and run the
 developer.hashicorp.com documentation locally.
 
-First checkout the [`hcp-docs`
-repository](https://github.com/hashicorp/hcp-docs). The following commands
-assume the `hcp-docs` repository is checked out in the same parent directory as
+First checkout the [`web-unified-docs`
+repository](https://github.com/hashicorp/web-unified-docs). The following commands
+assume the `web-unified-docs` repository is checked out in the same parent directory as
 `hcp`.
 
 ```sh
 $ make docs/gen
 $ make docs/move
-$ cd ../hcp-docs
+$ cd ../web-unified-docs
 $ make website
 ```
 
@@ -497,8 +497,7 @@ here](https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2303492328/Trigge
 
 After a successful release:
 
-- [ ] Update the `version/VERSION` file to the next version with `-dev` appended.
 - [ ] Update the developer.hashicorp.com documentation by following the steps
   outlined in the [Validating/generating the developer.hashicorp.com documentation](#validating/generating-the-developer.hashicorp.com-documentation) section.
-  PR the changes to the `hcp-docs` repository, have a team member review them,
+  PR the changes to the `web-unified-docs` repository, have a team member review them,
   and merge.

--- a/hack/mvdocs/main.go
+++ b/hack/mvdocs/main.go
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. 2024, 2025
 // SPDX-License-Identifier: MPL-2.0
 
-// This tool is used to move the generated commands documentation from the `web-docs` directory to the `hcp-docs` repository.
+// This tool is used to move the generated commands documentation from the `web-docs` directory to the `web-unified-docs` repository.
 package main
 
 import (
@@ -32,10 +32,10 @@ func run() error {
 	var srcNavJSON string
 	var destNavJSON string
 
-	flag.StringVar(&srcCommandsDir, "generated-commands-dir", "web-docs/commands", "The generated commands documentation to move to hcp-docs repository")
-	flag.StringVar(&destCommandsDir, "dest-commands-dir", "../hcp-docs/content/docs/cli/commands/", "The destination directory for the generated commands documentation")
+	flag.StringVar(&srcCommandsDir, "generated-commands-dir", "web-docs/commands", "The generated commands documentation to move to web-unified-docs repository")
+	flag.StringVar(&destCommandsDir, "dest-commands-dir", "../web-unified-docs/content/docs/cli/commands/", "The destination directory for the generated commands documentation")
 	flag.StringVar(&srcNavJSON, "generated-nav-json", "web-docs/nav.json", "The output path for the generated nav json")
-	flag.StringVar(&destNavJSON, "dest-nav-json", "../hcp-docs/data/docs-nav-data.json", "Path to `hcp-docs` nav json file")
+	flag.StringVar(&destNavJSON, "dest-nav-json", "../web-unified-docs/data/docs-nav-data.json", "Path to `web-unified-docs` nav json file")
 
 	// Parse the flags
 	flag.Parse()

--- a/internal/pkg/cmd/gen_nav_json.go
+++ b/internal/pkg/cmd/gen_nav_json.go
@@ -19,7 +19,7 @@ type DocNavItem struct {
 	Routes []*DocNavItem `json:"routes,omitempty"`
 }
 
-// GenNavJSON generates the navigation JSON in the format that hcp-docs expects,
+// GenNavJSON generates the navigation JSON in the format that web-unified-docs expects,
 // for the command structure.
 func GenNavJSON(c *Command, w io.Writer) error {
 


### PR DESCRIPTION
### :hammer_and_wrench:  Description

* hcp-docs has been moved to web-unified-docs (New public repo)
* This PR migrates the references, and supports ongoing re-generation of docs for the developer docs website.

<!-- What changed?
<!-- Why was it changed? -->
<!-- How does it affect end-user behavior? -->

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->

### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [ ] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.