### PR TITLE
Adds suppression to the binary scan

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -17,7 +17,6 @@ container {
 				"CVE-2025-48060",
  				"GO-2026-5932", // does not use crypto/pgp where the vuln is actually reported
             ]
-			]
 		}
   	}
 }

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -15,6 +15,8 @@ container {
 				"CVE-2024-58251",
 				"CVE-2024-23337",
 				"CVE-2025-48060",
+ 				"GO-2026-5932", // does not use crypto/pgp where the vuln is actually reported
+            ]
 			]
 		}
   	}

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -15,7 +15,6 @@ container {
 				"CVE-2024-58251",
 				"CVE-2024-23337",
 				"CVE-2025-48060",
-        "GO-2026-5932", //does not use crypto/pgp where the vuln is actually reported
 			]
 		}
   	}
@@ -27,4 +26,11 @@ binary {
 	osv          = true
 	oss_index    = false
 	nvd          = false
+	triage {
+        suppress {
+            vulnerabilities = [
+                "GO-2026-5932", // does not use crypto/pgp where the vuln is actually reported
+            ]
+        }
+    }
 }


### PR DESCRIPTION
### :hammer_and_wrench:  Description

<!-- What changed?
<!-- Why was it changed? -->
<!-- How does it affect end-user behavior? -->

The supression was added to the Container scan instead of the binary scan which is blocking the deployment

### :link:  Additional Link

<!-- Any additional link to understand the context of the change. -->



### :building_construction:  Local Testing

<!-- List steps to test your change on a local environment. -->

### :+1:  Checklist

- [ ] The PR has a descriptive title.
- [ ] Input validation updated
- [ ] Unit tests updated
- [ ] Documentation updated
- [ ] Major architecture changes have a corresponding RFC
- [ ] Tests added if applicable
- [x] CHANGELOG entry added or label 'pr/no-changelog' added to PR
  > Run `CHANGELOG_PR=<PR number> make changelog/new-entry` for guidance
  > in authoring a changelog entry, and commit the resulting file, which should
  > have a name matching your PR number. Entries should use imperative present
  > tense (e.g. Add support for...)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.