### PR TITLE
Docs Gen: Update Destination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ MOCKERY_DIRS=./ internal/commands/auth/ internal/pkg/api/iampolicy internal/pkg/
 MOCKERY_OUTPUT_DIRS=internal/pkg/api/mocks internal/commands/auth/mocks internal/pkg/api/releasesapi/mocks
 MOCKERY_OUTPUT_FILES=internal/pkg/api/iampolicy/mock_setter.go \
 					 internal/pkg/api/iampolicy/mock_resource_updater.go
+DOCS_DEST_DIR=../web-unified-docs/content/hcp-docs/content/docs/cli/commands
+DOCS_DEST_NAV=../web-unified-docs/content/hcp-docs/data/docs-nav-data.json
 
 # TARGET_DIR is set by actions-go-build (https://github.com/hashicorp/actions-go-build?tab=readme-ov-file#environment-variables)
 # if the build target is being invoked outside of the build.yml, we need to set this to something sensible
@@ -23,8 +25,11 @@ docs/gen: go/build ## Generate the HCP CLI documentation
 
 .PHONY: docs/move
 docs/move: go/build ## Copy the generated documentation to the HCP docs repository
-	@./bin/mvdocs -generated-commands-dir web-docs/commands --generated-nav-json web-docs/nav.json \
-		--dest-commands-dir ../web-unified-docs/content/docs/cli/commands --dest-nav-json ../web-unified-docs/data/docs-nav-data.json
+	@./bin/mvdocs \
+		-generated-commands-dir web-docs/commands \
+		--generated-nav-json web-docs/nav.json \
+		--dest-commands-dir $(DOCS_DEST_DIR) \
+		--dest-nav-json $(DOCS_DEST_NAV)
 
 .PHONY: gen/screenshot
 gen/screenshot: go/install ## Create a screenshot of the HCP CLI

--- a/hack/mvdocs/main.go
+++ b/hack/mvdocs/main.go
@@ -20,8 +20,8 @@ import (
 
 const (
 	destCommandsDir = "../web-unified-docs/content/hcp-docs/content/docs/cli/commands/"
-	destNavJson     = "../web-unified-docs/content/hcp-docs/data/docs-nav-data.json"
-	genNavJson      = "web-docs/nav.json"
+	destNavJSON     = "../web-unified-docs/content/hcp-docs/data/docs-nav-data.json"
+	genNavJSON      = "web-docs/nav.json"
 )
 
 func main() {
@@ -40,7 +40,7 @@ func run() error {
 
 	flag.StringVar(&srcCommandsDir, "generated-commands-dir", "web-docs/commands", "The generated commands documentation to move to web-unified-docs repository")
 	flag.StringVar(&destCommandsDir, "dest-commands-dir", destCommandsDir, "The destination directory for the generated commands documentation")
-	flag.StringVar(&srcNavJSON, "generated-nav-json", genNavJson, "The output path for the generated nav json")
+	flag.StringVar(&srcNavJSON, "generated-nav-json", genNavJSON, "The output path for the generated nav json")
 	flag.StringVar(&destNavJSON, "dest-nav-json", destNavJSON, "Path to `web-unified-docs` nav json file")
 
 	// Parse the flags

--- a/hack/mvdocs/main.go
+++ b/hack/mvdocs/main.go
@@ -18,6 +18,12 @@ import (
 	"github.com/hashicorp/hcp/internal/pkg/cmd"
 )
 
+const (
+	destCommandsDir = "../web-unified-docs/content/hcp-docs/content/docs/cli/commands/"
+	destNavJson     = "../web-unified-docs/content/hcp-docs/data/docs-nav-data.json"
+	genNavJson      = "web-docs/nav.json"
+)
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -33,9 +39,9 @@ func run() error {
 	var destNavJSON string
 
 	flag.StringVar(&srcCommandsDir, "generated-commands-dir", "web-docs/commands", "The generated commands documentation to move to web-unified-docs repository")
-	flag.StringVar(&destCommandsDir, "dest-commands-dir", "../web-unified-docs/content/docs/cli/commands/", "The destination directory for the generated commands documentation")
-	flag.StringVar(&srcNavJSON, "generated-nav-json", "web-docs/nav.json", "The output path for the generated nav json")
-	flag.StringVar(&destNavJSON, "dest-nav-json", "../web-unified-docs/data/docs-nav-data.json", "Path to `web-unified-docs` nav json file")
+	flag.StringVar(&destCommandsDir, "dest-commands-dir", destCommandsDir, "The destination directory for the generated commands documentation")
+	flag.StringVar(&srcNavJSON, "generated-nav-json", genNavJson, "The output path for the generated nav json")
+	flag.StringVar(&destNavJSON, "dest-nav-json", destNavJSON, "Path to `web-unified-docs` nav json file")
 
 	// Parse the flags
 	flag.Parse()


### PR DESCRIPTION
### :hammer_and_wrench:  Description

<!-- What changed?
<!-- Why was it changed? -->
<!-- How does it affect end-user behavior? -->

* The new public docs repo has extra directory nesting: `/content/hcp-docs`, compared to the previous `hcp-docs` repo.
* This PR updates the gen logic to place the generated docs in the correct location of the destination repo.

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->
* https://github.com/hashicorp/web-unified-docs/pull/1353

### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [ ] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [ ] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.