### PR TITLE
Adds suppression for security vuln found in CI

### DIFF
--- a/.changelog/264.txt
+++ b/.changelog/264.txt
@@ -1,3 +1,3 @@
-```release-note:security
-supression: supressing security vuln scanner for go-2026-5932 as it only applies to pgp which we are not using
+```release-note:bug
+security-supression: supressing security vuln scanner for go-2026-5932 as it only applies to pgp which we are not using
 ```

--- a/.changelog/264.txt
+++ b/.changelog/264.txt
@@ -1,0 +1,3 @@
+```release-note:security
+supression: supressing security vuln scanner for go-2026-5932 as it only applies to pgp which we are not using
+```

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -15,6 +15,7 @@ container {
 				"CVE-2024-58251",
 				"CVE-2024-23337",
 				"CVE-2025-48060",
+        "GO-2026-5932", //does not use crypto/pgp where the vuln is actually reported
 			]
 		}
   	}

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,13 @@ go/install: ## Install the HCP CLI binary
 go/lint: ## Run the Go Linter
 	@golangci-lint run
 
+.PHONY: go/vulncheck
+go/vulncheck: ## Run the Go vulnerability checker
+ifeq (, $(shell which govulncheck))
+	@go install golang.org/x/vuln/cmd/govulncheck@latest
+endif
+	@govulncheck ./...
+
 .PHONY: go/mocks
 go/mocks: ## Generates Go mock files.
 	@for dir in $(MOCKERY_OUTPUT_DIRS); do \


### PR DESCRIPTION
### :hammer_and_wrench:  Description

<!-- What changed?
<!-- Why was it changed? -->
<!-- How does it affect end-user behavior? -->


The security vulnerability https://pkg.go.dev/vuln/GO-2026-5932 applies only to the crypto/openpgp module which is not being used by this project, hence supressing the vulnerability in the scanner

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->

### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [x] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.